### PR TITLE
Make scrollbars in Chrome a bit wider

### DIFF
--- a/src/sass/components/_scrollbars.scss
+++ b/src/sass/components/_scrollbars.scss
@@ -1,7 +1,7 @@
 // TODO: Prefixes
 
 ::-webkit-scrollbar {
-    width: 5px;
+    width: 8px;
     background-color: #fcfcfc;
     border: 1px solid #f9f9f9;
 }

--- a/src/sass/sections/_conversation.scss
+++ b/src/sass/sections/_conversation.scss
@@ -63,7 +63,7 @@
         align-self: flex-end;
         height: 0;
         position: relative;
-        right: 8px;
+        right: 16px;
         bottom: 8px + $scrolljump-height;
         z-index: 15;
         outline: none;


### PR DESCRIPTION
The scrollbars are so small that some people don't even see them. I think making them a bit wider is fine (even though thin looks nicer).

Before:

![before](https://cloud.githubusercontent.com/assets/105168/23666039/6f5b3370-035a-11e7-939a-ed9efdf8b5bf.png)

After:

![after](https://cloud.githubusercontent.com/assets/105168/23666042/72cb13ea-035a-11e7-95e8-ad4cdc2a721e.png)
