### PR TITLE
Enhanced desktop notification preview

### DIFF
--- a/public/i18n/de.json
+++ b/public/i18n/de.json
@@ -150,7 +150,13 @@
     },
     "messageTypes": {
         "AUDIO_MESSAGE": "Sprachnachricht",
-        "FILE_MESSAGE": "Datei"
+        "FILE_MESSAGE": "Datei",
+        "image": "Bild",
+        "video": "Video",
+        "file": "Datei",
+        "audio": "Sprachnachricht",
+        "location": "Ort",
+        "ballot": "Umfrage"
     },
     "validationError": {
         "createReceiver": {

--- a/public/i18n/de.json
+++ b/public/i18n/de.json
@@ -156,7 +156,8 @@
         "file": "Datei",
         "audio": "Sprachnachricht",
         "location": "Ort",
-        "ballot": "Umfrage"
+        "ballot": "Umfrage",
+        "gif": "GIF"
     },
     "validationError": {
         "createReceiver": {

--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -151,7 +151,14 @@
     },
     "messageTypes": {
         "AUDIO_MESSAGE": "Audio Message",
-        "FILE_MESSAGE": "File Message"
+        "FILE_MESSAGE": "File Message",
+        "image": "Image",
+        "video": "Video",
+        "file": "File",
+        "audio": "Audio",
+        "location": "Location",
+        "ballot": "Ballot"
+
     },
     "validationError": {
         "createReceiver": {

--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -157,7 +157,8 @@
         "file": "File",
         "audio": "Audio",
         "location": "Location",
-        "ballot": "Ballot"
+        "ballot": "Ballot",
+        "gif": "GIF"
 
     },
     "validationError": {

--- a/src/directives/message_icon.ts
+++ b/src/directives/message_icon.ts
@@ -37,8 +37,9 @@ export default [
                         case 'location':
                             return 'ic_location_on_24px.svg';
                         case 'file':
-                            if (this.message.file.type === 'image/gif')
+                            if (this.message.file.type === 'image/gif') {
                                 return 'ic_image_24px.svg';
+                            }
                             return 'ic_insert_drive_file_24px.svg';
                         case 'ballot':
                             return 'ic_poll_24px.svg';

--- a/src/directives/message_icon.ts
+++ b/src/directives/message_icon.ts
@@ -37,6 +37,8 @@ export default [
                         case 'location':
                             return 'ic_location_on_24px.svg';
                         case 'file':
+                            if (this.message.file.type === 'image/gif')
+                                return 'ic_image_24px.svg';
                             return 'ic_insert_drive_file_24px.svg';
                         case 'ballot':
                             return 'ic_poll_24px.svg';

--- a/src/services/webclient.ts
+++ b/src/services/webclient.ts
@@ -2011,11 +2011,10 @@ export class WebClientService {
                 let messageType = message.type;
                 let caption = message.caption;
                 let captionString = '';
-                if (typeof caption !== "undefined"){
+                if (typeof caption !== 'undefined') {
                     captionString = captionString + ': ' + caption;
                 }
                 let messageTypeString = this.$translate.instant('messageTypes.' + messageType);
-                console.info(messageTypeString + ": " + messageType);
                 switch (messageType) {
                     case 'text':
                         body = message.body;

--- a/src/services/webclient.ts
+++ b/src/services/webclient.ts
@@ -29,6 +29,7 @@ import {QrCodeService} from './qrcode';
 import {ReceiverService} from './receiver';
 import {StateService} from './state';
 import {TitleService} from './title';
+import {log} from "util";
 
 class WebClientDefault {
     private avatar: threema.AvatarRegistry = {
@@ -2008,12 +2009,34 @@ export class WebClientService {
             .then((titlePrefix) =>  {
                 const title = `${titlePrefix} ${senderName}`;
                 let body = '';
-                switch (message.type) {
+                let messageType = message.type;
+                let caption = message.caption;
+                let captionString = '';
+                if (typeof caption !== "undefined"){
+                    captionString = captionString + ': ' + caption;
+                }
+                let messageTypeString = this.$translate.instant('messageTypes.' + messageType);
+                console.info(messageTypeString + ": " + messageType);
+                switch (messageType) {
                     case 'text':
                         body = message.body;
                         break;
+                    case 'location':
+                        body = messageTypeString + ': ' + message.location.poi;
+                        break;
+                    case 'file':
+                        if (captionString.length > 0) {
+                            body = messageTypeString + captionString;
+                            break;
+                        }
+                        body = messageTypeString + ': ' + message.file.name;
+                        break;
+                    case 'ballot':
+                        // TODO Show ballot title if ballot messages are implemented in the web version
+                        body = messageTypeString;
+                        break;
                     default:
-                        body = `[${message.type}]`;
+                        body = messageTypeString + captionString;
                 }
                 if (conversation.type === 'group') {
                     body = partnerName + ': ' + body;

--- a/src/services/webclient.ts
+++ b/src/services/webclient.ts
@@ -2025,6 +2025,11 @@ export class WebClientService {
                         body = messageTypeString + ': ' + message.location.poi;
                         break;
                     case 'file':
+                        if (message.file.type === 'image/gif') {
+                            body = this.$translate.instant('messageTypes.' + 'gif') + captionString;
+                            break;
+                        }
+                        // Display caption, if available otherwise use filename
                         if (captionString.length > 0) {
                             body = messageTypeString + captionString;
                             break;
@@ -2036,6 +2041,7 @@ export class WebClientService {
                         body = messageTypeString;
                         break;
                     default:
+                        // Image, video and audio
                         body = messageTypeString + captionString;
                 }
                 if (conversation.type === 'group') {

--- a/src/services/webclient.ts
+++ b/src/services/webclient.ts
@@ -29,7 +29,6 @@ import {QrCodeService} from './qrcode';
 import {ReceiverService} from './receiver';
 import {StateService} from './state';
 import {TitleService} from './title';
-import {log} from "util";
 
 class WebClientDefault {
     private avatar: threema.AvatarRegistry = {

--- a/src/services/webclient.ts
+++ b/src/services/webclient.ts
@@ -2011,7 +2011,7 @@ export class WebClientService {
                 let messageType = message.type;
                 let caption = message.caption;
                 let captionString = '';
-                if (typeof caption !== 'undefined') {
+                if (caption !== undefined) {
                     captionString = captionString + ': ' + caption;
                 }
                 let messageTypeString = this.$translate.instant('messageTypes.' + messageType);
@@ -2030,9 +2030,9 @@ export class WebClientService {
                         // Display caption, if available otherwise use filename
                         if (captionString.length > 0) {
                             body = messageTypeString + captionString;
-                            break;
+                        } else {
+                            body = messageTypeString + ': ' + message.file.name;
                         }
-                        body = messageTypeString + ': ' + message.file.name;
                         break;
                     case 'ballot':
                         // TODO Show ballot title if ballot messages are implemented in the web version


### PR DESCRIPTION
Fixes #186 

- Desktop notifications now include captions, filenames and translated filetype:
![vorschau](https://cloud.githubusercontent.com/assets/6652142/24587918/309e34ba-17bf-11e7-839e-471b00edd250.png)

- Gifs now show the 'image' icon in the recent list (like the Android app)

@sillych Can you compare my implementation with the Android implementation? Maybe I forgot some filetype. Asking is easier than trial and error ;)