### PR TITLE
Show warning if browser blocks local storage

### DIFF
--- a/public/i18n/de.json
+++ b/public/i18n/de.json
@@ -30,7 +30,8 @@
         "MANUAL_START_STEP1": "Öffnen Sie die Threema App und tippen Sie auf \"Threema Web\" in der linken Navigation",
         "MANUAL_START_STEP2": "Tippen Sie auf die Sitzung, die Sie wiederherstellen möchten",
         "MANUAL_START_STEP3": "Wählen Sie im Menu \"Sitzung starten\"",
-        "MORE_ABOUT_WEB": "Mehr über Threema Web"
+        "MORE_ABOUT_WEB": "Mehr über Threema Web",
+        "LOCAL_STORAGE_MISSING_DETAILS": "Zugriff auf LocalStorage ist nicht möglich. Dies kann geschehen, wenn in Ihrem Brower Cookies blockiert werden, oder wenn ein Browser-Add-On installiert ist, welches den Zugriff auf LocalStorage blockiert. Bitte erlauben Sie die Nutzung von LocalStorage in Ihrem Browser oder deaktivieren Sie installierte Browser-Add-Ons."
     },
     "connecting": {
         "CONNECTION_PROBLEMS": "Verbindungsprobleme",

--- a/public/i18n/de.json
+++ b/public/i18n/de.json
@@ -31,7 +31,7 @@
         "MANUAL_START_STEP2": "Tippen Sie auf die Sitzung, die Sie wiederherstellen möchten",
         "MANUAL_START_STEP3": "Wählen Sie im Menu \"Sitzung starten\"",
         "MORE_ABOUT_WEB": "Mehr über Threema Web",
-        "LOCAL_STORAGE_MISSING_DETAILS": "Zugriff auf LocalStorage ist nicht möglich. Dies kann geschehen, wenn in Ihrem Brower Cookies blockiert werden, oder wenn ein Browser-Add-On installiert ist, welches den Zugriff auf LocalStorage blockiert. Bitte erlauben Sie die Nutzung von LocalStorage in Ihrem Browser oder deaktivieren Sie installierte Browser-Add-Ons."
+        "LOCAL_STORAGE_MISSING_DETAILS": "Zugriff auf LocalStorage ist nicht möglich.  Dieses Problem kann auftreten, wenn in Ihrem Browser Cookies blockiert werden, oder wenn ein Browser-Add-On installiert ist, welches den Zugriff auf LocalStorage blockiert. Bitte erlauben Sie die Nutzung von LocalStorage in Ihrem Browser oder deaktivieren Sie die installierten Browser-Add-Ons."
     },
     "connecting": {
         "CONNECTION_PROBLEMS": "Verbindungsprobleme",

--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -30,7 +30,8 @@
         "MANUAL_START_STEP1": "Open the Threema app and tap on \"Threema Web\" in the left navigation drawer",
         "MANUAL_START_STEP2": "Tap on the session related to this browser",
         "MANUAL_START_STEP3": "Select \"Start session\" to start the session",
-        "MORE_ABOUT_WEB": "More about Threema Web"
+        "MORE_ABOUT_WEB": "More about Threema Web",
+        "LOCAL_STORAGE_MISSING_DETAILS": "Access to LocalStorage not possible. This can occur if your browser is configured to reject cookies, or if you installed a browser add-on that blocks access to LocalStorage. Please allow local storage in your browser settings or disable any add-ons you might have installed."
     },
     "connecting": {
         "CONNECTION_PROBLEMS": "Connection problems",

--- a/src/partials/welcome.ts
+++ b/src/partials/welcome.ts
@@ -119,7 +119,13 @@ class WelcomeController {
             this.showBrowserWarning();
         }
 
-        // clear cache
+        // Determine whether local storage is available
+        if (this.TrustedKeyStore.blocked === true) {
+            $log.error('Cannot access local storage. Is it being blocked by a browser add-on?');
+            this.showLocalStorageWarning();
+        }
+
+        // Clear cache
         this.webClientService.clearCache();
 
         // Determine connection mode
@@ -236,7 +242,7 @@ class WelcomeController {
     }
 
     /**
-     * Show the "decryption failed" dialog.
+     * Show a browser warning dialog.
      */
     private showBrowserWarning(): void {
         const confirm = this.$mdDialog.confirm()
@@ -250,6 +256,17 @@ class WelcomeController {
             // Redirect to Threema website
             window.location.replace('https://threema.ch/');
         });
+    }
+
+    /**
+     * Show a dialog indicating that local storage is not available.
+     */
+    private showLocalStorageWarning(): void {
+        const confirm = this.$mdDialog.alert()
+            .title(this.$translate.instant('common.ERROR'))
+            .htmlContent(this.$translate.instant('welcome.LOCAL_STORAGE_MISSING_DETAILS'))
+            .ok(this.$translate.instant('common.OK'));
+        this.$mdDialog.show(confirm);
     }
 
     /**

--- a/src/sass/components/_dialogs.scss
+++ b/src/sass/components/_dialogs.scss
@@ -1,5 +1,6 @@
 md-dialog {
     min-width: 470px;
+    max-width: 600px;
     p {
         margin-bottom: 16px;
         line-height: 1.3em;
@@ -17,6 +18,9 @@ md-dialog {
         li {
             line-height: 1.5em;
         }
+    }
+    md-dialog-content {
+        line-height: 1.3em;
     }
 }
 

--- a/src/threema.d.ts
+++ b/src/threema.d.ts
@@ -365,6 +365,7 @@ declare namespace threema {
     }
 
     interface TrustedKeyStoreService {
+        blocked: boolean;
         storeTrustedKey(ownPublicKey: Uint8Array, ownSecretKey: Uint8Array, peerPublicKey: Uint8Array,
                         pushToken: string | null, password: string): void;
         hasTrustedKey(): boolean;


### PR DESCRIPTION
This can happen through add-ons or when blocking website content. Here e.g. in Chrome:

![chromesetting](https://cloud.githubusercontent.com/assets/105168/23120545/0da72160-f75d-11e6-89b9-2e4d893e3a45.png)

This is the warning we show:

![localstorage-de](https://cloud.githubusercontent.com/assets/105168/23120560/18db5560-f75d-11e6-91f6-3aed00b487bd.png)
![localstorage-en](https://cloud.githubusercontent.com/assets/105168/23120561/18defb20-f75d-11e6-89c7-5bdde1171c7a.png)
