### PR TITLE
ICE Connectivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,7 @@ The configuration of Threema Web can be tweaked in `src/config.ts`:
 
 **ICE**
 
-- `SALTYRTC_STUN`: Configuration object for the WebRTC STUN server.
-- `SALTYRTC_TURN`: Configuration object for the WebRTC TURN server.
+- `ICE_SERVERS`: Configuration object for the WebRTC STUN and ICE servers.
 
 **Push**
 

--- a/docs/self_hosting.md
+++ b/docs/self_hosting.md
@@ -30,8 +30,7 @@ First, adjust the configuration in `src/config.ts`:
 
 - Set `SELF_HOSTED` to `true`
 - If you host your own SaltyRTC server, adjust the `SALTYRTC_*` variables
-- If you host your own STUN / TURN server, adjust the `SALTYRTC_STUN` and
-  `SALTYRTC_TURN` variables
+- If you host your own STUN / TURN server, adjust the `ICE_SERVERS` variable
 
 Then, build the release version of Threema Web:
 

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "node-sass": "~3.10.0",
     "saltyrtc-client": "~0.9.1",
     "saltyrtc-task-webrtc": "~0.9.1",
+    "sdp": "~1.3.0",
     "tsify": "~2.0.1",
     "tweetnacl": "~0.14.4",
     "typescript": "~2.1.0",

--- a/src/config.ts
+++ b/src/config.ts
@@ -16,14 +16,11 @@ export default {
     SALTYRTC_SERVER_KEY: 'b1337fc8402f7db8ea639e05ed05d65463e24809792f91eca29e88101b4a2171',
 
     // ICE
-    SALTYRTC_STUN: {
-        urls: 'stun:stun.threema.ch:443',
-    },
-    SALTYRTC_TURN: {
+    ICE_SERVERS: [{
         urls: 'turn:turn.threema.ch:443',
         username: 'threema-angular',
         credential: 'Uv0LcCq3kyx6EiRwQW5jVigkhzbp70CjN2CJqzmRxG3UGIdJHSJV6tpo7Gj7YnGB',
-    },
+    }],
 
     // Push
     PUSH_URL: 'https://push-web.threema.ch/push',

--- a/src/config.ts
+++ b/src/config.ts
@@ -17,7 +17,10 @@ export default {
 
     // ICE
     ICE_SERVERS: [{
-        urls: ['turn:turn.threema.ch:443', 'turn:turn.threema.ch:443?transport=tcp'],
+        urls: [
+            'turn:turn.threema.ch:443?transport=udp',
+            'turn:turn.threema.ch:443?transport=tcp'
+        ],
         username: 'threema-angular',
         credential: 'Uv0LcCq3kyx6EiRwQW5jVigkhzbp70CjN2CJqzmRxG3UGIdJHSJV6tpo7Gj7YnGB',
     }],

--- a/src/config.ts
+++ b/src/config.ts
@@ -17,7 +17,7 @@ export default {
 
     // ICE
     ICE_SERVERS: [{
-        urls: 'turn:turn.threema.ch:443',
+        urls: ['turn:turn.threema.ch:443', 'turn:turn.threema.ch:443?transport=tcp'],
         username: 'threema-angular',
         credential: 'Uv0LcCq3kyx6EiRwQW5jVigkhzbp70CjN2CJqzmRxG3UGIdJHSJV6tpo7Gj7YnGB',
     }],

--- a/src/services/peerconnection.ts
+++ b/src/services/peerconnection.ts
@@ -16,7 +16,7 @@
  */
 
 /// <reference types="saltyrtc-task-webrtc" />
-const SDPUtils = require('sdp');
+import * as SDPUtils from 'sdp';
 
 /**
  * Wrapper around the WebRTC PeerConnection.
@@ -250,12 +250,12 @@ export class PeerConnectionHelper {
      */
     private static censorCandidate(candidateInit: string): string {
         let candidate = SDPUtils.parseCandidate(candidateInit);
-        if (candidate.type != 'relay') {
+        if (candidate.type !== 'relay') {
             candidate.ip = '***';
             candidate.port = 1;
         }
         candidate.relatedAddress = '***';
         candidate.relatedPort = 2;
-        return SDPUtils.writeCandidate(candidate)
+        return SDPUtils.writeCandidate(candidate);
     }
 }

--- a/src/services/peerconnection.ts
+++ b/src/services/peerconnection.ts
@@ -103,6 +103,8 @@ export class PeerConnectionHelper {
                     sdpMid: e.candidate.sdpMid,
                     sdpMLineIndex: e.candidate.sdpMLineIndex,
                 });
+            } else {
+                this.$log.debug(this.logTag, 'No more local ICE candidates');
             }
         };
         this.pc.onicecandidateerror = (e: RTCPeerConnectionIceErrorEvent) => {

--- a/src/services/peerconnection.ts
+++ b/src/services/peerconnection.ts
@@ -46,7 +46,7 @@ export class PeerConnectionHelper {
     constructor($log: ng.ILogService, $q: ng.IQService,
                 $timeout: ng.ITimeoutService, $rootScope: ng.IRootScopeService,
                 webrtcTask: saltyrtc.tasks.webrtc.WebRTCTask,
-                stunServer: RTCIceServer, turnServer: RTCIceServer) {
+                iceServers: RTCIceServer[]) {
         this.$log = $log;
         this.$log.info('Initialize WebRTC PeerConnection');
         this.$q = $q;
@@ -56,7 +56,7 @@ export class PeerConnectionHelper {
         this.webrtcTask = webrtcTask;
 
         // Set up peer connection
-        this.pc = new RTCPeerConnection({iceServers: [stunServer, turnServer]});
+        this.pc = new RTCPeerConnection({iceServers: iceServers});
         this.pc.onnegotiationneeded = (e: Event) => {
             this.$log.debug(this.logTag, 'RTCPeerConnection: negotiation needed');
             this.initiatorFlow().then(

--- a/src/services/webclient.ts
+++ b/src/services/webclient.ts
@@ -367,7 +367,7 @@ export class WebClientService implements threema.WebClientService {
         this.salty.once('state-change:task', () => {
             this.pcHelper = new PeerConnectionHelper(this.$log, this.$q, this.$timeout,
                                                      this.$rootScope, this.webrtcTask,
-                                                     this.config.SALTYRTC_STUN, this.config.SALTYRTC_TURN);
+                                                     this.config.ICE_SERVERS);
 
             // On state changes in the PeerConnectionHelper class, let state service know about it
             this.pcHelper.onConnectionStateChange = (state: threema.RTCConnectionState) => {

--- a/src/threema.d.ts
+++ b/src/threema.d.ts
@@ -463,8 +463,7 @@ declare namespace threema {
         SALTYRTC_HOST: string | null;
         SALTYRTC_HOST_PREFIX: string | null;
         SALTYRTC_HOST_SUFFIX: string | null;
-        SALTYRTC_STUN: RTCIceServer;
-        SALTYRTC_TURN: RTCIceServer;
+        ICE_SERVERS: RTCIceServer[];
         PUSH_URL: string;
     }
 


### PR DESCRIPTION
This PR should resolve most of the problems described in  #43 by enabling the use of TURN-TCP. I assume the problem was that the STUN/TURN requests have used UDP over port 443 which was blocked by the (corporate) firewalls.

Any remaining connectivity issues should be fixable by enabling TURN-over-TLS but this requires some modification to the TURN server configuration.

I also added some ICE candidate logging.