### PR TITLE
Clean up types

### DIFF
--- a/src/controller_model/avatar.ts
+++ b/src/controller_model/avatar.ts
@@ -1,3 +1,4 @@
+import {WebClientService} from "../services/webclient";
 /**
  * This file is part of Threema Web.
  *
@@ -22,7 +23,7 @@ export class AvatarControllerModel implements threema.AvatarControllerModel {
     public onChangeAvatar: (image: ArrayBuffer) => void;
 
     constructor($log: ng.ILogService,
-                webClientService: threema.WebClientService,
+                webClientService: WebClientService,
                 receiver: threema.Receiver) {
         this.$log = $log;
         this.loadAvatar = new Promise((resolve, reject) => {

--- a/src/controller_model/avatar.ts
+++ b/src/controller_model/avatar.ts
@@ -1,4 +1,3 @@
-import {WebClientService} from "../services/webclient";
 /**
  * This file is part of Threema Web.
  *
@@ -15,6 +14,8 @@ import {WebClientService} from "../services/webclient";
  * You should have received a copy of the GNU Affero General Public License
  * along with Threema Web. If not, see <http://www.gnu.org/licenses/>.
  */
+
+import {WebClientService} from '../services/webclient';
 
 export class AvatarControllerModel implements threema.AvatarControllerModel {
     private $log: ng.ILogService;

--- a/src/controller_model/avatar.ts
+++ b/src/controller_model/avatar.ts
@@ -17,7 +17,7 @@
 
 import {WebClientService} from '../services/webclient';
 
-export class AvatarControllerModel implements threema.AvatarControllerModel {
+export class AvatarControllerModel {
     private $log: ng.ILogService;
     private avatar: ArrayBuffer = null;
     private loadAvatar: Promise<string>;

--- a/src/controller_model/contact.ts
+++ b/src/controller_model/contact.ts
@@ -17,6 +17,7 @@
 
 import {ControllerModelMode} from '../types/enums';
 import {AvatarControllerModel} from './avatar';
+import {WebClientService} from "../services/webclient";
 
 export class ContactControllerModel implements threema.ControllerModel {
 
@@ -34,13 +35,13 @@ export class ContactControllerModel implements threema.ControllerModel {
     public isLoading = false;
 
     private contact: threema.ContactReceiver;
-    private webClientService: threema.WebClientService;
+    private webClientService: WebClientService;
     private firstNameLabel: string;
     private avatarController: threema.AvatarControllerModel;
     private mode = ControllerModelMode.NEW;
 
     constructor($log: ng.ILogService, $translate: ng.translate.ITranslateService, $mdDialog: ng.material.IDialogService,
-                webClientService: threema.WebClientService,
+                webClientService: WebClientService,
                 mode: ControllerModelMode,
                 contact: threema.ContactReceiver = undefined) {
         this.$log = $log;

--- a/src/controller_model/contact.ts
+++ b/src/controller_model/contact.ts
@@ -15,9 +15,9 @@
  * along with Threema Web. If not, see <http://www.gnu.org/licenses/>.
  */
 
+import {WebClientService} from '../services/webclient';
 import {ControllerModelMode} from '../types/enums';
 import {AvatarControllerModel} from './avatar';
-import {WebClientService} from "../services/webclient";
 
 export class ContactControllerModel implements threema.ControllerModel {
 

--- a/src/controller_model/contact.ts
+++ b/src/controller_model/contact.ts
@@ -37,7 +37,7 @@ export class ContactControllerModel implements threema.ControllerModel {
     private contact: threema.ContactReceiver;
     private webClientService: WebClientService;
     private firstNameLabel: string;
-    private avatarController: threema.AvatarControllerModel;
+    private avatarController: AvatarControllerModel;
     private mode = ControllerModelMode.NEW;
 
     constructor($log: ng.ILogService, $translate: ng.translate.ITranslateService, $mdDialog: ng.material.IDialogService,

--- a/src/controller_model/distributionList.ts
+++ b/src/controller_model/distributionList.ts
@@ -15,8 +15,8 @@
  * along with Threema Web. If not, see <http://www.gnu.org/licenses/>.
  */
 
+import {WebClientService} from '../services/webclient';
 import {ControllerModelMode} from '../types/enums';
-import {WebClientService} from "../services/webclient";
 
 export class DistributionListControllerModel implements threema.ControllerModel {
 

--- a/src/controller_model/distributionList.ts
+++ b/src/controller_model/distributionList.ts
@@ -16,6 +16,7 @@
  */
 
 import {ControllerModelMode} from '../types/enums';
+import {WebClientService} from "../services/webclient";
 
 export class DistributionListControllerModel implements threema.ControllerModel {
 
@@ -29,12 +30,12 @@ export class DistributionListControllerModel implements threema.ControllerModel 
 
     private addContactPlaceholder: string;
     private distributionList: threema.DistributionListReceiver;
-    private webClientService: threema.WebClientService;
+    private webClientService: WebClientService;
     private mode: ControllerModelMode;
     private onRemovedCallback: any;
 
     constructor($log: ng.ILogService, $translate: ng.translate.ITranslateService, $mdDialog: ng.material.IDialogService,
-                webClientService: threema.WebClientService,
+                webClientService: WebClientService,
                 mode: ControllerModelMode,
                 distributionList: threema.DistributionListReceiver = undefined) {
         this.$log = $log;

--- a/src/controller_model/group.ts
+++ b/src/controller_model/group.ts
@@ -17,6 +17,7 @@
 
 import {ControllerModelMode} from '../types/enums';
 import {AvatarControllerModel} from './avatar';
+import {WebClientService} from "../services/webclient";
 
 export class GroupControllerModel implements threema.ControllerModel {
 
@@ -30,13 +31,13 @@ export class GroupControllerModel implements threema.ControllerModel {
 
     private addContactPlaceholder: string;
     private group: threema.GroupReceiver;
-    private webClientService: threema.WebClientService;
+    private webClientService: WebClientService;
     private avatarController: threema.AvatarControllerModel;
     private mode: ControllerModelMode;
     private onRemovedCallback: any;
 
     constructor($log: ng.ILogService, $translate: ng.translate.ITranslateService, $mdDialog: ng.material.IDialogService,
-                webClientService: threema.WebClientService,
+                webClientService: WebClientService,
                 mode: ControllerModelMode,
                 group: threema.GroupReceiver = undefined) {
         this.$log = $log;

--- a/src/controller_model/group.ts
+++ b/src/controller_model/group.ts
@@ -15,9 +15,9 @@
  * along with Threema Web. If not, see <http://www.gnu.org/licenses/>.
  */
 
+import {WebClientService} from '../services/webclient';
 import {ControllerModelMode} from '../types/enums';
 import {AvatarControllerModel} from './avatar';
-import {WebClientService} from "../services/webclient";
 
 export class GroupControllerModel implements threema.ControllerModel {
 

--- a/src/controller_model/group.ts
+++ b/src/controller_model/group.ts
@@ -32,7 +32,7 @@ export class GroupControllerModel implements threema.ControllerModel {
     private addContactPlaceholder: string;
     private group: threema.GroupReceiver;
     private webClientService: WebClientService;
-    private avatarController: threema.AvatarControllerModel;
+    private avatarController: AvatarControllerModel;
     private mode: ControllerModelMode;
     private onRemovedCallback: any;
 

--- a/src/controllers/status.ts
+++ b/src/controllers/status.ts
@@ -15,6 +15,10 @@
  * along with Threema Web. If not, see <http://www.gnu.org/licenses/>.
  */
 
+import {StateService} from "../services/state";
+import {WebClientService} from "../services/webclient";
+import {ControllerService} from "../services/controller";
+
 /**
  * This controller handles state changes globally.
  *
@@ -41,15 +45,15 @@ export class StatusController {
     private $log: ng.ILogService;
 
     // Custom services
-    private stateService: threema.StateService;
-    private webClientService: threema.WebClientService;
-    private controllerService: threema.ControllerService;
+    private stateService: StateService;
+    private webClientService: WebClientService;
+    private controllerService: ControllerService;
 
     public static $inject = ['$scope', '$timeout', '$log', '$state', 'StateService',
         'WebClientService', 'ControllerService'];
     constructor($scope, $timeout: ng.ITimeoutService, $log: ng.ILogService, $state: ng.ui.IStateService,
-                stateService: threema.StateService, webClientService: threema.WebClientService,
-                controllerService: threema.ControllerService) {
+                stateService: StateService, webClientService: WebClientService,
+                controllerService: ControllerService) {
 
         // Angular services
         this.$timeout = $timeout;

--- a/src/controllers/status.ts
+++ b/src/controllers/status.ts
@@ -15,9 +15,9 @@
  * along with Threema Web. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import {StateService} from "../services/state";
-import {WebClientService} from "../services/webclient";
-import {ControllerService} from "../services/controller";
+import {ControllerService} from '../services/controller';
+import {StateService} from '../services/state';
+import {WebClientService} from '../services/webclient';
 
 /**
  * This controller handles state changes globally.

--- a/src/directives/avatar.ts
+++ b/src/directives/avatar.ts
@@ -15,7 +15,7 @@
  * along with Threema Web. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import {WebClientService} from "../services/webclient";
+import {WebClientService} from '../services/webclient';
 
 export default [
     '$rootScope',

--- a/src/directives/avatar.ts
+++ b/src/directives/avatar.ts
@@ -15,13 +15,15 @@
  * along with Threema Web. If not, see <http://www.gnu.org/licenses/>.
  */
 
+import {WebClientService} from "../services/webclient";
+
 export default [
     '$rootScope',
     '$timeout',
     'WebClientService',
     function($rootScope: ng.IRootScopeService,
              $timeout: ng.ITimeoutService,
-             webClientService: threema.WebClientService) {
+             webClientService: WebClientService) {
         return {
             restrict: 'E',
             scope: {},

--- a/src/directives/compose_area.ts
+++ b/src/directives/compose_area.ts
@@ -15,8 +15,8 @@
  * along with Threema Web. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import {BrowserService} from "../services/browser";
-import {StringService} from "../services/string";
+import {BrowserService} from '../services/browser';
+import {StringService} from '../services/string';
 
 /**
  * The compose area where messages are written.

--- a/src/directives/compose_area.ts
+++ b/src/directives/compose_area.ts
@@ -15,6 +15,9 @@
  * along with Threema Web. If not, see <http://www.gnu.org/licenses/>.
  */
 
+import {BrowserService} from "../services/browser";
+import {StringService} from "../services/string";
+
 /**
  * The compose area where messages are written.
  */
@@ -27,8 +30,8 @@ export default [
     '$mdDialog',
     '$filter',
     '$log',
-    function(browserService: threema.BrowserService,
-             stringService: threema.StringService,
+    function(browserService: BrowserService,
+             stringService: StringService,
              $window, $timeout: ng.ITimeoutService,
              $translate: ng.translate.ITranslateService,
              $mdDialog: ng.material.IDialogService,

--- a/src/directives/contact_badge.ts
+++ b/src/directives/contact_badge.ts
@@ -17,13 +17,15 @@
 
 // tslint:disable:max-line-length
 
+import {WebClientService} from "../services/webclient";
+
 /**
  * Show a contact receiver with small avatar, name and verification level
  */
 export default [
     'WebClientService',
     '$state',
-    function(webClientService: threema.WebClientService, $state: ng.ui.IStateService) {
+    function(webClientService: WebClientService, $state: ng.ui.IStateService) {
         return {
             restrict: 'EA',
             scope: {},

--- a/src/directives/contact_badge.ts
+++ b/src/directives/contact_badge.ts
@@ -17,7 +17,7 @@
 
 // tslint:disable:max-line-length
 
-import {WebClientService} from "../services/webclient";
+import {WebClientService} from '../services/webclient';
 
 /**
  * Show a contact receiver with small avatar, name and verification level

--- a/src/directives/latest_message.ts
+++ b/src/directives/latest_message.ts
@@ -15,8 +15,8 @@
  * along with Threema Web. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import {WebClientService} from "../services/webclient";
-import {ReceiverService} from "../services/receiver";
+import {ReceiverService} from '../services/receiver';
+import {WebClientService} from '../services/webclient';
 
 export default [
     'WebClientService', 'ReceiverService',

--- a/src/directives/latest_message.ts
+++ b/src/directives/latest_message.ts
@@ -15,9 +15,12 @@
  * along with Threema Web. If not, see <http://www.gnu.org/licenses/>.
  */
 
+import {WebClientService} from "../services/webclient";
+import {ReceiverService} from "../services/receiver";
+
 export default [
     'WebClientService', 'ReceiverService',
-    function(webClientService: threema.WebClientService, receiverService: threema.ReceiverService) {
+    function(webClientService: WebClientService, receiverService: ReceiverService) {
         return {
             restrict: 'EA',
             scope: {},

--- a/src/directives/member_list_editor.ts
+++ b/src/directives/member_list_editor.ts
@@ -15,7 +15,7 @@
  * along with Threema Web. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import {WebClientService} from "../services/webclient";
+import {WebClientService} from '../services/webclient';
 
 export default [
     'WebClientService',

--- a/src/directives/member_list_editor.ts
+++ b/src/directives/member_list_editor.ts
@@ -15,9 +15,11 @@
  * along with Threema Web. If not, see <http://www.gnu.org/licenses/>.
  */
 
+import {WebClientService} from "../services/webclient";
+
 export default [
     'WebClientService',
-    function(webClientService: threema.WebClientService) {
+    function(webClientService: WebClientService) {
         return {
             restrict: 'EA',
             scope: {},

--- a/src/directives/message.ts
+++ b/src/directives/message.ts
@@ -15,9 +15,9 @@
  * along with Threema Web. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import {WebClientService} from "../services/webclient";
-import {ReceiverService} from "../services/receiver";
-import {MessageService} from "../services/message";
+import {MessageService} from '../services/message';
+import {ReceiverService} from '../services/receiver';
+import {WebClientService} from '../services/webclient';
 
 export default [
     'WebClientService',

--- a/src/directives/message.ts
+++ b/src/directives/message.ts
@@ -15,6 +15,10 @@
  * along with Threema Web. If not, see <http://www.gnu.org/licenses/>.
  */
 
+import {WebClientService} from "../services/webclient";
+import {ReceiverService} from "../services/receiver";
+import {MessageService} from "../services/message";
+
 export default [
     'WebClientService',
     'MessageService',
@@ -23,8 +27,8 @@ export default [
     '$translate',
     '$rootScope',
     '$log',
-    function(webClientService: threema.WebClientService, messageService: threema.MessageService,
-             receiverService: threema.ReceiverService,
+    function(webClientService: WebClientService, messageService: MessageService,
+             receiverService: ReceiverService,
              $mdDialog: ng.material.IDialogService, $translate: ng.translate.ITranslateService,
              $rootScope: ng.IRootScopeService, $log: ng.ILogService) {
 

--- a/src/directives/message_media.ts
+++ b/src/directives/message_media.ts
@@ -15,8 +15,8 @@
  * along with Threema Web. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import {WebClientService} from "../services/webclient";
-import {MessageService} from "../services/message";
+import {MessageService} from '../services/message';
+import {WebClientService} from '../services/webclient';
 
 export default [
     'WebClientService',

--- a/src/directives/message_media.ts
+++ b/src/directives/message_media.ts
@@ -15,6 +15,9 @@
  * along with Threema Web. If not, see <http://www.gnu.org/licenses/>.
  */
 
+import {WebClientService} from "../services/webclient";
+import {MessageService} from "../services/message";
+
 export default [
     'WebClientService',
     'MessageService',
@@ -23,7 +26,7 @@ export default [
     '$timeout',
     '$log',
     '$filter',
-    function(webClientService: threema.WebClientService, messageService: threema.MessageService,
+    function(webClientService: WebClientService, messageService: MessageService,
              $rootScope: ng.IRootScopeService,
              $mdDialog: ng.material.IDialogService,
              $timeout: ng.ITimeoutService, $log: ng.ILogService,

--- a/src/directives/message_quote.ts
+++ b/src/directives/message_quote.ts
@@ -15,7 +15,7 @@
  * along with Threema Web. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import {WebClientService} from "../services/webclient";
+import {WebClientService} from '../services/webclient';
 
 // tslint:disable:max-line-length
 

--- a/src/directives/message_quote.ts
+++ b/src/directives/message_quote.ts
@@ -15,11 +15,13 @@
  * along with Threema Web. If not, see <http://www.gnu.org/licenses/>.
  */
 
+import {WebClientService} from "../services/webclient";
+
 // tslint:disable:max-line-length
 
 export default [
     'WebClientService',
-    function(webClientService: threema.WebClientService) {
+    function(webClientService: WebClientService) {
         return {
             restrict: 'EA',
             scope: {},

--- a/src/directives/status_bar.ts
+++ b/src/directives/status_bar.ts
@@ -15,6 +15,9 @@
  * along with Threema Web. If not, see <http://www.gnu.org/licenses/>.
  */
 
+import {StateService} from "../services/state";
+import {TrustedKeyStoreService} from "../services/keystore";
+
 // tslint:disable:max-line-length
 
 export default [
@@ -22,8 +25,8 @@ export default [
     'TrustedKeyStore',
     'StateService',
     function($window: ng.IWindowService,
-             trustedKeyStore: threema.TrustedKeyStoreService,
-             stateService: threema.StateService) {
+             trustedKeyStore: TrustedKeyStoreService,
+             stateService: StateService) {
         return {
             restrict: 'E',
             scope: {},

--- a/src/directives/status_bar.ts
+++ b/src/directives/status_bar.ts
@@ -15,8 +15,8 @@
  * along with Threema Web. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import {StateService} from "../services/state";
-import {TrustedKeyStoreService} from "../services/keystore";
+import {TrustedKeyStoreService} from '../services/keystore';
+import {StateService} from '../services/state';
 
 // tslint:disable:max-line-length
 

--- a/src/filters.ts
+++ b/src/filters.ts
@@ -16,8 +16,8 @@
  */
 
 import {filter} from './helpers';
-import {WebClientService} from "./services/webclient";
-import {MimeService} from "./services/mime";
+import {MimeService} from './services/mime';
+import {WebClientService} from './services/webclient';
 
 angular.module('3ema.filters', [])
 

--- a/src/filters.ts
+++ b/src/filters.ts
@@ -16,6 +16,8 @@
  */
 
 import {filter} from './helpers';
+import {WebClientService} from "./services/webclient";
+import {MimeService} from "./services/mime";
 
 angular.module('3ema.filters', [])
 
@@ -141,7 +143,7 @@ angular.module('3ema.filters', [])
 /**
  * Return whether contact is not me.
  */
-.filter('isNotMe', ['WebClientService', function(webClientService: threema.WebClientService) {
+.filter('isNotMe', ['WebClientService', function(webClientService: WebClientService) {
     return function(obj: threema.Receiver) {
         const valid = (contact: threema.Receiver) => contact.id !== webClientService.receivers.me.id;
         return filter(obj, valid);
@@ -234,7 +236,7 @@ angular.module('3ema.filters', [])
         return (x + ' ' + ['B', 'kB', 'MB', 'GB', 'TB'][i]);
     };
 })
-.filter('mimeType', ['MimeService', function(mimeService: threema.MimeService) {
+.filter('mimeType', ['MimeService', function(mimeService: MimeService) {
     return (mimeType: string, asText: boolean = true) => {
         if (asText) {
             return mimeService.getLabel(mimeType);
@@ -247,7 +249,7 @@ angular.module('3ema.filters', [])
 /**
  * Convert ID-Array to (Display-)Name-String, separated by ','
  */
-.filter('idsToNames', ['WebClientService', function (webClientService: threema.WebClientService) {
+.filter('idsToNames', ['WebClientService', function (webClientService: WebClientService) {
     return(ids: string[]) => {
         let names: string[] = [];
         for (let id of ids) {

--- a/src/partials/messenger.ts
+++ b/src/partials/messenger.ts
@@ -17,19 +17,19 @@
 
 import {ContactControllerModel} from '../controller_model/contact';
 import {supportsPassive, throttle} from '../helpers';
+import {ContactService} from '../services/contact';
+import {ControllerService} from '../services/controller';
+import {ControllerModelService} from '../services/controller_model';
 import {ExecuteService} from '../services/execute';
+import {FingerPrintService} from '../services/fingerprint';
+import {TrustedKeyStoreService} from '../services/keystore';
+import {MimeService} from '../services/mime';
+import {NotificationService} from '../services/notification';
+import {ReceiverService} from '../services/receiver';
+import {SettingsService} from '../services/settings';
 import {StateService} from '../services/state';
+import {WebClientService} from '../services/webclient';
 import {ControllerModelMode} from '../types/enums';
-import {SettingsService} from "../services/settings";
-import {WebClientService} from "../services/webclient";
-import {ReceiverService} from "../services/receiver";
-import {TrustedKeyStoreService} from "../services/keystore";
-import {ControllerService} from "../services/controller";
-import {FingerPrintService} from "../services/fingerprint";
-import {ContactService} from "../services/contact";
-import {ControllerModelService} from "../services/controller_model";
-import {MimeService} from "../services/mime";
-import {NotificationService} from "../services/notification";
 
 abstract class DialogController {
     public static $inject = ['$mdDialog'];
@@ -100,7 +100,7 @@ class SettingsController {
     public $mdDialog: ng.material.IDialogService;
     public $window: ng.IWindowService;
     public settingsService: SettingsService;
-    private notificationService: NotificationService
+    private notificationService: NotificationService;
     public activeElement: HTMLElement | null;
 
     private desktopNotifications: boolean;

--- a/src/partials/messenger.ts
+++ b/src/partials/messenger.ts
@@ -18,7 +18,18 @@
 import {ContactControllerModel} from '../controller_model/contact';
 import {supportsPassive, throttle} from '../helpers';
 import {ExecuteService} from '../services/execute';
+import {StateService} from '../services/state';
 import {ControllerModelMode} from '../types/enums';
+import {SettingsService} from "../services/settings";
+import {WebClientService} from "../services/webclient";
+import {ReceiverService} from "../services/receiver";
+import {TrustedKeyStoreService} from "../services/keystore";
+import {ControllerService} from "../services/controller";
+import {FingerPrintService} from "../services/fingerprint";
+import {ContactService} from "../services/contact";
+import {ControllerModelService} from "../services/controller_model";
+import {MimeService} from "../services/mime";
+import {NotificationService} from "../services/notification";
 
 abstract class DialogController {
     public static $inject = ['$mdDialog'];
@@ -88,8 +99,8 @@ class SettingsController {
 
     public $mdDialog: ng.material.IDialogService;
     public $window: ng.IWindowService;
-    public settingsService: threema.SettingsService;
-    private notificationService: threema.NotificationService;
+    public settingsService: SettingsService;
+    private notificationService: NotificationService
     public activeElement: HTMLElement | null;
 
     private desktopNotifications: boolean;
@@ -99,8 +110,8 @@ class SettingsController {
 
     constructor($mdDialog: ng.material.IDialogService,
                 $window: ng.IWindowService,
-                settingsService: threema.SettingsService,
-                notificationService: threema.NotificationService) {
+                settingsService: SettingsService,
+                notificationService: NotificationService) {
         this.$mdDialog = $mdDialog;
         this.$window = $window;
         this.settingsService = settingsService;
@@ -150,10 +161,10 @@ class ConversationController {
     private $scope: ng.IScope;
 
     // Own services
-    private webClientService: threema.WebClientService;
-    private receiverService: threema.ReceiverService;
-    private stateService: threema.StateService;
-    private mimeService: threema.MimeService;
+    private webClientService: WebClientService;
+    private receiverService: ReceiverService;
+    private stateService: StateService;
+    private mimeService: MimeService;
 
     // Third party services
     private $mdDialog: ng.material.IDialogService;
@@ -201,10 +212,10 @@ class ConversationController {
                 $mdToast: ng.material.IToastService,
                 $location,
                 $translate: ng.translate.ITranslateService,
-                webClientService: threema.WebClientService,
-                stateService: threema.StateService,
-                receiverService: threema.ReceiverService,
-                mimeService: threema.MimeService) {
+                webClientService: WebClientService,
+                stateService: StateService,
+                receiverService: ReceiverService,
+                mimeService: MimeService) {
         this.$stateParams = $stateParams;
         this.$timeout = $timeout;
         this.$log = $log;
@@ -577,10 +588,10 @@ class NavigationController {
 
     public name = 'navigation';
 
-    private webClientService: threema.WebClientService;
-    private receiverService: threema.ReceiverService;
-    private stateService: threema.StateService;
-    private trustedKeyStoreService: threema.TrustedKeyStoreService;
+    private webClientService: WebClientService;
+    private receiverService: ReceiverService;
+    private stateService: StateService;
+    private trustedKeyStoreService: TrustedKeyStoreService;
 
     private activeTab: 'contacts' | 'conversations' = 'conversations';
     private searchVisible = false;
@@ -597,9 +608,9 @@ class NavigationController {
 
     constructor($log: ng.ILogService, $state: ng.ui.IStateService,
                 $mdDialog: ng.material.IDialogService, $translate: ng.translate.ITranslateService,
-                webClientService: threema.WebClientService, stateService: threema.StateService,
-                receiverService: threema.ReceiverService,
-                trustedKeyStoreService: threema.TrustedKeyStoreService) {
+                webClientService: WebClientService, stateService: StateService,
+                receiverService: ReceiverService,
+                trustedKeyStoreService: TrustedKeyStoreService) {
 
         // Redirect to welcome if necessary
         if (stateService.state === 'error') {
@@ -783,9 +794,9 @@ class NavigationController {
 
 class MessengerController {
     public name = 'messenger';
-    private receiverService: threema.ReceiverService;
+    private receiverService: ReceiverService;
     private $state;
-    private webClientService: threema.WebClientService;
+    private webClientService: WebClientService;
 
     public static $inject = [
         '$scope', '$state', '$log', '$mdDialog', '$translate',
@@ -793,8 +804,8 @@ class MessengerController {
     ];
     constructor($scope, $state, $log: ng.ILogService, $mdDialog: ng.material.IDialogService,
                 $translate: ng.translate.ITranslateService,
-                stateService: threema.StateService, receiverService: threema.ReceiverService,
-                webClientService: threema.WebClientService, controllerService: threema.ControllerService) {
+                stateService: StateService, receiverService: ReceiverService,
+                webClientService: WebClientService, controllerService: ControllerService) {
         // Redirect to welcome if necessary
         if (stateService.state === 'error') {
             $log.debug('MessengerController: WebClient not yet running, redirecting to welcome screen');
@@ -859,8 +870,8 @@ class ReceiverDetailController {
     public receiver: threema.Receiver;
     public title: string;
     public fingerPrint?: string;
-    private fingerPrintService: threema.FingerPrintService;
-    private contactService: threema.ContactService;
+    private fingerPrintService: FingerPrintService;
+    private contactService: ContactService;
     private showGroups = false;
     private showDistributionLists = false;
     private inGroups: threema.GroupReceiver[] = [];
@@ -875,8 +886,8 @@ class ReceiverDetailController {
         'WebClientService', 'FingerPrintService', 'ContactService', 'ControllerModelService',
     ];
     constructor($log: ng.ILogService, $stateParams, $state: ng.ui.IStateService, $mdDialog: ng.material.IDialogService,
-                webClientService: threema.WebClientService, fingerPrintService: threema.FingerPrintService,
-                contactService: threema.ContactService, controllerModelService: threema.ControllerModelService) {
+                webClientService: WebClientService, fingerPrintService: FingerPrintService,
+                contactService: ContactService, controllerModelService: ControllerModelService) {
 
         this.$mdDialog = $mdDialog;
         this.$state = $state;
@@ -983,7 +994,7 @@ class ReceiverEditController {
     ];
     constructor($log: ng.ILogService, $stateParams, $state: ng.ui.IStateService,
                 $mdDialog, $timeout: ng.ITimeoutService, $translate: ng.translate.ITranslateService,
-                webClientService: threema.WebClientService, controllerModelService: threema.ControllerModelService) {
+                webClientService: WebClientService, controllerModelService: ControllerModelService) {
 
         this.$mdDialog = $mdDialog;
         this.$state = $state;
@@ -1073,7 +1084,7 @@ class ReceiverCreateController {
 
     constructor($stateParams: threema.CreateReceiverStateParams, $mdDialog, $mdToast, $translate,
                 $timeout: ng.ITimeoutService, $state: ng.ui.IStateService, $log: ng.ILogService,
-                controllerModelService: threema.ControllerModelService) {
+                controllerModelService: ControllerModelService) {
         this.$mdDialog = $mdDialog;
         this.$timeout = $timeout;
         this.$state = $state;

--- a/src/partials/welcome.ts
+++ b/src/partials/welcome.ts
@@ -15,13 +15,12 @@
  * along with Threema Web. If not, see <http://www.gnu.org/licenses/>.
  */
 
+import {BrowserService} from '../services/browser';
+import {ControllerService} from '../services/controller';
 import {TrustedKeyStoreService} from '../services/keystore';
-import {StateService} from "../services/state";
-import {WebClientService} from "../services/webclient";
-import {PushService} from "../services/push";
-import {BrowserService} from "../services/browser";
-import BrowserMinVersions = threema.BrowserMinVersions;
-import {ControllerService} from "../services/controller";
+import {PushService} from '../services/push';
+import {StateService} from '../services/state';
+import {WebClientService} from '../services/webclient';
 
 class DialogController {
     // TODO: This is also used in partials/messenger.ts. We could somehow
@@ -79,7 +78,7 @@ class WelcomeController {
                 webClientService: WebClientService, TrustedKeyStore: TrustedKeyStoreService,
                 stateService: StateService, pushService: PushService,
                 browserService: BrowserService,
-                minVersions: BrowserMinVersions,
+                minVersions: threema.BrowserMinVersions,
                 controllerService: ControllerService) {
         controllerService.setControllerName('welcome');
         // Angular services

--- a/src/partials/welcome.ts
+++ b/src/partials/welcome.ts
@@ -15,8 +15,13 @@
  * along with Threema Web. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import {AvatarControllerModel} from '../controller_model/avatar';
 import {TrustedKeyStoreService} from '../services/keystore';
+import {StateService} from "../services/state";
+import {WebClientService} from "../services/webclient";
+import {PushService} from "../services/push";
+import {BrowserService} from "../services/browser";
+import BrowserMinVersions = threema.BrowserMinVersions;
+import {ControllerService} from "../services/controller";
 
 class DialogController {
     // TODO: This is also used in partials/messenger.ts. We could somehow
@@ -51,10 +56,10 @@ class WelcomeController {
     private $translate: ng.translate.ITranslateService;
 
     // Custom services
-    private webClientService: threema.WebClientService;
+    private webClientService: WebClientService;
     private TrustedKeyStore: TrustedKeyStoreService;
-    private pushService: threema.PushService;
-    private stateService: threema.StateService;
+    private pushService: PushService;
+    private stateService: StateService;
 
     // Other
     public name = 'welcome';
@@ -71,11 +76,11 @@ class WelcomeController {
                 $timeout: ng.ITimeoutService, $interval: ng.IIntervalService,
                 $log: ng.ILogService, $window: ng.IWindowService, $mdDialog: ng.material.IDialogService,
                 $translate: ng.translate.ITranslateService,
-                webClientService: threema.WebClientService, TrustedKeyStore: TrustedKeyStoreService,
-                stateService: threema.StateService, pushService: threema.PushService,
-                browserService: threema.BrowserService,
-                minVersions: threema.BrowserMinVersions,
-                controllerService: threema.ControllerService) {
+                webClientService: WebClientService, TrustedKeyStore: TrustedKeyStoreService,
+                stateService: StateService, pushService: PushService,
+                browserService: BrowserService,
+                minVersions: BrowserMinVersions,
+                controllerService: ControllerService) {
         controllerService.setControllerName('welcome');
         // Angular services
         this.$scope = $scope;

--- a/src/services/browser.ts
+++ b/src/services/browser.ts
@@ -15,7 +15,7 @@
  * along with Threema Web. If not, see <http://www.gnu.org/licenses/>.
  */
 
-export class BrowserService implements threema.BrowserService {
+export class BrowserService {
     private browser: threema.BrowserInfo;
     private $log: ng.ILogService;
     private isPageVisible = true;

--- a/src/services/contact.ts
+++ b/src/services/contact.ts
@@ -1,4 +1,3 @@
-import {WebClientService} from "./webclient";
 /**
  * This file is part of Threema Web.
  *
@@ -15,6 +14,8 @@ import {WebClientService} from "./webclient";
  * You should have received a copy of the GNU Affero General Public License
  * along with Threema Web. If not, see <http://www.gnu.org/licenses/>.
  */
+
+import {WebClientService} from './webclient';
 
 export class ContactService {
     private webClientService: WebClientService;

--- a/src/services/contact.ts
+++ b/src/services/contact.ts
@@ -1,3 +1,4 @@
+import {WebClientService} from "./webclient";
 /**
  * This file is part of Threema Web.
  *
@@ -15,11 +16,11 @@
  * along with Threema Web. If not, see <http://www.gnu.org/licenses/>.
  */
 
-export class ContactService implements threema.ContactService {
-    private webClientService: threema.WebClientService;
+export class ContactService {
+    private webClientService: WebClientService;
 
     public static $inject = ['WebClientService'];
-    constructor(webClientService: threema.WebClientService) {
+    constructor(webClientService: WebClientService) {
         this.webClientService = webClientService;
     }
 

--- a/src/services/controller.ts
+++ b/src/services/controller.ts
@@ -18,7 +18,7 @@
 /**
  * controller states
  */
-export class ControllerService implements threema.ControllerService {
+export class ControllerService {
     private currentController: string;
     private $log: ng.ILogService;
     public static $inject = ['$log'];

--- a/src/services/controller_model.ts
+++ b/src/services/controller_model.ts
@@ -19,19 +19,20 @@ import {ContactControllerModel} from '../controller_model/contact';
 import {DistributionListControllerModel} from '../controller_model/distributionList';
 import {GroupControllerModel} from '../controller_model/group';
 import {ControllerModelMode} from '../types/enums';
+import {WebClientService} from "./webclient";
 
 /**
  * Factory to create ControllerModels
  */
-export class ControllerModelService implements threema.ControllerModelService {
+export class ControllerModelService {
     private $log: ng.ILogService;
     private $translate: ng.translate.ITranslateService;
     private $mdDialog: ng.material.IDialogService;
-    private webClientService: threema.WebClientService;
+    private webClientService: WebClientService;
 
     public static $inject = ['$log', '$translate', '$mdDialog', 'WebClientService'];
     constructor($log: ng.ILogService, $translate: ng.translate.ITranslateService,
-                $mdDialog: ng.material.IDialogService, webClientService: threema.WebClientService) {
+                $mdDialog: ng.material.IDialogService, webClientService: WebClientService) {
         this.$log = $log;
         this.$translate = $translate;
         this.$mdDialog = $mdDialog;

--- a/src/services/controller_model.ts
+++ b/src/services/controller_model.ts
@@ -19,7 +19,7 @@ import {ContactControllerModel} from '../controller_model/contact';
 import {DistributionListControllerModel} from '../controller_model/distributionList';
 import {GroupControllerModel} from '../controller_model/group';
 import {ControllerModelMode} from '../types/enums';
-import {WebClientService} from "./webclient";
+import {WebClientService} from './webclient';
 
 /**
  * Factory to create ControllerModels

--- a/src/services/fingerprint.ts
+++ b/src/services/fingerprint.ts
@@ -15,7 +15,7 @@
  * along with Threema Web. If not, see <http://www.gnu.org/licenses/>.
  */
 
-export class FingerPrintService implements threema.FingerPrintService {
+export class FingerPrintService {
     private $log: ng.ILogService;
 
     public static $inject = ['$log'];

--- a/src/services/keystore.ts
+++ b/src/services/keystore.ts
@@ -37,7 +37,7 @@ import {stringToUtf8a, utf8aToString} from '../helpers';
  *     "<nonceHexString>:<encryptedHexString>"
  *
  */
-export class TrustedKeyStoreService implements threema.TrustedKeyStoreService {
+export class TrustedKeyStoreService {
     private static STORAGE_KEY = 'trusted';
 
     private logTag: string = '[TrustedKeyStoreService]';

--- a/src/services/message.ts
+++ b/src/services/message.ts
@@ -15,7 +15,7 @@
  * along with Threema Web. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import {ReceiverService} from "./receiver";
+import {ReceiverService} from './receiver';
 
 class MessageAccess implements threema.MessageAccess {
     public quote = false;

--- a/src/services/message.ts
+++ b/src/services/message.ts
@@ -15,6 +15,8 @@
  * along with Threema Web. If not, see <http://www.gnu.org/licenses/>.
  */
 
+import {ReceiverService} from "./receiver";
+
 class MessageAccess implements threema.MessageAccess {
     public quote = false;
     public ack = false;
@@ -24,13 +26,13 @@ class MessageAccess implements threema.MessageAccess {
     public copy = false;
 }
 
-export class MessageService implements threema.MessageService {
+export class MessageService {
 
     private $log: ng.ILogService;
-    private receiverService: threema.ReceiverService;
+    private receiverService: ReceiverService;
 
     public static $inject = ['$log', 'ReceiverService'];
-    constructor($log: ng.ILogService, receiverService: threema.ReceiverService) {
+    constructor($log: ng.ILogService, receiverService: ReceiverService) {
         this.$log = $log;
         this.receiverService = receiverService;
     }

--- a/src/services/message.ts
+++ b/src/services/message.ts
@@ -17,7 +17,7 @@
 
 import {ReceiverService} from './receiver';
 
-class MessageAccess implements threema.MessageAccess {
+export class MessageAccess {
     public quote = false;
     public ack = false;
     public dec = false;

--- a/src/services/mime.ts
+++ b/src/services/mime.ts
@@ -15,7 +15,7 @@
  * along with Threema Web. If not, see <http://www.gnu.org/licenses/>.
  */
 
-export class MimeService implements threema.MimeService {
+export class MimeService {
     public static $inject = ['$log', '$translate'];
 
     private $log: ng.ILogService;

--- a/src/services/notification.ts
+++ b/src/services/notification.ts
@@ -15,9 +15,11 @@
  * along with Threema Web. If not, see <http://www.gnu.org/licenses/>.
  */
 
+import {SettingsService} from './settings';
+
 import Receiver = threema.Receiver;
-import SettingsService = threema.SettingsService;
-export class NotificationService implements threema.NotificationService {
+
+export class NotificationService {
 
     private static SETTINGS_NOTIFICATIONS = 'notifications';
     private static SETTINGS_NOTIFICATION_PREVIEW = 'notificationPreview';

--- a/src/services/notification.ts
+++ b/src/services/notification.ts
@@ -17,8 +17,6 @@
 
 import {SettingsService} from './settings';
 
-import Receiver = threema.Receiver;
-
 export class NotificationService {
 
     private static SETTINGS_NOTIFICATIONS = 'notifications';

--- a/src/services/push.ts
+++ b/src/services/push.ts
@@ -15,7 +15,7 @@
  * along with Threema Web. If not, see <http://www.gnu.org/licenses/>.
  */
 
-export class PushService implements threema.PushService {
+export class PushService {
     private static ARG_TOKEN = 'token';
     private static ARG_SESSION = 'session';
     private static ARG_VERSION = 'version';

--- a/src/services/qrcode.ts
+++ b/src/services/qrcode.ts
@@ -20,7 +20,7 @@ import {stringToUtf8a} from '../helpers';
 /**
  * Functionality related to the initial QR code.
  */
-export class QrCodeService implements threema.QrCodeService {
+export class QrCodeService {
 
     private config: threema.Config;
     private protocolVersion: number;

--- a/src/services/receiver.ts
+++ b/src/services/receiver.ts
@@ -15,7 +15,7 @@
  * along with Threema Web. If not, see <http://www.gnu.org/licenses/>.
  */
 
-export class ReceiverService implements threema.ReceiverService {
+export class ReceiverService {
     private $log: ng.ILogService;
     private activeReceiver: threema.Receiver;
     public static $inject = ['$log'];

--- a/src/services/settings.ts
+++ b/src/services/settings.ts
@@ -19,7 +19,7 @@
  * The settings service can update variables for settings and persist them to
  * LocalStorage.
  */
-export class SettingsService implements threema.SettingsService {
+export class SettingsService {
     private $log: ng.ILogService;
 
     private static STORAGE_KEY_PREFIX = 'settings-';

--- a/src/services/state.ts
+++ b/src/services/state.ts
@@ -15,7 +15,7 @@
  * along with Threema Web. If not, see <http://www.gnu.org/licenses/>.
  */
 
-export class StateService implements threema.StateService {
+export class StateService {
 
     // Angular services
     private $log: ng.ILogService;

--- a/src/services/string.ts
+++ b/src/services/string.ts
@@ -15,7 +15,7 @@
  * along with Threema Web. If not, see <http://www.gnu.org/licenses/>.
  */
 
-export class StringService implements threema.StringService {
+export class StringService {
     public byteChunk(str: string, byteLength: number, offset: number = null): string[] {
         let chars = [...str];
         let chunks = [''];

--- a/src/services/title.ts
+++ b/src/services/title.ts
@@ -18,7 +18,7 @@
 /**
  * The title service can update the window title.
  */
-export class TitleService implements threema.TitleService {
+export class TitleService {
 
     private $log: ng.ILogService;
     private $document: ng.IDocumentService;

--- a/src/services/webclient.ts
+++ b/src/services/webclient.ts
@@ -17,18 +17,18 @@
 
 import * as msgpack from 'msgpack-lite';
 import {hexToU8a} from '../helpers';
+import {BrowserService} from './browser';
+import {FingerPrintService} from './fingerprint';
 import {TrustedKeyStoreService} from './keystore';
-import {StateService} from "./state";
+import {MessageService} from './message';
+import {MimeService} from './mime';
+import {NotificationService} from './notification';
 import {PeerConnectionHelper} from './peerconnection';
-import {NotificationService} from "./notification";
-import {MessageService} from "./message";
-import {PushService} from "./push";
-import {BrowserService} from "./browser";
-import {TitleService} from "./title";
-import {FingerPrintService} from "./fingerprint";
-import {QrCodeService} from "./qrcode";
-import {MimeService} from "./mime";
-import {ReceiverService} from "./receiver";
+import {PushService} from './push';
+import {QrCodeService} from './qrcode';
+import {ReceiverService} from './receiver';
+import {StateService} from './state';
+import {TitleService} from './title';
 
 class WebClientDefault implements threema.WebClientDefault {
     private avatar: threema.AvatarRegistry = {

--- a/src/services/webclient.ts
+++ b/src/services/webclient.ts
@@ -18,7 +18,17 @@
 import * as msgpack from 'msgpack-lite';
 import {hexToU8a} from '../helpers';
 import {TrustedKeyStoreService} from './keystore';
+import {StateService} from "./state";
 import {PeerConnectionHelper} from './peerconnection';
+import {NotificationService} from "./notification";
+import {MessageService} from "./message";
+import {PushService} from "./push";
+import {BrowserService} from "./browser";
+import {TitleService} from "./title";
+import {FingerPrintService} from "./fingerprint";
+import {QrCodeService} from "./qrcode";
+import {MimeService} from "./mime";
+import {ReceiverService} from "./receiver";
 
 class WebClientDefault implements threema.WebClientDefault {
     private avatar: threema.AvatarRegistry = {
@@ -53,7 +63,7 @@ class WebClientDefault implements threema.WebClientDefault {
 /**
  * This service handles everything related to the communication with the peer.
  */
-export class WebClientService implements threema.WebClientService {
+export class WebClientService {
     private static AVATAR_LOW_MAX_SIZE = 48;
     private static MAX_TEXT_LENGTH = 3500;
     private static MAX_FILE_SIZE = 15 * 1024 * 1024;
@@ -124,15 +134,15 @@ export class WebClientService implements threema.WebClientService {
     private $timeout: ng.ITimeoutService;
 
     // Custom services
-    private notificationService: threema.NotificationService;
-    private messageService: threema.MessageService;
-    private pushService: threema.PushService;
-    private browserService: threema.BrowserService;
-    private titleService: threema.TitleService;
-    private fingerPrintService: threema.FingerPrintService;
-    private qrCodeService: threema.QrCodeService;
-    private mimeService: threema.MimeService;
-    private receiverService: threema.ReceiverService;
+    private notificationService: NotificationService;
+    private messageService: MessageService;
+    private pushService: PushService;
+    private browserService: BrowserService;
+    private titleService: TitleService;
+    private fingerPrintService: FingerPrintService;
+    private qrCodeService: QrCodeService;
+    private mimeService: MimeService;
+    private receiverService: ReceiverService;
 
     // State handling
     private startupPromise: ng.IDeferred<{}>; // TODO: deferred type
@@ -140,7 +150,7 @@ export class WebClientService implements threema.WebClientService {
     private pendingInitializationStepRoutines: threema.InitializationStepRoutine[] = [];
     private initialized: Set<threema.InitializationStep> = new Set();
     private initializedThreshold = 3;
-    private state: threema.StateService;
+    private state: StateService;
 
     // SaltyRTC
     private saltyRtcHost: string = null;
@@ -196,16 +206,16 @@ export class WebClientService implements threema.WebClientService {
                 $timeout: ng.ITimeoutService,
                 container: threema.Container.Factory,
                 trustedKeyStore: TrustedKeyStoreService,
-                stateService: threema.StateService,
-                notificationService: threema.NotificationService,
-                messageService: threema.MessageService,
-                pushService: threema.PushService,
-                browserService: threema.BrowserService,
-                titleService: threema.TitleService,
-                fingerPrintService: threema.FingerPrintService,
-                qrCodeService: threema.QrCodeService,
-                mimeService: threema.MimeService,
-                receiverService: threema.ReceiverService,
+                stateService: StateService,
+                notificationService: NotificationService,
+                messageService: MessageService,
+                pushService: PushService,
+                browserService: BrowserService,
+                titleService: TitleService,
+                fingerPrintService: FingerPrintService,
+                qrCodeService: QrCodeService,
+                mimeService: MimeService,
+                receiverService: ReceiverService,
                 CONFIG: threema.Config) {
 
         // Angular services

--- a/src/services/webclient.ts
+++ b/src/services/webclient.ts
@@ -30,7 +30,7 @@ import {ReceiverService} from './receiver';
 import {StateService} from './state';
 import {TitleService} from './title';
 
-class WebClientDefault implements threema.WebClientDefault {
+class WebClientDefault {
     private avatar: threema.AvatarRegistry = {
         group: {
             low: 'img/ic_group_t.png',
@@ -163,7 +163,7 @@ export class WebClientService {
     public conversations: threema.Container.Conversations;
     public receivers: threema.Container.Receivers;
     public alerts: threema.Alert[] = [];
-    public defaults: threema.WebClientDefault;
+    public defaults: WebClientDefault;
     private myIdentity: threema.Identity;
     private pushToken: string = null;
 

--- a/src/threema.d.ts
+++ b/src/threema.d.ts
@@ -356,11 +356,6 @@ declare namespace threema {
         setOnRemoved(callback: any): void;
     }
 
-    interface AvatarControllerModel {
-        onChangeAvatar: (image: ArrayBuffer) => void;
-        getAvatar(): ArrayBuffer | null;
-    }
-
     interface Alert {
         source: string;
         type: string;

--- a/src/threema.d.ts
+++ b/src/threema.d.ts
@@ -313,15 +313,6 @@ declare namespace threema {
         initParams: null | {identity: null};
     }
 
-    interface MessageAccess {
-        quote: boolean;
-        ack: boolean;
-        dec: boolean;
-        delete: boolean;
-        download: boolean;
-        copy: boolean;
-    }
-
     interface Quote {
         identity: string;
         text: string;

--- a/src/threema.d.ts
+++ b/src/threema.d.ts
@@ -44,8 +44,6 @@ declare namespace threema {
         data?: any;
     }
 
-    type WireMessageCallback = (message: WireMessage, result: any) => boolean;
-
     type MessageType = 'text' | 'image' | 'video' | 'audio' | 'location' | 'status' | 'ballot' | 'file';
     type MessageState = 'delivered' | 'read' | 'send-failed' | 'sent' | 'user-ack' | 'user-dec' | 'pending' | 'sending';
     type InitializationStep = 'client info' | 'conversations' |  'receivers';
@@ -264,11 +262,6 @@ declare namespace threema {
      * Type of message to be sent to a receiver.
      */
     type MessageContentType = 'text' | 'file';
-
-    /**
-     * Possible message types sent to the receiver.
-     */
-    type MessageDataType = 'text' | 'file';
 
     interface MessageData {
         // optional quote object

--- a/src/threema.d.ts
+++ b/src/threema.d.ts
@@ -388,10 +388,6 @@ declare namespace threema {
         OPERA: number;
     }
 
-    interface WebClientDefault {
-        getAvatar(type: string, highResolution: boolean): string;
-    }
-
     namespace Container {
         interface ReceiverData {
             me: MeReceiver;

--- a/src/threema.d.ts
+++ b/src/threema.d.ts
@@ -313,56 +313,6 @@ declare namespace threema {
         initParams: null | {identity: null};
     }
 
-    /**
-     * State service.
-     */
-    interface StateService {
-        // WebRTC states
-        signalingConnectionState: saltyrtc.SignalingState;
-        rtcConnectionState: RTCConnectionState;
-
-        // Global connection state
-        state: 'ok' | 'warning' | 'error';
-        stage: 'signaling' | 'rtc';
-        wasConnected: boolean;
-
-        // Connection buildup
-        connectionBuildupState: ConnectionBuildupState;
-        progress: number;
-        slowConnect: boolean;
-
-        // Update states
-        updateSignalingConnectionState(state: saltyrtc.SignalingState): void;
-        updateRtcConnectionState(state: RTCConnectionState): void;
-        updateConnectionBuildupState(state: ConnectionBuildupState): void;
-
-        reset(): void;
-    }
-
-    /**
-     * Notification service.
-     */
-    interface NotificationService {
-        getNotificationPermission(): boolean;
-        getWantsNotifications(): boolean;
-        setWantsNotifications(wantsNotifications: boolean): void;
-        setWantsPreview(wantsPreview: boolean): void;
-        getWantsPreview(): boolean;
-        init(): void;
-        isNotificationApiAvailable(): boolean;
-        showNotification(id: string, title: string, body: string,
-                         avatar: string | null, clickCallback: any | null): boolean;
-        clearCache(tag: string): void;
-        hideNotification(tag: string): boolean;
-    }
-
-    interface MessageService {
-        getAccess(message: Message, receiver: Receiver): MessageAccess;
-        createTemporary(receiver: Receiver, type: string, messageData: MessageData): Message;
-        showStatusIcon(message: Message, receiver: Receiver): boolean;
-        getFileName(message: Message): string;
-    }
-
     interface MessageAccess {
         quote: boolean;
         ack: boolean;
@@ -391,22 +341,6 @@ declare namespace threema {
         pushToken: string | null;
     }
 
-    interface TrustedKeyStoreService {
-        blocked: boolean;
-        storeTrustedKey(ownPublicKey: Uint8Array, ownSecretKey: Uint8Array, peerPublicKey: Uint8Array,
-                        pushToken: string | null, password: string): void;
-        hasTrustedKey(): boolean;
-        retrieveTrustedKey(password: string): TrustedKeyStoreData;
-        clearTrustedKey(): void;
-    }
-
-    interface PushService {
-        init(pushToken: string): void;
-        reset(): void;
-        isAvailable(): boolean;
-        sendPush(session: Uint8Array): Promise<boolean>;
-    }
-
     interface BrowserInfo {
         chrome: boolean;
         firefox: boolean;
@@ -415,35 +349,6 @@ declare namespace threema {
         safari: boolean;
         version: string;
         textInfo: string;
-    }
-
-    interface BrowserService {
-        getBrowser(): BrowserInfo;
-        isVisible(): boolean;
-    }
-
-    interface TitleService {
-        updateUnreadCount(count: number): void;
-    }
-
-    interface FingerPrintService {
-        generate(publicKey: ArrayBuffer): string;
-    }
-
-    interface ContactService {
-        requiredDetails(contactReceiver: ContactReceiver): Promise<ContactReceiver>;
-    }
-
-    interface ControllerModelService {
-        contact(receiver: ContactReceiver, mode: any): ControllerModel;
-        group(receiver: GroupReceiver, mode: any): ControllerModel;
-        distributionList(receiver: DistributionListReceiver, mode: any): ControllerModel;
-    }
-
-    interface QrCodeService {
-        buildQrCodePayload(initiatorKey: Uint8Array, authToken: Uint8Array, serverKey: Uint8Array | null,
-                           host: string, port: number,
-                           persistent: boolean): string;
     }
 
     interface PromiseCallbacks {
@@ -499,104 +404,8 @@ declare namespace threema {
         OPERA: number;
     }
 
-    interface MimeService {
-        isImage(mimeType: string): boolean;
-        isAudio(mimeType: string): boolean;
-        isVideo(mimeType: string): boolean;
-        getLabel(mimeType: string): string;
-        getIconUrl(mimeType: string): string;
-    }
-
-    interface ReceiverService {
-        setActive(activeReceiver: Receiver): void;
-        getActive(): Receiver;
-        isConversationActive(conversation: Conversation): boolean;
-        compare(a: Conversation | Receiver, b: Conversation| Receiver): boolean;
-        isContact(receiver: Receiver): boolean;
-        isGroup(receiver: Receiver): boolean;
-        isDistributionList(receiver: Receiver): boolean;
-        isBusinessContact(receiver: Receiver): boolean;
-    }
-
-    interface SettingsService {
-        storeUntrustedKeyValuePair(key: string, value: string): void;
-        retrieveUntrustedKeyValuePair(key: string): string;
-    }
-
     interface WebClientDefault {
         getAvatar(type: string, highResolution: boolean): string;
-    }
-
-    interface WebClientService {
-        salty: saltyrtc.SaltyRTC;
-        messages: Container.Messages;
-        conversations: Container.Conversations;
-        receivers: Container.Receivers;
-        alerts: Alert[];
-        defaults: WebClientDefault;
-        receiverListener: ReceiverListener[];
-
-        me: MeReceiver;
-        contacts: Map<string, ContactReceiver>;
-        groups: Map<string, GroupReceiver>;
-        distributionLists: Map<string, DistributionListReceiver>;
-        typing: Container.Typing;
-
-        buildQrCodePayload(persistent: boolean): string;
-        init(keyStore?: saltyrtc.KeyStore, peerTrustedKey?: Uint8Array, resetField?: boolean): void;
-        start(): ng.IPromise<any>;
-        stop(requestedByUs: boolean, deleteStoredData?: boolean, resetPush?: boolean, redirect?: boolean): void;
-        registerInitializationStep(name: string): void;
-        setReceiverListener(listener: ReceiverListener): void;
-        requestClientInfo(): void;
-        requestReceivers(): void;
-        requestConversations(): void;
-        requestMessages(receiver: Receiver, reloadExisting?: boolean): number;
-        requestAvatar(receiver: Receiver, highResolution: boolean): Promise<any>;
-        requestThumbnail(receiver: Receiver, message: Message): Promise<any>;
-        requestBlob(msgId: number, receiver: Receiver): Promise<ArrayBuffer>;
-        requestRead(receiver, newestMessageId: number): void;
-        requestContactDetail(contactReceiver: ContactReceiver): Promise<any>;
-        sendMessage(receiver, type: MessageContentType, message: MessageData): Promise<Promise<any>>;
-        ackMessage(receiver, message: Message, acknowledged?: boolean): void;
-        deleteMessage(receiver, message: Message): void;
-        sendMeIsTyping(receiver, isTyping: boolean): void;
-        sendKeyPersisted(): void;
-        addContact(threemaId: String): Promise<ContactReceiver>;
-        modifyContact(threemaId: String, firstName: String, lastName: String, avatar?: ArrayBuffer):
-            Promise<ContactReceiver>;
-        createGroup(members: String[], name: String, avatar?: ArrayBuffer): Promise<GroupReceiver>;
-        modifyGroup(id: string, members: String[], name: String, avatar?: ArrayBuffer): Promise<GroupReceiver>;
-        leaveGroup(group: GroupReceiver): Promise<any>;
-        deleteGroup(group: GroupReceiver): Promise<any>;
-        syncGroup(group: GroupReceiver): Promise<any>;
-        createDistributionList(members: String[], name: String): Promise<DistributionListReceiver>;
-        modifyDistributionList(id: string, members: String[], name: String): Promise<DistributionListReceiver>;
-        deleteDistributionList(distributionList: DistributionListReceiver): Promise<any>;
-        isTyping(receiver: ContactReceiver): boolean;
-        getMyIdentity(): Identity;
-        getQuote(receiver: Receiver): Quote;
-        setQuote(receiver: Receiver, message?: Message): void;
-        setDraft(receiver: Receiver, message: string): void;
-        getDraft(receiver: Receiver): string;
-        setPassword(password: string): void;
-        clearCache(): void;
-        getMaxTextLength(): number;
-    }
-
-    interface ControllerService {
-        setControllerName(name: string): void;
-        getControllerName(): string;
-    }
-
-    interface StringService {
-        /**
-         * create chunks of a string by counting the used bytes
-         * @param str
-         * @param byteLength
-         * @param offset
-         */
-        byteChunk(str: string, byteLength: number, offset: number): string[];
     }
 
     namespace Container {

--- a/src/threema/container.ts
+++ b/src/threema/container.ts
@@ -15,7 +15,7 @@
  * along with Threema Web. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import {ReceiverService} from "../services/receiver";
+import {ReceiverService} from '../services/receiver';
 
 /**
  * A simple HashSet implementation based on a JavaScript object.

--- a/src/threema/container.ts
+++ b/src/threema/container.ts
@@ -15,6 +15,8 @@
  * along with Threema Web. If not, see <http://www.gnu.org/licenses/>.
  */
 
+import {ReceiverService} from "../services/receiver";
+
 /**
  * A simple HashSet implementation based on a JavaScript object.
  *
@@ -49,7 +51,7 @@ class StringHashSet {
 
 angular.module('3ema.container', [])
 .factory('Container', ['$filter', '$log', 'ReceiverService',
-    function($filter, $log, receiverService: threema.ReceiverService) {
+    function($filter, $log, receiverService: ReceiverService) {
     type ContactMap = Map<string, threema.ContactReceiver>;
     type GroupMap = Map<string, threema.GroupReceiver>;
     type DistributionListMap = Map<string, threema.DistributionListReceiver>;


### PR DESCRIPTION
Instead of using interfaces, we can just as well import the ES2015 types. It also reduces problems when importing external TS libraries. (The Threema type declarations predate ES2015 import support for Typescript.)