### PR TITLE
Fix intermittent test failures

### DIFF
--- a/tests/filters.js
+++ b/tests/filters.js
@@ -2,7 +2,8 @@ describe('Filters', function() {
 
     let $filter;
 
-    beforeAll(() => window.onbeforeunload = () => 'Ignoring page reload request');
+    // Ignoring page reload request
+    beforeAll(() => window.onbeforeunload = () => null);
 
     beforeEach(function() {
 

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -2,7 +2,8 @@ describe('Helpers', function () {
 
     let stringService;
 
-    beforeAll(() => window.onbeforeunload = () => 'Ignoring page reload request');
+    // Ignoring page reload request
+    beforeAll(() => window.onbeforeunload = () => null);
 
     beforeEach(function () {
         // Load 3ema.services

--- a/tests/service/message.js
+++ b/tests/service/message.js
@@ -2,7 +2,8 @@ describe('MessageService', function() {
 
     let messageService;
 
-    beforeAll(() => window.onbeforeunload = () => 'Ignoring page reload request');
+    // Ignoring page reload request
+    beforeAll(() => window.onbeforeunload = () => null);
 
     beforeEach(function() {
 

--- a/tests/service/mime.js
+++ b/tests/service/mime.js
@@ -2,7 +2,8 @@ describe('MimeService', function() {
 
     let $service;
 
-    beforeAll(() => window.onbeforeunload = () => 'Ignoring page reload request');
+    // Ignoring page reload request
+    beforeAll(() => window.onbeforeunload = () => null);
 
     beforeEach(function() {
 

--- a/tests/service/qrcode.js
+++ b/tests/service/qrcode.js
@@ -2,7 +2,8 @@ describe('QrCodeService', function() {
 
     let $service;
 
-    beforeAll(() => window.onbeforeunload = () => 'Ignoring page reload request');
+    // Ignoring page reload request
+    beforeAll(() => window.onbeforeunload = () => null);
 
     beforeEach(function() {
 

--- a/tests/service/uri.js
+++ b/tests/service/uri.js
@@ -2,7 +2,8 @@ describe('UriService', function() {
 
     let $service;
 
-    beforeAll(() => window.onbeforeunload = () => 'Ignoring page reload request');
+    // Ignoring page reload request
+    beforeAll(() => window.onbeforeunload = () => null);
 
     beforeEach(function() {
 


### PR DESCRIPTION
Because we override the `window.onbeforeunload`, Chrome would sometimes
show a popup box when trying to close the window at the end of the tests.