### PR TITLE
Show notification settings

### DIFF
--- a/public/i18n/de.json
+++ b/public/i18n/de.json
@@ -164,7 +164,7 @@
         "TEXT_TOO_LONG": "Diese Nachricht ist zu lang und kann nicht gesendet werden (Maximale Länge {max} Zeichen).",
         "NOTIFICATION_PERMISSION_DENIED" : "Berechtigung nicht erteilt. Sie müssen die Berechtigungen für Threema Web manuell erteilen.",
         "NOTIFICATION_PERMISSION_DENIED_LEARN_MORE" : "Mehr erfahren.",
-        "API_NOT_AVAILABLE" : "Ihr Browser unterstütz keine Desktopbenachrichtigungen."
+        "API_NOT_AVAILABLE" : "Ihr Browser unterstützt keine Desktopbenachrichtigungen."
     },
     "mimeTypes": {
         "android_apk": "Android-Paket",

--- a/public/i18n/de.json
+++ b/public/i18n/de.json
@@ -164,7 +164,7 @@
         "TEXT_TOO_LONG": "Diese Nachricht ist zu lang und kann nicht gesendet werden (Maximale Länge {max} Zeichen).",
         "NOTIFICATION_PERMISSION_DENIED" : "Berechtigung nicht erteilt. Sie müssen die Berechtigungen für Threema Web manuell erteilen.",
         "NOTIFICATION_PERMISSION_DENIED_LEARN_MORE" : "Mehr erfahren.",
-        "API_NOT_AVAILABLE" : "Ihr Browser unterstützt keine Desktopbenachrichtigungen."
+        "NOTIFICATION_API_NOT_AVAILABLE" : "Ihr Browser unterstützt keine Desktopbenachrichtigungen."
     },
     "mimeTypes": {
         "android_apk": "Android-Paket",
@@ -198,7 +198,7 @@
         "notifications": {
             "NOTIFICATIONS" : "Benachrichtigungen",
             "SHOW_NOTIFICATIONS" : "Desktopbenachrichtigungen anzeigen",
-            "SHOW_PREVIEW" : "Vorschau anzeigen"
+            "SHOW_PREVIEW" : "Nachrichteninhalt in Benachrichtigungen anzeigen"
         }
     }
 }

--- a/public/i18n/de.json
+++ b/public/i18n/de.json
@@ -191,6 +191,10 @@
         "LICENSE_LINK_AFTER": "gefunden werden"
     },
     "settings": {
-        "SETTINGS":"Einstellungen"
+        "SETTINGS":"Einstellungen",
+        "notifications": {
+            "NOTIFICATIONS" : "Benachrichtigungen",
+            "SHOW_NOTIFICATIONS" : "Desktopbenachrichtigungen anzeigen"
+        }
     }
 }

--- a/public/i18n/de.json
+++ b/public/i18n/de.json
@@ -161,7 +161,10 @@
         "FILE_MESSAGES_NOT_SUPPORTED": "«{receiverName}» kann noch keine Dateien erhalten.",
         "ERROR_OCCURRED": "Es ist ein Fehler aufgetreten.",
         "FILE_TOO_LARGE": "Aktuell können keine Dateien grösser als 15 MiB über Threema Web versendet werden",
-        "TEXT_TOO_LONG": "Diese Nachricht ist zu lang und kann nicht gesendet werden (Maximale Länge {max} Zeichen)."
+        "TEXT_TOO_LONG": "Diese Nachricht ist zu lang und kann nicht gesendet werden (Maximale Länge {max} Zeichen).",
+        "NOTIFICATION_PERMISSION_DENIED" : "Berechtigung nicht erteilt. Sie müssen die Berechtigungen für Threema Web manuell erteilen.",
+        "NOTIFICATION_PERMISSION_DENIED_LEARN_MORE" : "Mehr erfahren.",
+        "API_NOT_AVAILABLE" : "Ihr Browser unterstütz keine Desktopbenachrichtigungen."
     },
     "mimeTypes": {
         "android_apk": "Android-Paket",
@@ -194,7 +197,8 @@
         "SETTINGS":"Einstellungen",
         "notifications": {
             "NOTIFICATIONS" : "Benachrichtigungen",
-            "SHOW_NOTIFICATIONS" : "Desktopbenachrichtigungen anzeigen"
+            "SHOW_NOTIFICATIONS" : "Desktopbenachrichtigungen anzeigen",
+            "SHOW_PREVIEW" : "Vorschau anzeigen"
         }
     }
 }

--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -162,7 +162,10 @@
         "FILE_MESSAGES_NOT_SUPPORTED": "«{receiverName}» cannot receive files.",
         "ERROR_OCCURRED": "An error occurred.",
         "FILE_TOO_LARGE": "Currently files larger than 15 MiB cannot be sent through Threema Web",
