### PR TITLE
Fix / improve soft reconnect behavior

### DIFF
--- a/LICENSE-3RD-PARTY.txt
+++ b/LICENSE-3RD-PARTY.txt
@@ -707,7 +707,7 @@ License for saltyrtc-client
 
 The MIT License (MIT)
 
-Copyright (c) 2016 Threema GmbH
+Copyright (c) 2016-2017 Threema GmbH
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -756,6 +756,16 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
+
+
+
+----------
+License for ts-events
+----------
+
+Copyright (c) 2015, Rogier Schouten <github@workingcode.ninja>
+Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies.
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 
 

--- a/gather-licenses.sh
+++ b/gather-licenses.sh
@@ -29,6 +29,7 @@ LICENSE_FILES=(
     'node-sass' 'node_modules/node-sass/LICENSE'
     'saltyrtc-client' 'node_modules/saltyrtc-client/LICENSE.md'
     'saltyrtc-task-webrtc' 'node_modules/saltyrtc-task-webrtc/LICENSE.md'
+    'ts-events' 'node_modules/ts-events/LICENSE'
     'tsify' '.licenses/tsify'
     'tweetnacl' 'node_modules/tweetnacl/LICENSE'
     'typescript' 'node_modules/typescript/LICENSE.txt'

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -52,11 +52,6 @@
       "from": "@types/webrtc@>=0.0.21 <0.1.0",
       "resolved": "https://registry.npmjs.org/@types/webrtc/-/webrtc-0.0.21.tgz"
     },
-    "JSONStream": {
-      "version": "1.3.0",
-      "from": "JSONStream@>=1.0.3 <2.0.0",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.0.tgz"
-    },
     "abbrev": {
       "version": "1.0.9",
       "from": "abbrev@>=1.0.0 <2.0.0",
@@ -2274,6 +2269,11 @@
       "from": "jsonpointer@>=4.0.0 <5.0.0",
       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz"
     },
+    "JSONStream": {
+      "version": "1.3.0",
+      "from": "JSONStream@>=1.0.3 <2.0.0",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.0.tgz"
+    },
     "jsprim": {
       "version": "1.3.1",
       "from": "jsprim@>=1.2.2 <2.0.0",
@@ -3741,15 +3741,15 @@
         }
       }
     },
