### PR TITLE
Add referrer policy to HTML

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,6 +23,7 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="referrer" content="no-referrer">
     <title>Threema Web</title>
 
     <!-- Favicon -->


### PR DESCRIPTION
You already use a HTTP header on your web site, but users hosting their own-version of Threema Web or using a local HTML version may not get this header, so better specify it in the HTML source (too).