-        "TEXT_TOO_LONG": "This message is too long and cannot be sent (Max length {max} characters)."
+        "TEXT_TOO_LONG": "This message is too long and cannot be sent (Max length {max} characters).",
+        "NOTIFICATION_PERMISSION_DENIED" : "Permission denied. You have to grant the permission for Threema Web manually.",
+        "NOTIFICATION_PERMISSION_DENIED_LEARN_MORE" : "Learn more.",
+        "API_NOT_AVAILABLE" : "Your browser does not support desktop notifications."
     },
     "mimeTypes": {
         "android_apk": "Android package",
@@ -195,7 +198,8 @@
         "SETTINGS": "Settings",
         "notifications": {
             "NOTIFICATIONS" : "Notifications",
-            "SHOW_NOTIFICATIONS" : "Show desktop notifications"
+            "SHOW_NOTIFICATIONS" : "Show desktop notifications",
+            "SHOW_PREVIEW" : "Show message preview"
         }
     }
 }

--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -165,7 +165,7 @@
         "TEXT_TOO_LONG": "This message is too long and cannot be sent (Max length {max} characters).",
         "NOTIFICATION_PERMISSION_DENIED" : "Permission denied. You have to grant the permission for Threema Web manually.",
         "NOTIFICATION_PERMISSION_DENIED_LEARN_MORE" : "Learn more.",
-        "API_NOT_AVAILABLE" : "Your browser does not support desktop notifications."
+        "NOTIFICATION_API_NOT_AVAILABLE" : "Your browser does not support desktop notifications."
     },
     "mimeTypes": {
         "android_apk": "Android package",
@@ -199,7 +199,7 @@
         "notifications": {
             "NOTIFICATIONS" : "Notifications",
             "SHOW_NOTIFICATIONS" : "Show desktop notifications",
-            "SHOW_PREVIEW" : "Show message preview"
+            "SHOW_PREVIEW" : "Show message contents in notifications"
         }
     }
 }

--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -192,6 +192,10 @@
         "LICENSE_LINK_AFTER": ""
     },
     "settings": {
-        "SETTINGS":"Settings"
+        "SETTINGS": "Settings",
+        "notifications": {
+            "NOTIFICATIONS" : "Notifications",
+            "SHOW_NOTIFICATIONS" : "Show desktop notifications"
+        }
     }
 }

