### PR TITLE
Replace many md-progress-circular instances with CSS

### DIFF
--- a/src/directives/avatar.ts
+++ b/src/directives/avatar.ts
@@ -80,8 +80,7 @@ export default [
             template: `
                 <div class="avatar" ng-class="ctrl.avatarClass()">
                     <div class="avatar-loading" ng-if="ctrl.isLoading">
-                        <md-progress-circular class="md-accent" md-diameter="100">
-                        </md-progress-circular>
+                        <span></span>
                     </div>
                     <img class="avatar-default" ng-if="!ctrl.avatarExists()"
                          ng-class="ctrl.avatarClass()"

--- a/src/directives/avatar.ts
+++ b/src/directives/avatar.ts
@@ -79,7 +79,7 @@ export default [
             }],
             template: `
                 <div class="avatar" ng-class="ctrl.avatarClass()">
-                    <div class="avatar-loading" ng-show="ctrl.isLoading">
+                    <div class="avatar-loading" ng-if="ctrl.isLoading">
                         <md-progress-circular class="md-accent" md-diameter="100">
                         </md-progress-circular>
                     </div>

--- a/src/directives/status_bar.ts
+++ b/src/directives/status_bar.ts
@@ -40,7 +40,7 @@ export default [
             }],
             template: `
                 <div id="expanded-status-bar" ng-class="{'active': ctrl.active}">
-                    <div>
+                    <div ng-if="ctrl.active">
                         <md-progress-circular class="md-accent" md-diameter="32"></md-progress-circular>
                     </div>
                     <div>

--- a/src/directives/status_bar.ts
+++ b/src/directives/status_bar.ts
@@ -41,7 +41,7 @@ export default [
             template: `
                 <div id="expanded-status-bar" ng-class="{'active': ctrl.active}">
                     <div ng-if="ctrl.active">
-                        <md-progress-circular class="md-accent" md-diameter="32"></md-progress-circular>
+                        <div class="loading"><span></span></div>
                     </div>
                     <div>
                         <h1 translate>connecting.CONNECTION_PROBLEMS</h1>

--- a/src/partials/messenger.conversation.html
+++ b/src/partials/messenger.conversation.html
@@ -37,11 +37,9 @@
 
     <div id="conversation-chat" scroll-glue in-view-container ng-show="!ctrl.locked">
         <ul class="chat">
-            <li in-view="$inview && !ctrl.locked && ctrl.requestMessages()" class="load-more">
+            <li in-view="$inview && !ctrl.locked && ctrl.topOfChat()" class="load-more">
                 <div ng-if="ctrl.hasMoreMessages()" class="loading">
-                    <md-progress-circular
-                            class="md-primary"
-                            md-diameter="30"></md-progress-circular>
+                    <span></span>
                 </div>
             </li>
             <li ng-repeat="message in ctrl.messages" id="message-{{message.id}}">

--- a/src/partials/messenger.ts
+++ b/src/partials/messenger.ts
@@ -444,6 +444,13 @@ class ConversationController {
         this.webClientService.sendMeIsTyping(this.$stateParams, false);
     }
 
+    /**
+     * User scrolled to the top of the chat.
+     */
+    public topOfChat(): void {
+        this.requestMessages();
+    }
+
     public requestMessages(): void {
         let refMsgId = this.webClientService.requestMessages(this.$stateParams);
 

--- a/src/sass/app.scss
+++ b/src/sass/app.scss
@@ -25,6 +25,7 @@
 // Components: Micro layout files. Your styles for buttons and navigation and
 // similar page components.
 //@import "components/lists";
+@import "components/spinner";
 @import "components/links";
 @import "components/scrollbars";
 @import "components/avatar";
@@ -33,7 +34,6 @@
 @import "components/fade_blink";
 @import "components/no_lastpass";
 @import "components/dialogs";
-@import "components/spinner";
 @import "components/message_media";
 @import "components/emoji_picker";
 @import "components/placeholder";

--- a/src/sass/components/_avatar.scss
+++ b/src/sass/components/_avatar.scss
@@ -7,7 +7,6 @@
         }
     }
     &.avatar-high {
-
         max-width: 540px;
         max-height: 540px;
     }
