### PR TITLE
Improve error handling in bufferToUrl filter

### DIFF
--- a/src/filters.ts
+++ b/src/filters.ts
@@ -178,8 +178,13 @@ angular.module('3ema.filters', [])
         return padLeft + left + ':' + padRight + right;
     };
 })
-.filter('bufferToUrl', ['$sce', function($sce) {
+.filter('bufferToUrl', ['$sce', '$log', function($sce, $log) {
+    const logTag = '[filters.bufferToUrl]';
     return function(buffer: ArrayBuffer, mimeType) {
+        if (!buffer) {
+            $log.error(logTag, 'Could not apply bufferToUrl filter: buffer is', buffer);
+            return '';
+        }
         let binary = '';
         const bytes = new Uint8Array(buffer);
         const len = bytes.byteLength;


### PR DESCRIPTION
If `buffer` is falsy, log an error and abort. Otherwise, we'll get generic `InvalidArgument` exceptions.

Refs #95 