### PR TITLE
Enforce the type field for all receivers

### DIFF
--- a/src/controllers/status.ts
+++ b/src/controllers/status.ts
@@ -136,7 +136,7 @@ export class StatusController {
     }
 
     /**
-     * Go back to the welcome screen and try to reconnect using the same keys as right now.
+     * Attempt to reconnect after a connection loss.
      */
     private reconnect(): void {
         this.$log.warn(this.logTag, 'Connection lost. Attempting to reconnect...');

--- a/src/directives/latest_message.html
+++ b/src/directives/latest_message.html
@@ -1,4 +1,4 @@
-<div class="latest-message" ng-class="{'has-draft': ctrl.hasDraft(), 'is-typing': ctrl.isTyping(), 'is-hidden': ctrl.isHidden()}">
+<div class="latest-message" ng-class="{'show-draft': ctrl.showDraft(), 'is-typing': ctrl.isTyping(), 'is-hidden': ctrl.isHidden()}">
 
     <!-- Typing indicator -->
     <div class="left typing">

--- a/src/directives/latest_message.ts
+++ b/src/directives/latest_message.ts
@@ -78,13 +78,14 @@ export default [
                     && this.message.type !== 'status';
 
                 this.getDraft = () => {
-                    if (receiverService.isConversationActive(this.receiver)) {
-                        return null;
-                    }
                     return webClientService.getDraft(this.receiver);
                 };
 
-                this.hasDraft = () => {
+                this.showDraft = () => {
+                    if (receiverService.isConversationActive(this.receiver)) {
+                        // Don't show draft if conversation is active
+                        return false;
+                    }
                     let draft = this.getDraft();
                     return draft !== undefined && draft !== null;
                 };

--- a/src/sass/sections/_navigation.scss
+++ b/src/sass/sections/_navigation.scss
@@ -191,7 +191,7 @@
                         }
                     }
 
-                    &.has-draft {
+                    &.show-draft {
                         .no-draft {
                             display: none;
                         }
@@ -202,7 +202,7 @@
                             display: none;
                         }
                     }
-                    &:not(.has-draft) {
+                    &:not(.show-draft) {
                         .draft {
                             display: none;
                         }

--- a/src/services/receiver.ts
+++ b/src/services/receiver.ts
@@ -40,11 +40,16 @@ export class ReceiverService {
     }
 
     public isConversationActive(conversation: threema.Conversation): boolean {
-        if (this.activeReceiver !== undefined) {
-           return this.compare(conversation, this.activeReceiver);
+        if (!this.activeReceiver) {
+            return false;
         }
+        return this.compare(conversation, this.activeReceiver);
     }
 
+    /**
+     * Compare two conversations and/or receivers.
+     * Return `true` if they both have the same type and id.
+     */
     public compare(a: threema.Conversation | threema.Receiver,
                    b: threema.Conversation | threema.Receiver): boolean {
         return a !== undefined

--- a/src/threema.d.ts
+++ b/src/threema.d.ts
@@ -139,15 +139,18 @@ declare namespace threema {
         canChangeMembers?: boolean;
     }
 
+    interface BaseReceiver {
+        id: string;
+        type: ReceiverType;
+    }
+
     /**
      * A generic receiver.
      *
      * Note that the id is not unique for all receivers, only for all receivers
      * of a certain type. The primary key for a receiver is the tuple (type, id).
      */
-    interface Receiver {
-        type?: ReceiverType;
-        id: string;
+    interface Receiver extends BaseReceiver {
         displayName: string;
         color: string;
         avatar?: Avatar; // May be set if already fetched
@@ -160,7 +163,7 @@ declare namespace threema {
      * A contact.
      */
     interface ContactReceiver extends Receiver {
-        type?: 'contact' | 'me';
+        type: 'contact' | 'me';
         publicNickname?: string;
         firstName?: string;
         lastName?: string;
@@ -176,14 +179,14 @@ declare namespace threema {
      * Own contact.
      */
     interface MeReceiver extends ContactReceiver {
-        type?: 'me';
+        type: 'me';
     }
 
     /**
      * A group.
      */
     interface GroupReceiver extends Receiver {
-        type?: 'group';
+        type: 'group';
         disabled: boolean;
         members: string[];
         administrator: string;
@@ -194,7 +197,7 @@ declare namespace threema {
      * A distribution list.
      */
     interface DistributionListReceiver extends Receiver {
-        type?: 'distributionList';
+        type: 'distributionList';
         members: string[];
         access: DistributionListReceiverAccess;
     }

--- a/src/threema/container.ts
+++ b/src/threema/container.ts
@@ -116,6 +116,7 @@ angular.module('3ema.container', [])
          * Set own contact.
          */
         public setMe(data: threema.MeReceiver): void {
+            data.type = 'me';
             this.me = data;
         }
 
@@ -123,7 +124,10 @@ angular.module('3ema.container', [])
          * Set contacts.
          */
         public setContacts(data: threema.ContactReceiver[]): void {
-            this.contacts = new Map(data.map((c) => [c.id, c]) as any) as ContactMap;
+            this.contacts = new Map(data.map((c) => {
+                c.type = 'contact';
+                return [c.id, c];
+            }) as any) as ContactMap;
             if (this.me !== undefined) {
                 this.contacts.set(this.me.id, this.me);
             }
@@ -133,14 +137,20 @@ angular.module('3ema.container', [])
          * Set groups.
          */
         public setGroups(data: threema.GroupReceiver[]): void {
-            this.groups = new Map(data.map((g) => [g.id, g]) as any) as GroupMap;
+            this.groups = new Map(data.map((g) => {
+                g.type = 'group';
+                return [g.id, g];
+            }) as any) as GroupMap;
         }
 
         /**
          * Set distribution lists.
          */
         public setDistributionLists(data: threema.DistributionListReceiver[]): void {
-            this.distributionLists = new Map(data.map((d) => [d.id, d]) as any) as DistributionListMap;
+            this.distributionLists = new Map(data.map((d) => {
+                d.type = 'distributionList';
+                return [d.id, d];
+            }) as any) as DistributionListMap;
         }
 
         public extend(receiverType: threema.ReceiverType, data: threema.Receiver): threema.Receiver {
@@ -161,6 +171,7 @@ angular.module('3ema.container', [])
         public extendDistributionList(data: threema.DistributionListReceiver): threema.DistributionListReceiver {
             let distributionListReceiver  = this.distributionLists.get(data.id);
             if (distributionListReceiver === undefined) {
+                data.type = 'distributionList';
                 this.distributionLists.set(data.id, data);
                 return data;
             }
@@ -173,6 +184,7 @@ angular.module('3ema.container', [])
         public extendGroup(data: threema.GroupReceiver): threema.GroupReceiver {
             let groupReceiver  = this.groups.get(data.id);
             if (groupReceiver === undefined) {
+                data.type = 'group';
                 this.groups.set(data.id, data);
                 return data;
             }
@@ -184,6 +196,7 @@ angular.module('3ema.container', [])
 
         public extendMe(data: threema.MeReceiver): threema.MeReceiver {
             if (this.me === undefined) {
+                data.type = 'me';
                 this.me = data;
                 return data;
             }
@@ -196,6 +209,7 @@ angular.module('3ema.container', [])
         public extendContact(data: threema.ContactReceiver): threema.ContactReceiver {
             let contactReceiver = this.contacts.get(data.id);
             if (contactReceiver === undefined) {
+                data.type = 'contact';
                 this.contacts.set(data.id, data);
                 return data;
             }


### PR DESCRIPTION
Some receivers didn't have a type field set. This messes up functions like `ReceiverService.isConversationActive` that need the type to be set to work properly.

This PR requires all receiver instances to have a `type` field. The receivers container was adjusted to always set the type.

I also added a `BaseReceiver` interface that can be used in places where only the type and id fields are required.

Fixes #189.