### PR TITLE
Submit file using enter key

### DIFF
--- a/src/partials/messenger.ts
+++ b/src/partials/messenger.ts
@@ -325,11 +325,11 @@ class ConversationController {
                         controllerAs: 'ctrl',
                         // tslint:disable:max-line-length
                         template: `
-                            <md-dialog class="send-file-dialog" ng-keypress="ctrl.keypress($event)">
+                            <md-dialog class="send-file-dialog">
                                 <md-dialog-content class="md-dialog-content">
                                     <h2 class="md-title">${title}</h2>
                                     <md-input-container md-no-float class="input-caption md-prompt-input-container">
-                                        <input md-autofocus ng-model="ctrl.caption" placeholder="${placeholder}" aria-label="${placeholder}">
+                                        <input md-autofocus ng-keypress="ctrl.keypress($event)" ng-model="ctrl.caption" placeholder="${placeholder}" aria-label="${placeholder}">
                                     </md-input-container>
                                     <md-input-container md-no-float class="input-send-as-file md-prompt-input-container" ng-show="${showSendAsFileCheckbox}">
                                         <md-checkbox ng-model="ctrl.sendAsFile" aria-label="${confirmSendAsFile}">

--- a/src/partials/messenger.ts
+++ b/src/partials/messenger.ts
@@ -69,7 +69,7 @@ class SendFileController extends DialogController {
     }
 
     public keypress($event: KeyboardEvent): void {
-        if ($event.charCode === 13) { // Enter
+        if ($event.key === 'Enter') { // see https://developer.mozilla.org/de/docs/Web/API/KeyboardEvent/key/Key_Values
             this.send();
         }
     }
@@ -325,11 +325,11 @@ class ConversationController {
                         controllerAs: 'ctrl',
                         // tslint:disable:max-line-length
                         template: `
-                            <md-dialog class="send-file-dialog">
+                            <md-dialog class="send-file-dialog" ng-keypress="ctrl.keypress($event)">
                                 <md-dialog-content class="md-dialog-content">
                                     <h2 class="md-title">${title}</h2>
                                     <md-input-container md-no-float class="input-caption md-prompt-input-container">
-                                        <input md-autofocus ng-keypress="ctrl.keypress($event)" ng-model="ctrl.caption" placeholder="${placeholder}" aria-label="${placeholder}">
+                                        <input md-autofocus ng-model="ctrl.caption" placeholder="${placeholder}" aria-label="${placeholder}">
                                     </md-input-container>
                                     <md-input-container md-no-float class="input-send-as-file md-prompt-input-container" ng-show="${showSendAsFileCheckbox}">
                                         <md-checkbox ng-model="ctrl.sendAsFile" aria-label="${confirmSendAsFile}">


### PR DESCRIPTION
Fixes #122

[KeyboardEvent.charCode](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/charCode) is deprechated. Used [KeyboardEvent.key](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key) instead.