### PR TITLE
Fix TypeError in emoji insert function

### DIFF
--- a/src/directives/compose_area.ts
+++ b/src/directives/compose_area.ts
@@ -437,8 +437,10 @@ export default [
 
                     // In Chrome in right-to-left mode, our content editable
                     // area may contain a DIV element.
-                    const nestedDiv = composeDiv[0].childNodes.length === 1
-                        && composeDiv[0].childNodes[0].tagName.toLowerCase() === 'div';
+                    const childNodes = composeDiv[0].childNodes;
+                    const nestedDiv = childNodes.length === 1
+                        && childNodes[0].tagName !== undefined
+                        && childNodes[0].tagName.toLowerCase() === 'div';
                     let contentElement;
                     if (nestedDiv === true) {
                         contentElement = composeDiv[0].childNodes[0];


### PR DESCRIPTION
In Chrome, text nodes are not "real" nodes, so they don't have a `tagName` property.

Fixes #256.