### PR TITLE
Hide desktop notifications for read conversations

### DIFF
--- a/src/services/notification.ts
+++ b/src/services/notification.ts
@@ -18,6 +18,8 @@
 import Receiver = threema.Receiver;
 export class NotificationService implements threema.NotificationService {
 
+    private logTag: string = '[NotificationService]';
+
     private $log: ng.ILogService;
     private $window: ng.IWindowService;
     private $state: ng.ui.IStateService;
@@ -45,17 +47,21 @@ export class NotificationService implements threema.NotificationService {
     public requestNotificationPermission(): void {
         if (!('Notification' in this.$window)) {
             // API not available
+            this.$log.warn(this.logTag, 'Notification API not available');
             this.mayNotify = null;
         } else {
             const Notification = this.$window.Notification;
             if (Notification.permission === 'granted') {
                 // Already granted
+                this.$log.debug(this.logTag, 'Notification permission granted');
                 this.mayNotify = true;
             } else if (Notification.permission === 'denied') {
                 // Not granted
+                this.$log.warn(this.logTag, 'Notification permission denied');
                 this.mayNotify = false;
             } else {
                 // Ask user
+                this.$log.debug(this.logTag, 'Requesting notification permission');
                 Notification.requestPermission((result) => {
                     if (result === 'granted') {
                         this.mayNotify = true;
@@ -91,6 +97,7 @@ export class NotificationService implements threema.NotificationService {
         }
 
         // Show notification
+        this.$log.debug(this.logTag, 'Showing notification', tag);
         const notification = new this.$window.Notification(title, {
             icon: avatar,
             body: body.trim(),
@@ -105,6 +112,7 @@ export class NotificationService implements threema.NotificationService {
             if (clickCallback !== undefined) {
                 clickCallback();
             }
+            this.$log.debug(this.logTag, 'Hiding notification', tag, 'on click');
             notification.close();
             this.clearCache(tag);
         };
@@ -113,6 +121,23 @@ export class NotificationService implements threema.NotificationService {
         this.notificationCache[tag] = notification;
 
         return true;
+    }
+
+    /**
+     * Hide the notification with the specified tag.
+     *
+     * Return whether the notification was hidden.
+     */
+    public hideNotification(tag: string): boolean {
+        const notification = this.notificationCache[tag];
+        if (notification !== undefined) {
+            this.$log.debug(this.logTag, 'Hiding notification', tag);
+            notification.close();
+            this.clearCache(tag);
+            return true;
+        } else {
+            return false;
+        }
     }
 
     /**

--- a/src/services/webclient.ts
+++ b/src/services/webclient.ts
@@ -1543,21 +1543,20 @@ export class WebClientService implements threema.WebClientService {
                     for (let conversation of this.conversations.get()) {
                         if (this.receiverService.compare(conversation, data)) {
 
-                            // This is our conversation! If the unreadcount has increased,
-                            // we received a new message.
                             if (data.unreadCount > conversation.unreadCount) {
+                                // This is our conversation! If the unreadcount
+                                // has increased, we received a new message.
                                 this.onNewMessage(data.latestMessage, conversation);
-
-                            // Otherwise, if it has decreased, clear the notification cache.
                             } else if (data.unreadCount < conversation.unreadCount) {
-                                this.notificationService.clearCache(data.type + '-' + data.id);
+                                // Otherwise, if it has decreased, hide the notification.
+                                this.notificationService.hideNotification(data.type + '-' + data.id);
                             }
 
                             break;
                         }
                     }
                 } else {
-                    this.notificationService.clearCache(data.type + '-' + data.id);
+                    this.notificationService.hideNotification(data.type + '-' + data.id);
                 }
                 // we have to call update or add, we are not sure if this
                 // conversation is already fetched

--- a/src/threema.d.ts
+++ b/src/threema.d.ts
@@ -347,6 +347,7 @@ declare namespace threema {
         showNotification(id: string, title: string, body: string,
                          avatar: string | null, clickCallback: any | null): boolean;
         clearCache(tag: string): void;
+        hideNotification(tag: string): boolean;
     }
 
     interface MessageService {


### PR DESCRIPTION
If the unread counter for a conversation decreases, hide related notifications.

Fixes #131.