### PR TITLE
show ellipsis on long file names

### DIFF
--- a/src/sass/components/_message_media.scss
+++ b/src/sass/components/_message_media.scss
@@ -148,6 +148,8 @@ $loading-ring-thickness: 5px;
                 line-height: normal;
                 padding: 0;
                 font-size: 10pt;
+                text-overflow: ellipsis;
+                overflow: hidden;
             }
 
             p:first-child {


### PR DESCRIPTION
Fixes #69

![2017-02-21-163911_869x97_scrot](https://cloud.githubusercontent.com/assets/3036773/23171956/7a6b2880-f854-11e6-8278-f557b30e4e7c.png)
