### PR TITLE
Update unread count on initial loading

### DIFF
--- a/src/services/webclient.ts
+++ b/src/services/webclient.ts
@@ -1487,6 +1487,7 @@ export class WebClientService implements threema.WebClientService {
                 this.conversations.updateOrAdd(conversation);
             }
         }
+        this.updateUnreadCount();
         this.registerInitializationStep('conversations');
     }
 
@@ -1548,11 +1549,7 @@ export class WebClientService implements threema.WebClientService {
                 return;
         }
 
-        // Update unread count
-        const totalUnreadCount = this.conversations
-            .get()
-            .reduce((a: number, b: threema.Conversation) => a + b.unreadCount, 0);
-        this.titleService.updateUnreadCount(totalUnreadCount);
+        this.updateUnreadCount();
     }
 
     private _receiveResponseMessages(message: threema.WireMessage): void {
@@ -2317,5 +2314,15 @@ export class WebClientService implements threema.WebClientService {
 
     public getControllerName(): string {
         return this.currentController;
+    }
+
+    /**
+     * Update the unread count in the window title.
+     */
+    private updateUnreadCount(): void {
+        const totalUnreadCount = this.conversations
+            .get()
+            .reduce((a: number, b: threema.Conversation) => a + b.unreadCount, 0);
+        this.titleService.updateUnreadCount(totalUnreadCount);
     }
 }


### PR DESCRIPTION
Previously the unread counter was only updated if a specific conversation was updated. Now, it's also updated when the complete list of conversations is updated (e.g. on first load).

Fixes #93.