### PR TITLE
[UX] enforce 'cursor: text' on compose box

### DIFF
--- a/src/sass/sections/_compose_area.scss
+++ b/src/sass/sections/_compose_area.scss
@@ -35,6 +35,7 @@
                     line-height: 1.3em;
                     max-height: calc(1.3em * 5);
                     min-height: 1.3em;
+                    cursor: text;
 
                     img {
                         vertical-align: middle;


### PR DESCRIPTION
In Chrome when the compose box is focused, only its padding has a text cursor, the containing ::before element has a default cursor.
This does not apply in FF.
Alternatively you could define the text cursor for the :before element, but considering this would have to be set on all future child elements, setting it on the parent is prabably be more future proof.