--- a/src/directives/compose_area.ts
+++ b/src/directives/compose_area.ts
@@ -79,7 +79,7 @@ export default [
                 /**
                  * Stop propagation of click events and hold htmlElement of the emojipicker
                  */
-                let EmoijPickerContainer = (function(){
+                let EmoijPickerContainer = (function() {
                     let instance;
 
                     function click(e) {

--- a/src/filters.ts
+++ b/src/filters.ts
@@ -250,7 +250,7 @@ angular.module('3ema.filters', [])
 .filter('idsToNames', ['WebClientService', function (webClientService: threema.WebClientService) {
     return(ids: string[]) => {
         let names: string[] = [];
-        for (let id of ids){
+        for (let id of ids) {
             this.contactReceiver = webClientService.contacts.get(id);
             names.push(this.contactReceiver.displayName);
         }

--- a/src/filters.ts
+++ b/src/filters.ts
@@ -244,4 +244,18 @@ angular.module('3ema.filters', [])
     };
 }])
 
+/**
+ * Convert ID-Array to (Display-)Name-String, separated by ','
+ */
+.filter('idsToNames', ['WebClientService', function (webClientService: threema.WebClientService) {
+    return(ids: string[]) => {
+        let names: string[] = [];
+        for (let id of ids){
+            this.contactReceiver = webClientService.contacts.get(id);
+            names.push(this.contactReceiver.displayName);
+        }
+        return names.join(', ');
+    };
+}])
+
 ;

--- a/src/partials/dialog.about.html
+++ b/src/partials/dialog.about.html
@@ -2,7 +2,7 @@
     <form ng-cloak>
         <md-toolbar>
             <div class="md-toolbar-tools">
-                <h2>About</h2>
+                <h2 translate>messenger.ABOUT</h2>
                 <span flex></span>
                 <md-button class="md-icon-button" ng-click="ctrl.cancel()">
                     <md-icon aria-label="Close dialog" class="material-icons md-24">close</md-icon>

--- a/src/partials/dialog.settings.html
+++ b/src/partials/dialog.settings.html
@@ -19,7 +19,8 @@
                             <md-checkbox
                                     ng-disabled="!ctrl.notificationApiAvailable || ctrl.notificationPermission === false"
                                     ng-model="ctrl.desktopNotifications"
-                                    ng-change="ctrl.setWantsNotifications(ctrl.desktopNotifications)">
+                                    ng-change="ctrl.setWantsNotifications(ctrl.desktopNotifications)"
+                                    aria-label="Show desktop notifications">
                             </md-checkbox>
                             <p translate>settings.notifications.SHOW_NOTIFICATIONS</p>
                         </md-list-item>
@@ -27,7 +28,8 @@
                             <md-checkbox
                                     ng-disabled="!ctrl.desktopNotifications"
                                     ng-model="ctrl.notificationPreview"
-                                    ng-change="ctrl.setWantsPreview(ctrl.notificationPreview)">
+                                    ng-change="ctrl.setWantsPreview(ctrl.notificationPreview)"
+                                    aria-label="Show message preview">
                             </md-checkbox>
                             <span translate>settings.notifications.SHOW_PREVIEW</span>
                         </md-list-item>
@@ -38,7 +40,7 @@
                     </div>
                     <div ng-if="ctrl.notificationPermission === false && ctrl.notificationApiAvailable">
                         <span translate>error.NOTIFICATION_PERMISSION_DENIED</span>
-                        <a href="https://github.com/threema-ch/threema-web"
+                        <a href="https://threema.ch/de/faq/web_notifications"
                            target="_blank" rel="noopener noreferrer"><span translate>error.NOTIFICATION_PERMISSION_DENIED_LEARN_MORE</span></a>
                     </div>
                 </section>

--- a/src/partials/dialog.settings.html
+++ b/src/partials/dialog.settings.html
@@ -14,34 +14,37 @@
                 <section>
                     <md-subheader class="md-accent"><span translate>settings.notifications.NOTIFICATIONS</span>
                     </md-subheader>
-                    <md-list flex>
+                    <md-list flex ng-if="ctrl.notificationApiAvailable && ctrl.notificationPermission !== false">
                         <md-list-item>
                             <md-checkbox
                                     ng-disabled="!ctrl.notificationApiAvailable || ctrl.notificationPermission === false"
                                     ng-model="ctrl.desktopNotifications"
                                     ng-change="ctrl.setWantsNotifications(ctrl.desktopNotifications)"
                                     aria-label="Show desktop notifications">
+                                <span translate>settings.notifications.SHOW_NOTIFICATIONS</span>
                             </md-checkbox>
-                            <p translate>settings.notifications.SHOW_NOTIFICATIONS</p>
                         </md-list-item>
-                        <md-list-item>
+                        <md-list-item ng-if="ctrl.desktopNotifications">
                             <md-checkbox
                                     ng-disabled="!ctrl.desktopNotifications"
                                     ng-model="ctrl.notificationPreview"
                                     ng-change="ctrl.setWantsPreview(ctrl.notificationPreview)"
                                     aria-label="Show message preview">
+                                <span translate>settings.notifications.SHOW_PREVIEW</span>
                             </md-checkbox>
-                            <span translate>settings.notifications.SHOW_PREVIEW</span>
                         </md-list-item>
                     </md-list>
 
-                    <div ng-if="!ctrl.notificationApiAvailable">
+                    <div ng-if="!ctrl.notificationApiAvailable" class="status status-no">
+                        <i class="material-icons md-24">error</i>
                         <span translate>error.NOTIFICATION_API_NOT_AVAILABLE</span>
                     </div>
-                    <div ng-if="ctrl.notificationPermission === false && ctrl.notificationApiAvailable">
-                        <span translate>error.NOTIFICATION_PERMISSION_DENIED</span>
+                    <div ng-if="ctrl.notificationPermission === false && ctrl.notificationApiAvailable" class="status status-no">
+                        <i class="material-icons md-24">error</i> <span translate>error.NOTIFICATION_PERMISSION_DENIED</span>
                         <a href="https://threema.ch/de/faq/web_notifications"
-                           target="_blank" rel="noopener noreferrer"><span translate>error.NOTIFICATION_PERMISSION_DENIED_LEARN_MORE</span></a>
+                           target="_blank" rel="noopener noreferrer">
+                            <span translate>error.NOTIFICATION_PERMISSION_DENIED_LEARN_MORE</span>
+                        </a>
                     </div>
                 </section>
             </div>

--- a/src/partials/dialog.settings.html
+++ b/src/partials/dialog.settings.html
@@ -11,7 +11,12 @@
         </md-toolbar>
         <md-dialog-content>
             <div class="md-dialog-content">
-
+                <section>
+                    <md-subheader class="md-primary"><span translate>settings.notifications.NOTIFICATIONS</span></md-subheader>
+                            <md-checkbox ng-disabled="ctrl.getNotificationPermission() == null" ng-model="ctrl.desktopNotifications" ng-change="ctrl.setWantsNotifications(ctrl.desktopNotifications)" layout-padding>
+                                <span translate>settings.notifications.SHOW_NOTIFICATIONS</span>
+                            </md-checkbox>
+                </section>
             </div>
         </md-dialog-content>
     </form>

--- a/src/partials/dialog.settings.html
+++ b/src/partials/dialog.settings.html
@@ -12,10 +12,35 @@
         <md-dialog-content>
             <div class="md-dialog-content">
                 <section>
-                    <md-subheader class="md-primary"><span translate>settings.notifications.NOTIFICATIONS</span></md-subheader>
-                            <md-checkbox ng-disabled="ctrl.getNotificationPermission() == null" ng-model="ctrl.desktopNotifications" ng-change="ctrl.setWantsNotifications(ctrl.desktopNotifications)" layout-padding>
-                                <span translate>settings.notifications.SHOW_NOTIFICATIONS</span>
+                    <md-subheader class="md-accent"><span translate>settings.notifications.NOTIFICATIONS</span>
+                    </md-subheader>
+                    <md-list flex>
+                        <md-list-item>
+                            <md-checkbox
+                                    ng-disabled="!ctrl.notificationApiAvailable || ctrl.notificationPermission === false"
+                                    ng-model="ctrl.desktopNotifications"
+                                    ng-change="ctrl.setWantsNotifications(ctrl.desktopNotifications)">
                             </md-checkbox>
+                            <p translate>settings.notifications.SHOW_NOTIFICATIONS</p>
+                        </md-list-item>
+                        <md-list-item>
+                            <md-checkbox
+                                    ng-disabled="!ctrl.desktopNotifications"
+                                    ng-model="ctrl.notificationPreview"
+                                    ng-change="ctrl.setWantsPreview(ctrl.notificationPreview)">
+                            </md-checkbox>
+                            <span translate>settings.notifications.SHOW_PREVIEW</span>
+                        </md-list-item>
+                    </md-list>
+
+                    <div ng-if="!ctrl.notificationApiAvailable">
+                        <span translate>error.NOTIFICATION_API_NOT_AVAILABLE</span>
+                    </div>
+                    <div ng-if="ctrl.notificationPermission === false && ctrl.notificationApiAvailable">
+                        <span translate>error.NOTIFICATION_PERMISSION_DENIED</span>
+                        <a href="https://github.com/threema-ch/threema-web"
+                           target="_blank" rel="noopener noreferrer"><span translate>error.NOTIFICATION_PERMISSION_DENIED_LEARN_MORE</span></a>
+                    </div>
                 </section>
             </div>
         </md-dialog-content>

--- a/src/partials/dialog.settings.html
+++ b/src/partials/dialog.settings.html
@@ -19,6 +19,12 @@
                 </section>
             </div>
         </md-dialog-content>
+        <md-dialog-actions layout="row">
+            <span flex></span>
+            <md-button ng-click="ctrl.cancel()">
+                <span translate>common.OK</span>
+            </md-button>
+        </md-dialog-actions>
     </form>
 </md-dialog>
 

--- a/src/partials/messenger.conversation.html
+++ b/src/partials/messenger.conversation.html
@@ -20,6 +20,10 @@
             <eee-verification-level ng-if="ctrl.type == 'contact'"
                                     contact="ctrl.receiver"></eee-verification-level>
             </div>
+            <div class="conversation-header-details-detail" ng-if="ctrl.type == 'group'"
+                 title="{{ ctrl.receiver.members | idsToNames }}">
+                <span>{{ ctrl.receiver.members | idsToNames }}</span>
+            </div>
         </div>
     </div>
     <div id="conversation-is-private" ng-if="ctrl.locked">

--- a/src/partials/messenger.navigation.html
+++ b/src/partials/messenger.navigation.html
@@ -1,7 +1,7 @@
 <!-- My identity -->
 <div id="my-identity" ng-if="ctrl.showMyIdentity()">
     <div class="my-identity-content" eee-my-identity
-            eee-identity="ctrl.getMyIdentity()"></div>
+         eee-identity="ctrl.getMyIdentity()"></div>
 
     <md-menu md-position-mode="target-right target" md-offset="0 45">
         <md-button aria-label="Open menu" class="md-icon-button" ng-click="$mdOpenMenu($event)">
@@ -53,7 +53,8 @@
         </md-button>
     </div>
     <div class="search" searchbox searchbox-focus="ctrl.searchVisible">
-        <input type="text" ng-model="ctrl.searchText" translate translate-attr-placeholder="messenger.SEARCH" aria-label="Search" translate-attr-aria-label="messenger.SEARCH">
+        <input type="text" ng-model="ctrl.searchText" translate translate-attr-placeholder="messenger.SEARCH"
+               aria-label="Search" translate-attr-aria-label="messenger.SEARCH">
     </div>
 </div>
 
@@ -85,11 +86,11 @@
 
                 <section class="message-box">
                     <eee-latest-message
-                        ng-show="!conversation.receiver.isTyping() && conversation.latestMessage"
-                        ng-class="latest-message-text"
-                        eee-type="conversation.type"
-                        eee-receiver="conversation.receiver"
-                        eee-message="conversation.latestMessage"></eee-latest-message>
+                            ng-show="!conversation.receiver.isTyping() && conversation.latestMessage"
+                            ng-class="latest-message-text"
+                            eee-type="conversation.type"
+                            eee-receiver="conversation.receiver"
+                            eee-message="conversation.latestMessage"></eee-latest-message>
                 </section>
             </section>
 
@@ -125,8 +126,8 @@
                 </div>
                 <div class="verification-level">
                     <eee-verification-level
-                        contact="contact"
-                        ng-if="contact.verificationLevel">
+                            contact="contact"
+                            ng-if="contact.verificationLevel">
                     </eee-verification-level>
                 </div>
             </section>

--- a/src/partials/messenger.navigation.html
+++ b/src/partials/messenger.navigation.html
@@ -21,15 +21,15 @@
                 </md-button>
             </md-menu-item>
             <md-menu-item>
-                <md-button ng-click="ctrl.about()">
-                    <md-icon aria-label="About" class="material-icons md-24">info</md-icon>
-                    <span translate>messenger.ABOUT</span>
-                </md-button>
-            </md-menu-item>
-            <md-menu-item>
                 <md-button ng-click="ctrl.settings()">
                     <md-icon aria-label="Settings" class="material-icons md-24">settings</md-icon>
                     <span translate>messenger.SETTINGS</span>
+                </md-button>
+            </md-menu-item>
+            <md-menu-item>
+                <md-button ng-click="ctrl.about()">
+                    <md-icon aria-label="About" class="material-icons md-24">info</md-icon>
+                    <span translate>messenger.ABOUT</span>
                 </md-button>
             </md-menu-item>
         </md-menu-content>

--- a/src/partials/messenger.navigation.html
+++ b/src/partials/messenger.navigation.html
@@ -1,7 +1,7 @@
 <!-- My identity -->
 <div id="my-identity" ng-if="ctrl.showMyIdentity()">
     <div class="my-identity-content" eee-my-identity
-         eee-identity="ctrl.getMyIdentity()"></div>
+            eee-identity="ctrl.getMyIdentity()"></div>
 
     <md-menu md-position-mode="target-right target" md-offset="0 45">
         <md-button aria-label="Open menu" class="md-icon-button" ng-click="$mdOpenMenu($event)">
@@ -86,11 +86,11 @@
 
                 <section class="message-box">
                     <eee-latest-message
-                            ng-show="!conversation.receiver.isTyping() && conversation.latestMessage"
-                            ng-class="latest-message-text"
-                            eee-type="conversation.type"
-                            eee-receiver="conversation.receiver"
-                            eee-message="conversation.latestMessage"></eee-latest-message>
+                        ng-show="!conversation.receiver.isTyping() && conversation.latestMessage"
+                        ng-class="latest-message-text"
+                        eee-type="conversation.type"
+                        eee-receiver="conversation.receiver"
+                        eee-message="conversation.latestMessage"></eee-latest-message>
                 </section>
             </section>
 
@@ -126,8 +126,8 @@
                 </div>
                 <div class="verification-level">
                     <eee-verification-level
-                            contact="contact"
-                            ng-if="contact.verificationLevel">
+                        contact="contact"
+                        ng-if="contact.verificationLevel">
                     </eee-verification-level>
                 </div>
             </section>

--- a/src/partials/messenger.ts
+++ b/src/partials/messenger.ts
@@ -84,20 +84,26 @@ class SendFileController extends DialogController {
  */
 class SettingsController {
 
-    public static $inject = ['$mdDialog', '$window', 'SettingsService'];
+    public static $inject = ['$mdDialog', '$window', 'SettingsService', 'NotificationService'];
 
     public $mdDialog: ng.material.IDialogService;
     public $window: ng.IWindowService;
     public settingsService: threema.SettingsService;
+    private notificationService: threema.NotificationService;
     public activeElement: HTMLElement | null;
+
+    private desktopNotifications: boolean;
 
     constructor($mdDialog: ng.material.IDialogService,
                 $window: ng.IWindowService,
-                settingsService: threema.SettingsService) {
+                settingsService: threema.SettingsService,
+                notificationService: threema.NotificationService) {
         this.$mdDialog = $mdDialog;
         this.$window = $window;
         this.settingsService = settingsService;
+        this.notificationService = notificationService;
         this.activeElement = document.activeElement as HTMLElement;
+        this.desktopNotifications = notificationService.getWantsNotifications();
     }
 
     public cancel(): void {
@@ -115,6 +121,15 @@ class SettingsController {
             // Reset focus
             this.activeElement.focus();
         }
+    }
+
+    public getNotificationPermission(): boolean{
+        return this.notificationService.getNotificationPermission();
+    }
+
+    public setWantsNotifications(desktopNotifications: boolean){
+        console.info("Requested change to " + desktopNotifications);
+        this.notificationService.setWantsNotifications(desktopNotifications);
     }
 
 }

--- a/src/partials/messenger.ts
+++ b/src/partials/messenger.ts
@@ -93,6 +93,9 @@ class SettingsController {
     public activeElement: HTMLElement | null;
 
     private desktopNotifications: boolean;
+    private notificationApiAvailable: boolean;
+    private notificationPermission: boolean;
+    private notificationPreview: boolean;
 
     constructor($mdDialog: ng.material.IDialogService,
                 $window: ng.IWindowService,
@@ -104,6 +107,10 @@ class SettingsController {
         this.notificationService = notificationService;
         this.activeElement = document.activeElement as HTMLElement;
         this.desktopNotifications = notificationService.getWantsNotifications();
+        this.notificationApiAvailable = notificationService.isNotificationApiAvailable();
+        this.notificationPermission = notificationService.getNotificationPermission();
+        this.notificationPreview = notificationService.getWantsPreview();
+        console.info("init dialog complete");
     }
 
     public cancel(): void {
@@ -123,13 +130,18 @@ class SettingsController {
         }
     }
 
-    public getNotificationPermission(): boolean{
+/*    public getNotificationPermission(): boolean{
         return this.notificationService.getNotificationPermission();
-    }
+    }*/
 
     public setWantsNotifications(desktopNotifications: boolean){
         console.info("Requested change to " + desktopNotifications);
         this.notificationService.setWantsNotifications(desktopNotifications);
+    }
+
+    public setWantsPreview(notificationPreview: boolean){
+        console.info("Preview request change to " + notificationPreview);
+        this.notificationService.setWantsPreview(notificationPreview);
     }
 
 }

--- a/src/partials/messenger.ts
+++ b/src/partials/messenger.ts
@@ -110,7 +110,6 @@ class SettingsController {
         this.notificationApiAvailable = notificationService.isNotificationApiAvailable();
         this.notificationPermission = notificationService.getNotificationPermission();
         this.notificationPreview = notificationService.getWantsPreview();
-        console.info("init dialog complete");
     }
 
     public cancel(): void {
@@ -130,17 +129,11 @@ class SettingsController {
         }
     }
 
-/*    public getNotificationPermission(): boolean{
-        return this.notificationService.getNotificationPermission();
-    }*/
-
-    public setWantsNotifications(desktopNotifications: boolean){
-        console.info("Requested change to " + desktopNotifications);
+    public setWantsNotifications(desktopNotifications: boolean) {
         this.notificationService.setWantsNotifications(desktopNotifications);
     }
 
-    public setWantsPreview(notificationPreview: boolean){
-        console.info("Preview request change to " + notificationPreview);
+    public setWantsPreview(notificationPreview: boolean) {
         this.notificationService.setWantsPreview(notificationPreview);
     }
 

--- a/src/sass/components/_avatar.scss
+++ b/src/sass/components/_avatar.scss
@@ -13,12 +13,13 @@
 
     &.is-loading {
         //show default blured
-        .avatar-default {
-            &.avatar-high {
+        &.avatar-high {
+            > img {
                 filter: blur(40px);
                 border-radius: 0;
             }
         }
+
     }
     .avatar-loading {
         position: absolute;

--- a/src/sass/components/_scrollbars.scss
+++ b/src/sass/components/_scrollbars.scss
@@ -1,7 +1,7 @@
 // TODO: Prefixes
 
 ::-webkit-scrollbar {
-    width: 5px;
+    width: 8px;
     background-color: #fcfcfc;
     border: 1px solid #f9f9f9;
 }

--- a/src/sass/layout/_main.scss
+++ b/src/sass/layout/_main.scss
@@ -324,3 +324,27 @@ md-toast.md-center {
     left: 50%;
     transform: translate3d(-50%, 0, 0);
 }
+
+.md-subheader {
+    background-color: transparent;
+}
+
+.md-subheader-inner {
+    padding-left: 0;
+}
+
+md-list-item .md-list-item-inner > md-checkbox .md-label {
+    display: inline-block;
+    white-space: inherit;
+}
+
+.status span {
+    display: inline;
+    line-height: 24px;
+    vertical-align: top;
+}
+
+.status-yes i { color: #4caf50; }
+.status-no i { color: #f44336; }
+.status-unknown i { color: #0277BD; }
+.small { font-size: 0.8em; font-weight: 300; }

--- a/src/sass/sections/_conversation.scss
+++ b/src/sass/sections/_conversation.scss
@@ -63,7 +63,7 @@
         align-self: flex-end;
         height: 0;
         position: relative;
-        right: 8px;
+        right: 16px;
         bottom: 8px + $scrolljump-height;
         z-index: 15;
         outline: none;

--- a/src/sass/sections/_conversation.scss
+++ b/src/sass/sections/_conversation.scss
@@ -17,7 +17,7 @@
 
         .header-details {
             @include mouse-hand;
-
+            overflow: hidden;
 
             & > *:first-child {
                 font-weight: bold;
@@ -28,6 +28,15 @@
             margin: 0 0 4px 0;
             padding: 0;
             font-size: 120%;
+        }
+
+        .conversation-header-details-detail, .conversation-header-details-name {
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            max-width: 100%;
+            display: inherit;
+            line-height: 1.3;
         }
     }
 

--- a/src/services/notification.ts
+++ b/src/services/notification.ts
@@ -18,6 +18,8 @@
 import Receiver = threema.Receiver;
 export class NotificationService implements threema.NotificationService {
 
+    private logTag: string = '[NotificationService]';
+
     private $log: ng.ILogService;
     private $window: ng.IWindowService;
     private $state: ng.ui.IStateService;
@@ -45,17 +47,21 @@ export class NotificationService implements threema.NotificationService {
     public requestNotificationPermission(): void {
         if (!('Notification' in this.$window)) {
             // API not available
+            this.$log.warn(this.logTag, 'Notification API not available');
             this.mayNotify = null;
         } else {
             const Notification = this.$window.Notification;
             if (Notification.permission === 'granted') {
                 // Already granted
+                this.$log.debug(this.logTag, 'Notification permission granted');
                 this.mayNotify = true;
             } else if (Notification.permission === 'denied') {
                 // Not granted
+                this.$log.warn(this.logTag, 'Notification permission denied');
                 this.mayNotify = false;
             } else {
                 // Ask user
+                this.$log.debug(this.logTag, 'Requesting notification permission');
                 Notification.requestPermission((result) => {
                     if (result === 'granted') {
                         this.mayNotify = true;
@@ -91,6 +97,7 @@ export class NotificationService implements threema.NotificationService {
         }
 
         // Show notification
+        this.$log.debug(this.logTag, 'Showing notification', tag);
         const notification = new this.$window.Notification(title, {
             icon: avatar,
             body: body.trim(),
@@ -105,6 +112,7 @@ export class NotificationService implements threema.NotificationService {
             if (clickCallback !== undefined) {
                 clickCallback();
             }
+            this.$log.debug(this.logTag, 'Hiding notification', tag, 'on click');
             notification.close();
             this.clearCache(tag);
         };
@@ -113,6 +121,23 @@ export class NotificationService implements threema.NotificationService {
         this.notificationCache[tag] = notification;
 
         return true;
+    }
+
+    /**
+     * Hide the notification with the specified tag.
+     *
+     * Return whether the notification was hidden.
+     */
+    public hideNotification(tag: string): boolean {
+        const notification = this.notificationCache[tag];
+        if (notification !== undefined) {
+            this.$log.debug(this.logTag, 'Hiding notification', tag);
+            notification.close();
+            this.clearCache(tag);
+            return true;
+        } else {
+            return false;
+        }
     }
 
     /**

--- a/src/services/notification.ts
+++ b/src/services/notification.ts
@@ -51,7 +51,7 @@ export class NotificationService implements threema.NotificationService {
         this.settingsService = settingsService;
     }
 
-    public init() {
+    public init(): void {
         this.checkNotificationAPI();
         this.fetchSettings();
     }
@@ -125,10 +125,10 @@ export class NotificationService implements threema.NotificationService {
         this.$log.debug(this.logTag, 'Initial notificationPermission', this.notificationPermission);
     }
 
+    /**
+     * Get the initial settings from local storage
+     */
     private fetchSettings(): void {
-        /**
-         * Get the initial settings from local storage
-         */
         this.$log.debug(this.logTag, 'Fetching settings...');
         let notifications = this.retrieveSetting(NotificationService.SETTINGS_NOTIFICATIONS);
         let preview = this.retrieveSetting(NotificationService.SETTINGS_NOTIFICATION_PREVIEW);
@@ -248,8 +248,10 @@ export class NotificationService implements threema.NotificationService {
             return false;
         }
 
+        // Clear body string if the user does not want a notification preview
         if (!this.notificationPreview) {
             body = '';
+            // Clear notification cache
             if (this.notificationCache[tag]) {
                 this.clearCache(tag);
             }

--- a/src/services/notification.ts
+++ b/src/services/notification.ts
@@ -140,8 +140,6 @@ export class NotificationService implements threema.NotificationService {
             this.notificationPreview = true;
             this.storeSetting(NotificationService.SETTINGS_NOTIFICATION_PREVIEW, 'true');
         }
-
-
     }
 
     public getNotificationPermission(): boolean {

--- a/src/services/webclient.ts
+++ b/src/services/webclient.ts
@@ -406,10 +406,9 @@ export class WebClientService implements threema.WebClientService {
         this.salty.on('handover', () => {
             this.$log.debug('Handover done');
 
-            // Ask user for notification permission
-            this.$log.debug('Check notification API and fetch initial settings...');
-            this.notificationService.checkNotificationAPI();
-            this.notificationService.fetchSettings();
+            // Initialize NotificationService
+            this.$log.debug('Initializing NotificationService...');
+            this.notificationService.init();
 
             // Create secure data channel
             this.$log.debug('Create SecureDataChannel "' + WebClientService.DC_LABEL + '"...');

--- a/src/services/webclient.ts
+++ b/src/services/webclient.ts
@@ -407,8 +407,7 @@ export class WebClientService implements threema.WebClientService {
             this.$log.debug('Handover done');
 
             // Ask user for notification permission
-            this.$log.debug('Check notification permission...');
-            //this.notificationService.requestNotificationPermission();
+            this.$log.debug('Check notification API and fetch initial settings...');
             this.notificationService.checkNotificationAPI();
             this.notificationService.fetchSettings();
 

--- a/src/services/webclient.ts
+++ b/src/services/webclient.ts
@@ -408,7 +408,9 @@ export class WebClientService implements threema.WebClientService {
 
             // Ask user for notification permission
             this.$log.debug('Check notification permission...');
-            this.notificationService.requestNotificationPermission();
+            //this.notificationService.requestNotificationPermission();
+            this.notificationService.checkNotificationAPI();
+            this.notificationService.fetchSettings();
 
             // Create secure data channel
             this.$log.debug('Create SecureDataChannel "' + WebClientService.DC_LABEL + '"...');

--- a/src/services/webclient.ts
+++ b/src/services/webclient.ts
@@ -531,6 +531,9 @@ export class WebClientService implements threema.WebClientService {
 
         this.state.reset();
 
+        // Reset the unread count
+        this.resetUnreadCount();
+
         // Clear stored data (trusted key, push token, etc)
         if (deleteStoredData === true) {
             this.trustedKeyStore.clearTrustedKey();
@@ -2350,5 +2353,12 @@ export class WebClientService implements threema.WebClientService {
             .get()
             .reduce((a: number, b: threema.Conversation) => a + b.unreadCount, 0);
         this.titleService.updateUnreadCount(totalUnreadCount);
+    }
+
+    /**
+     * Reset the unread count in the window title
+     */
+    private resetUnreadCount(): void {
+        this.titleService.updateUnreadCount(0);
     }
 }

--- a/src/services/webclient.ts
+++ b/src/services/webclient.ts
@@ -1543,21 +1543,20 @@ export class WebClientService implements threema.WebClientService {
                     for (let conversation of this.conversations.get()) {
                         if (this.receiverService.compare(conversation, data)) {
 
-                            // This is our conversation! If the unreadcount has increased,
-                            // we received a new message.
                             if (data.unreadCount > conversation.unreadCount) {
+                                // This is our conversation! If the unreadcount
+                                // has increased, we received a new message.
                                 this.onNewMessage(data.latestMessage, conversation);
-
-                            // Otherwise, if it has decreased, clear the notification cache.
                             } else if (data.unreadCount < conversation.unreadCount) {
-                                this.notificationService.clearCache(data.type + '-' + data.id);
+                                // Otherwise, if it has decreased, hide the notification.
+                                this.notificationService.hideNotification(data.type + '-' + data.id);
                             }
 
                             break;
                         }
                     }
                 } else {
-                    this.notificationService.clearCache(data.type + '-' + data.id);
+                    this.notificationService.hideNotification(data.type + '-' + data.id);
                 }
                 // we have to call update or add, we are not sure if this
                 // conversation is already fetched

--- a/src/threema.d.ts
+++ b/src/threema.d.ts
@@ -343,7 +343,12 @@ declare namespace threema {
      * Notification service.
      */
     interface NotificationService {
+        getNotificationPermission(): boolean;
+        getWantsNotifications(): boolean;
+        setWantsNotifications(wantsNotifications: boolean): void;
         requestNotificationPermission(): void;
+        fetchSettings(): void;
+        checkNotificationAPI(): void;
         showNotification(id: string, title: string, body: string,
                          avatar: string | null, clickCallback: any | null): boolean;
         clearCache(tag: string): void;

--- a/src/threema.d.ts
+++ b/src/threema.d.ts
@@ -347,6 +347,7 @@ declare namespace threema {
         showNotification(id: string, title: string, body: string,
                          avatar: string | null, clickCallback: any | null): boolean;
         clearCache(tag: string): void;
+        hideNotification(tag: string): boolean;
     }
 
     interface MessageService {

--- a/src/threema.d.ts
+++ b/src/threema.d.ts
@@ -346,9 +346,11 @@ declare namespace threema {
         getNotificationPermission(): boolean;
         getWantsNotifications(): boolean;
         setWantsNotifications(wantsNotifications: boolean): void;
-        requestNotificationPermission(): void;
+        setWantsPreview(wantsPreview: boolean): void;
+        getWantsPreview(): boolean;
         fetchSettings(): void;
         checkNotificationAPI(): void;
+        isNotificationApiAvailable(): boolean;
         showNotification(id: string, title: string, body: string,
                          avatar: string | null, clickCallback: any | null): boolean;
         clearCache(tag: string): void;

--- a/src/threema.d.ts
+++ b/src/threema.d.ts
@@ -348,8 +348,7 @@ declare namespace threema {
         setWantsNotifications(wantsNotifications: boolean): void;
         setWantsPreview(wantsPreview: boolean): void;
         getWantsPreview(): boolean;
-        fetchSettings(): void;
-        checkNotificationAPI(): void;
+        init(): void;
         isNotificationApiAvailable(): boolean;
         showNotification(id: string, title: string, body: string,
                          avatar: string | null, clickCallback: any | null): boolean;

--- a/troubleshoot/index.html
+++ b/troubleshoot/index.html
@@ -171,6 +171,20 @@
             </div>
         </div>
 
+        <h2>Are desktop notifications available?</h2>
+        <div id="status-dn">
+            <div class="status status-unknown">
+                <i class="material-icons md-36">help</i> <span class="text">Unknown</span>
+            </div>
+            <div class="status status-no hidden">
+                <i class="material-icons md-36">error</i> <span class="text">No</span>
+                <p class="small">Without desktop notifications, we cannot notify you when a new message arrives.</p>
+            </div>
+            <div class="status status-yes hidden">
+                <i class="material-icons md-36">check_circle</i> <span class="text">Yes</span>
+            </div>
+        </div>
+
         <h2>Does TURN work?</h2>
         <div id="status-turn">
             <div class="status status-unknown">

--- a/troubleshoot/troubleshoot.js
+++ b/troubleshoot/troubleshoot.js
@@ -49,6 +49,13 @@ function doChecks() {
         switchTo('ls', 'no');
     }
 
+    // Check for desktop notifications
+    if ('Notification' in window) {
+        switchTo('dn', 'yes');
+    } else {
+        switchTo('dn', 'no');
+    }
+
     // Check for TURN connectivity
     var timeout = null;
     function turnSuccess() {

--- a/tslint.json
+++ b/tslint.json
@@ -10,6 +10,7 @@
         "object-literal-sort-keys": false,
         "only-arrow-functions": false,
         "quotemark": [true, "single", "avoid-escape"],
-        "indent": [true, "spaces"]
+        "indent": [true, "spaces"],
+        "whitespace": [true, "check-branch", "check-decl", "check-operator", "check-module", "check-separator", "check-type", "check-typecast", "check-preblock"]
     }
 }


### PR DESCRIPTION
Fixes #8 

I also added the ability to hide/show the preview text (like the Android App).

Todo: @dbrgn or someone at Threema should add a notification faq, because there are some pitfalls. I already added a link to https://threema.ch/de/faq/web_notifications in the settings dialog if the permission was rejected. Feel free to remove or change the url.

For example if the user permanently blocked notifications for Threema Web he must manually re-grant permission via browser settings or by clicking on the icon at the url-bar and must reload the page.
Some browsers, for example firefox, offer to mute notifications until restarting the browser. Problem: this can´t be detected. So the user may think "I checked the notification checkbox and granted permission" but no notification shows up.