@@ -25,14 +24,13 @@
         position: absolute;
         width: 100%;
         height: 100%;
+        z-index: 10;
 
-        md-progress-circular {
-            z-index: 10;
-            display: inline;
+        $circle-diameter: 160px;
+        $thickness: 10px;
+        @include loading-spinner($circle-diameter - $thickness * 2, $thickness, rgba(255, 255, 255, 0.87), rgba(255, 255, 255, 0.1));
+        &>:first-child {
             position: relative;
-
-            // Progress circle diameter is hardcoded as 100px in avatar.ts
-            $circle-diameter: 100px;
             left: calc(50% - #{$circle-diameter / 2});
             top: calc(50% - #{$circle-diameter / 2});
         }

--- a/src/sass/components/_spinner.scss
+++ b/src/sass/components/_spinner.scss
@@ -14,7 +14,10 @@
     }
 }
 
-@mixin loading-spinner($diameter, $thickness, $color-fg, $color-bg) {
+@mixin loading-spinner($diameter,
+                       $thickness: 5px,
+                       $color-fg: $material-grey-dark,
+                       $color-bg: rgba(0, 0, 0, 0.1)) {
     display: block;
     &>:first-child {
         display: block;

--- a/src/sass/components/_spinner.scss
+++ b/src/sass/components/_spinner.scss
@@ -4,3 +4,25 @@
         margin: 0 auto;
     }
 }
+
+@keyframes rotater {
+    0% {
+        transform: rotate(0deg);
+    }
+    100% {
+        transform: rotate(360deg);
+    }
+}
+
+@mixin loading-spinner($diameter, $thickness, $color-fg, $color-bg) {
+    display: block;
+    &>:first-child {
+        display: block;
+        width: $diameter;
+        height: $diameter;
+        border: $thickness solid $color-bg;
+        border-left-color: $color-fg;
+        animation: rotater 1.1s infinite linear;
+        border-radius: 50%;
+    }
+}

--- a/src/sass/helpers/_colors.scss
+++ b/src/sass/helpers/_colors.scss
@@ -4,6 +4,7 @@ $status-error: #f44336;
 $border-grey: #dddddd;
 $background-grey: lighten($border-grey, 7%);
 $material-grey: rgba(0, 0, 0, 0.54);
+$material-grey-dark: rgba(0, 0, 0, 0.87);
 $url-light-blue: #63a6cf;
 
 $dark-background-color: #F6F6F6;

--- a/src/sass/sections/_conversation.scss
+++ b/src/sass/sections/_conversation.scss
@@ -126,7 +126,7 @@
             margin-top: $main-padding;
             text-align: center;
             .loading {
-                $loading-element-size: 20px;
+                @include loading-spinner(24px, 3px, $material-grey-dark, rgba(0, 0, 0, 0.1));
                 background-color: white;
                 border-radius: 50%;
                 display:inline-block;

--- a/src/sass/sections/_status_bar.scss
+++ b/src/sass/sections/_status_bar.scss
@@ -88,8 +88,8 @@ body {
     }
 
     // Loading indicator color
-    path {
-        stroke: white !important;
+    .loading {
+        @include loading-spinner(26px, 3px, white, rgba(255, 255, 255, 0.2));
     }
 
     > div {


### PR DESCRIPTION
Apparently even if invisible, multiple SVG based progress bars from angular-material were being animated in the background by the browser, leading to constant high CPU usage.

Worst offender was probably the loading indicator that appears when loading more messages.

This PR replaces most of those progress indicators with CSS based animations. Hopefully this will solve or at least reduce the problem of constant high CPU usage and laggy interface.

![2017-03-01-135443_3840x1200_scrot](https://cloud.githubusercontent.com/assets/105168/23460661/bdc3233e-fe86-11e6-997b-68b675c95c6a.png)

Refs #20 and #39.