### PR TITLE
Make emoji in emoji picker larger

### DIFF
--- a/src/sass/components/_emoji_picker.scss
+++ b/src/sass/components/_emoji_picker.scss
@@ -17,6 +17,9 @@
     .e1 {
         @include mouse-hand;
         margin-bottom: 8px;
+        transform: scale(1.0);
+        margin-right: 4px;
+        margin-bottom: 12px;
     }
 
     label {
@@ -29,8 +32,8 @@
         left: 1px;
         margin-left: -1px;
         .e1 {
-            top: 0;
-            left: 0;
+            top: 3px;
+            left: 3px;
         }
     }
 


### PR DESCRIPTION
During the switch to Emojione 3 I made the emoji in the picker smaller to match the in-text size. I think that was too small though.

Before:

![before](https://user-images.githubusercontent.com/105168/26867154-77fa3a9c-4b64-11e7-9b58-838c745805bc.png)

With this PR:

![after](https://user-images.githubusercontent.com/105168/26867158-7c56a4b8-4b64-11e7-9097-7d77992b91a4.png)