-    "string-width": {
-      "version": "1.0.2",
-      "from": "string-width@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz"
-    },
     "string_decoder": {
       "version": "0.10.31",
       "from": "string_decoder@>=0.10.0 <0.11.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+    },
+    "string-width": {
+      "version": "1.0.2",
+      "from": "string-width@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz"
     },
     "stringstream": {
       "version": "0.0.5",
@@ -3924,6 +3924,11 @@
       "version": "1.0.0",
       "from": "trim-newlines@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz"
+    },
+    "ts-events": {
+      "version": "3.1.5",
+      "from": "ts-events@latest",
+      "resolved": "https://registry.npmjs.org/ts-events/-/ts-events-3.1.5.tgz"
     },
     "tsconfig": {
       "version": "5.0.3",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "saltyrtc-client": "~0.9.1",
     "saltyrtc-task-webrtc": "~0.9.1",
     "sdp": "~1.3.0",
+    "ts-events": "^3.1.5",
     "tsify": "~2.0.1",
     "tweetnacl": "~0.14.4",
     "typescript": "~2.1.0",

--- a/src/app.ts
+++ b/src/app.ts
@@ -17,6 +17,8 @@
  * along with Threema Web. If not, see <http://www.gnu.org/licenses/>.
  */
 
+import {AsyncEvent} from 'ts-events';
+
 import config from './config';
 import './controllers';
 import './directives';
@@ -25,6 +27,12 @@ import './partials/messenger';
 import './partials/welcome';
 import './services';
 import './threema/container';
+
+// Configure asynchronous events
+AsyncEvent.setScheduler(function(callback) {
+    // Replace the default setImmediate() call by a setTimeout(, 0) call
+    setTimeout(callback, 0);
+});
 
 // Create app module and set dependencies
 angular.module('3ema', [

--- a/src/partials/welcome.ts
+++ b/src/partials/welcome.ts
@@ -390,6 +390,11 @@ class WelcomeController {
                 // TODO: should probably show an error message instead
                 this.$timeout(() => this.$state.reload(), WelcomeController.REDIRECT_DELAY);
             },
+
+            // State updates
+            (progress: threema.ConnectionBuildupStateChange) => {
+                // Do nothing
+            },
         );
     }
 

--- a/src/services/state.ts
+++ b/src/services/state.ts
@@ -15,6 +15,8 @@
  * along with Threema Web. If not, see <http://www.gnu.org/licenses/>.
  */
 
+import {AsyncEvent} from 'ts-events';
+
 export class StateService {
 
     private logTag: string = '[StateService]';
@@ -22,6 +24,9 @@ export class StateService {
     // Angular services
     private $log: ng.ILogService;
     private $interval: ng.IIntervalService;
+
+    // Events
+    public evtConnectionBuildupStateChange = new AsyncEvent<threema.ConnectionBuildupStateChange>();
 
     // WebRTC states
     public signalingConnectionState: saltyrtc.SignalingState;
@@ -111,10 +116,12 @@ export class StateService {
         if (this.connectionBuildupState === state) {
             return;
         }
-        this.$log.debug(this.logTag, 'Connection buildup state:', this.connectionBuildupState, '=>', state);
+        const prevState = this.connectionBuildupState;
+        this.$log.debug(this.logTag, 'Connection buildup state:', prevState, '=>', state);
 
         // Update state
         this.connectionBuildupState = state;
+        this.evtConnectionBuildupStateChange.post({state: state, prevState: prevState});
 
         // Cancel progress interval if present
         if (this.progressInterval !== null) {

--- a/src/services/state.ts
+++ b/src/services/state.ts
@@ -17,6 +17,8 @@
 
 export class StateService {
 
+    private logTag: string = '[StateService]';
+
     // Angular services
     private $log: ng.ILogService;
     private $interval: ng.IIntervalService;
@@ -50,7 +52,7 @@ export class StateService {
         const prevState = this.signalingConnectionState;
         this.signalingConnectionState = state;
         if (this.stage === 'signaling') {
-            this.$log.debug('[StateService] Signaling connection state:', prevState, '=>', state);
+            this.$log.debug(this.logTag, 'Signaling connection state:', prevState, '=>', state);
             switch (state) {
                 case 'new':
                 case 'ws-connecting':
@@ -67,10 +69,10 @@ export class StateService {
                     this.state = 'error';
                     break;
                 default:
-                    this.$log.warn('[StateService] Ignored signaling connection state change to', state);
+                    this.$log.warn(this.logTag, 'Ignored signaling connection state change to', state);
             }
         } else {
-            this.$log.debug('[StateService] Ignored signaling connection state to "' + state + '"');
+            this.$log.debug(this.logTag, 'Ignored signaling connection state to "' + state + '"');
         }
     }
 
@@ -81,7 +83,7 @@ export class StateService {
         const prevState = this.rtcConnectionState;
         this.rtcConnectionState = state;
         if (this.stage === 'rtc') {
-            this.$log.debug('[StateService] RTC connection state:', prevState, '=>', state);
+            this.$log.debug(this.logTag, 'RTC connection state:', prevState, '=>', state);
             switch (state) {
                 case 'new':
                 case 'connecting':
@@ -95,10 +97,10 @@ export class StateService {
                     this.state = 'error';
                     break;
                 default:
-                    this.$log.warn('[StateService] Ignored RTC connection state change to', state);
+                    this.$log.warn(this.logTag, 'Ignored RTC connection state change to', state);
             }
         } else {
-            this.$log.debug('[StateService] Ignored RTC connection state change to "' + state + '"');
+            this.$log.debug(this.logTag, 'Ignored RTC connection state change to "' + state + '"');
         }
     }
 
@@ -109,7 +111,7 @@ export class StateService {
         if (this.connectionBuildupState === state) {
             return;
         }
-        this.$log.debug('[StateService] Connection buildup state:', this.connectionBuildupState, '=>', state);
+        this.$log.debug(this.logTag, 'Connection buildup state:', this.connectionBuildupState, '=>', state);
 
         // Update state
         this.connectionBuildupState = state;
@@ -188,7 +190,7 @@ export class StateService {
      * Reset all states.
      */
     public reset(): void {
-        this.$log.debug('[StateService] Reset');
+        this.$log.debug(this.logTag, 'Reset');
 
         // Reset state
         this.signalingConnectionState = 'new';

--- a/src/services/webclient.ts
+++ b/src/services/webclient.ts
@@ -608,13 +608,16 @@ export class WebClientService {
         }
     }
 
-    // Mark a component as initialized
+    /**
+     * Mark a component as initialized
+     */
     public registerInitializationStep(name: threema.InitializationStep) {
         if (this.initialized.has(name) ) {
             this.$log.warn(this.logTag, 'initialization step', name, 'already registered');
             return;
         }
 
+        this.$log.debug(this.logTag, 'Initialization step', name, 'done');
         this.initialized.add(name);
 
         // check pending routines
@@ -637,6 +640,7 @@ export class WebClientService {
             this.stateService.updateConnectionBuildupState('done');
             this.startupPromise.resolve();
             this.startupDone = true;
+            this._resetInitializationSteps();
         }
     }
 
@@ -1234,13 +1238,20 @@ export class WebClientService {
     }
 
     /**
+     * Reset data related to initialization.
+     */
+    private _resetInitializationSteps(): void {
+        this.$log.debug(this.logTag, 'Reset initialization steps');
+        this.initialized.clear();
+        this.pendingInitializationStepRoutines = [];
+    }
+
+    /**
      * Reset data fields.
      */
     private _resetFields(): void {
-        // clear initialized steps
-        this.initialized.clear();
-        // clear step routines
-        this.pendingInitializationStepRoutines = [];
+        // Reset initialization data
+        this._resetInitializationSteps();
 
         // Create container instances
         this.receivers = this.container.createReceivers();
@@ -2363,4 +2374,5 @@ export class WebClientService {
     private resetUnreadCount(): void {
         this.titleService.updateUnreadCount(0);
     }
+
 }

--- a/src/services/webclient.ts
+++ b/src/services/webclient.ts
@@ -1256,14 +1256,6 @@ export class WebClientService {
         this.conversations.setFilter(this.container.Filters.hasData(this.receivers));
     }
 
-    private _resetUI(): void {
-        this.$log.debug('UI Reset');
-        // Only reset if currently in the messenger state
-        if (this.$state.includes('messenger')) {
-            this.$state.go(this.$state.current, this.$state.params, {reload: true});
-        }
-    }
-
     private _requestInitialData(): void {
         // if all conversations are reloaded, clear the message cache
         // to get in sync (we dont know if a message was removed, updated etc..)

--- a/src/services/webclient.ts
+++ b/src/services/webclient.ts
@@ -150,7 +150,7 @@ export class WebClientService {
     private pendingInitializationStepRoutines: threema.InitializationStepRoutine[] = [];
     private initialized: Set<threema.InitializationStep> = new Set();
     private initializedThreshold = 3;
-    private state: StateService;
+    private stateService: StateService;
 
     // SaltyRTC
     private saltyRtcHost: string = null;
@@ -243,7 +243,7 @@ export class WebClientService {
         this.config = CONFIG;
 
         // State
-        this.state = stateService;
+        this.stateService = stateService;
 
         // Other properties
         this.container = container;
@@ -295,7 +295,7 @@ export class WebClientService {
      */
     public init(keyStore?: saltyrtc.KeyStore, peerTrustedKey?: Uint8Array, resetFields = true): void {
         // Reset state
-        this.state.reset();
+        this.stateService.reset();
 
         // Create WebRTC task instance
         const maxPacketSize = this.browserService.getBrowser().firefox ? 16384 : 65536;
@@ -333,7 +333,7 @@ export class WebClientService {
         this.salty.on('new-responder', () => {
             if (!this.startupDone) {
                 // Peer handshake
-                this.state.updateConnectionBuildupState('peer_handshake');
+                this.stateService.updateConnectionBuildupState('peer_handshake');
             }
         });
 
@@ -347,16 +347,16 @@ export class WebClientService {
                         case 'new':
                         case 'ws-connecting':
                         case 'server-handshake':
-                            if (this.state.connectionBuildupState !== 'push'
-                                && this.state.connectionBuildupState !== 'manual_start') {
-                                this.state.updateConnectionBuildupState('connecting');
+                            if (this.stateService.connectionBuildupState !== 'push'
+                                && this.stateService.connectionBuildupState !== 'manual_start') {
+                                this.stateService.updateConnectionBuildupState('connecting');
                             }
                             break;
                         case 'peer-handshake':
                             // Waiting for peer
-                            if (this.state.connectionBuildupState !== 'push'
-                                && this.state.connectionBuildupState !== 'manual_start') {
-                                this.state.updateConnectionBuildupState('waiting');
+                            if (this.stateService.connectionBuildupState !== 'push'
+                                && this.stateService.connectionBuildupState !== 'manual_start') {
+                                this.stateService.updateConnectionBuildupState('waiting');
                             }
                             break;
                         case 'task':
@@ -364,13 +364,13 @@ export class WebClientService {
                             break;
                         case 'closing':
                         case 'closed':
-                            this.state.updateConnectionBuildupState('closed');
+                            this.stateService.updateConnectionBuildupState('closed');
                             break;
                         default:
                             this.$log.warn('Unknown signaling state:', state);
                     }
                 }
-                this.state.updateSignalingConnectionState(state);
+                this.stateService.updateSignalingConnectionState(state);
             }, 0);
         });
 
@@ -389,12 +389,12 @@ export class WebClientService {
 
             // On state changes in the PeerConnectionHelper class, let state service know about it
             this.pcHelper.onConnectionStateChange = (state: threema.RTCConnectionState) => {
-                if (state === 'connected' && this.state.wasConnected) {
+                if (state === 'connected' && this.stateService.wasConnected) {
                     // this happens if a lost connection could be restored
                     // without reset the peer connection
                     this._requestInitialData();
                 }
-                this.state.updateRtcConnectionState(state);
+                this.stateService.updateRtcConnectionState(state);
             };
 
             // Initiate handover
@@ -436,7 +436,7 @@ export class WebClientService {
                     this._requestInitialData();
 
                     // Notify state service about data loading
-                    this.state.updateConnectionBuildupState('loading');
+                    this.stateService.updateConnectionBuildupState('loading');
                 },
             );
 
@@ -505,12 +505,12 @@ export class WebClientService {
                 .then(() => {
                     this.$log.debug('Requested app wakeup');
                     this.$rootScope.$apply(() => {
-                        this.state.updateConnectionBuildupState('push');
+                        this.stateService.updateConnectionBuildupState('push');
                     });
                 });
         } else if (this.trustedKeyStore.hasTrustedKey()) {
             this.$log.debug('Push service not available');
-            this.state.updateConnectionBuildupState('manual_start');
+            this.stateService.updateConnectionBuildupState('manual_start');
         }
 
         return this.startupPromise.promise;
@@ -534,12 +534,12 @@ export class WebClientService {
                 redirect: boolean = false): void {
         this.$log.info('Disconnecting...');
 
-        if (requestedByUs && this.state.rtcConnectionState === 'connected') {
+        if (requestedByUs && this.stateService.rtcConnectionState === 'connected') {
             // Ask peer to disconnect too
             this.salty.sendApplicationMessage({type: 'disconnect', forget: deleteStoredData});
         }
 
-        this.state.reset();
+        this.stateService.reset();
 
         // Reset the unread count
         this.resetUnreadCount();
@@ -634,7 +634,7 @@ export class WebClientService {
         });
 
         if (this.initialized.size >= this.initializedThreshold) {
-            this.state.updateConnectionBuildupState('done');
+            this.stateService.updateConnectionBuildupState('done');
             this.startupPromise.resolve();
             this.startupDone = true;
         }

--- a/src/threema.d.ts
+++ b/src/threema.d.ts
@@ -15,8 +15,6 @@
  * along with Threema Web. If not, see <http://www.gnu.org/licenses/>.
  */
 
-// Types used for the Threema Webclient.
-
 declare const angular: ng.IAngularStatic;
 
 declare namespace threema {
@@ -247,6 +245,11 @@ declare namespace threema {
      */
     type ConnectionBuildupState = 'new' | 'connecting' | 'push' | 'manual_start' | 'waiting'
         | 'peer_handshake' | 'loading' | 'done' | 'closed';
+
+    interface ConnectionBuildupStateChange {
+        state: ConnectionBuildupState;
+        prevState: ConnectionBuildupState;
+    }
 
     /**
      * Connection state of the WebRTC peer connection.


### PR DESCRIPTION
This adds two main fixes / improvements:

- Previously, the initialization steps were not properly reset after a full intiialization. This meant that a soft reconnect would always fail, because the WebClientService would ignore already registered intiialization steps. This PR adds proper reset calls.
- Previously, with a timeout of 20 seconds, it could happen that a connection process would time out even though it was still in process (e.g. if the push takes a while to arrive). This PR resets the timeout every time an important connection buildup step is reached.

For the connection buildup state tracking, a new event emitter library was added: [ts-events](https://github.com/rogierschouten/ts-events). It allows adding self-contained event emitters as class attributes. Maybe we can convert some watches to explicit event emitters in the future. It provides a clear API and should improve performance compared to AngularJS watches.

Refs #106 (there are some other things that should be improved before it can be considered fixed).