### PR TITLE
Fix state transitions when restoring a session

### DIFF
--- a/src/partials/welcome.html
+++ b/src/partials/welcome.html
@@ -21,7 +21,7 @@
             </div>
         </div>
 
-        <div ng-if="(ctrl.state === 'connecting' || ctrl.state === 'waiting') && ctrl.mode === 'unlock'" class="unlock">
+        <div ng-if="ctrl.state === 'connecting' && ctrl.mode === 'unlock'" class="unlock">
             <h2 class="instructions" translate>welcome.PLEASE_UNLOCK</h2>
             <div class="password-entry">
                 <label>

--- a/src/partials/welcome.ts
+++ b/src/partials/welcome.ts
@@ -367,8 +367,8 @@ class WelcomeController {
      * It must be initialized before calling this method.
      */
     private start() {
-        // Start
         this.webClientService.start().then(
+            // If connection buildup is done...
             () => {
                 // Pass password to webclient service
                 this.webClientService.setPassword(this.password);
@@ -379,6 +379,8 @@ class WelcomeController {
                 // Redirect to home
                 this.$timeout(() => this.$state.go('messenger.home'), WelcomeController.REDIRECT_DELAY);
             },
+
+            // If an error occurs...
             (error) => {
                 this.$log.error('Error state:', error);
                 // TODO: should probably show an error message instead

--- a/src/services/webclient.ts
+++ b/src/services/webclient.ts
@@ -487,7 +487,9 @@ export class WebClientService implements threema.WebClientService {
                 .catch(() => this.$log.warn('Could not notify app!'))
                 .then(() => {
                     this.$log.debug('Requested app wakeup');
-                    this.state.updateConnectionBuildupState('push');
+                    this.$rootScope.$apply(() => {
+                        this.state.updateConnectionBuildupState('push');
+                    });
                 });
         } else if (this.trustedKeyStore.hasTrustedKey()) {
             this.$log.debug('Push service not available');

--- a/src/threema.d.ts
+++ b/src/threema.d.ts
@@ -233,8 +233,21 @@ declare namespace threema {
 
     /**
      * Connection state in the welcome dialog.
+     *
+     * States:
+     *
+     * - new: Initial state
+     * - connecting: Connecting to signaling server
+     * - push: When trying to reconnect, waiting for push notification to arrive
+     * - manual_start: When trying to reconnect, waiting for manual session start
+     * - waiting: Waiting for new-responder message from signaling server
+     * - peer_handshake: Doing SaltyRTC handshake with the peer
+     * - loading: Loading initial data
+     * - done: Initial loading is finished
+     * - closed: Connection is closed
+     *
      */
-    type ConnectionBuildupState = 'new' | 'push' | 'manual_start' | 'connecting' | 'waiting'
+    type ConnectionBuildupState = 'new' | 'connecting' | 'push' | 'manual_start' | 'waiting'
         | 'peer_handshake' | 'loading' | 'done' | 'closed';
 
     /**


### PR DESCRIPTION
There were two problems with the session restoring:

- The "push" state transition was done outside the digest loop, so sometimes the status indicator wasn't shown for a few seconds, causing people to click the button twice
- The unlock screen was shown in the "waiting" state

This resulted in bad usability, Threema Web generally felt buggy when reconnecting.

This PR should solve those problems.

Fixes #102.