### PR TITLE
Version update detection fixes

### DIFF
--- a/src/services/version.ts
+++ b/src/services/version.ts
@@ -27,6 +27,7 @@ export class VersionService {
     private $window: ng.IWindowService;
 
     private version: string;
+    private dialogShowing = false;
 
     constructor($log: ng.ILogService,
                 $http: ng.IHttpService,
@@ -114,10 +115,15 @@ export class VersionService {
      * A new version is available!
      */
     private notifyNewVersion(version: string): void {
+        if (this.dialogShowing === true) {
+            // Don't show again if dialog is already showing.
+            return;
+        }
         const confirm = this.$mdDialog.alert()
             .title(this.$translate.instant('version.NEW_VERSION', {version: version}))
             .textContent(this.$translate.instant('version.NEW_VERSION_BODY', {version: version}))
             .ok(this.$translate.instant('common.OK'));
+        this.dialogShowing = true;
         this.$mdDialog.show(confirm).then(() => {
             this.$window.location.reload();
         }, () => {

--- a/src/services/webclient.ts
+++ b/src/services/webclient.ts
@@ -451,7 +451,9 @@ export class WebClientService {
                     this._requestInitialData();
 
                     // Fetch current version
-                    this.versionService.checkForUpdate();
+                    // Delay it to prevent the dialog from being closed by the messenger constructor,
+                    // which closes all open dialogs.
+                    this.$timeout(() => this.versionService.checkForUpdate(), 7000);
 
                     // Notify state service about data loading
                     this.stateService.updateConnectionBuildupState('loading');


### PR DESCRIPTION
**Prevent version update dialog from showing twice**

The problem with this is that launching the dialog a second time will
close the first dialog, therefore triggering a page reload.

**Add delay to version check on connect**

The reason for this is that the messenger constructor closes all
potentially open dialogs. We want to avoid having our dialog closed too.

7 seconds should be plenty of time for the initial data to be loaded.