### PR TITLE
Fix Safari version detection

### DIFF
--- a/src/services/browser.ts
+++ b/src/services/browser.ts
@@ -113,6 +113,8 @@ export class BrowserService {
                         b = 'msie|edge';
                     } else if (x === 'opera') {
                         b = 'opr';
+                    } else if (x === 'safari') {
+                        b = 'version';
                     } else {
                         b = x;
                     }


### PR DESCRIPTION
The user agent string looks like this:

> Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/603.3.3 (KHTML, like Gecko) Version/10.1.2 Safari/603.3.3

Before this change it would match the version `603`, which is the layout engine. Instead, we want to match `10`, which is the major release version.