### PR TITLE
Make battery icon unselectable 

### DIFF
--- a/src/sass/components/_battery.scss
+++ b/src/sass/components/_battery.scss
@@ -6,6 +6,13 @@
     &.with-percent {
         top: -18px;
     }
+    
+    md-icon {
+        -webkit-touch-callout: none;
+        -webkit-user-select: none;
+        -moz-user-select: none;
+        user-select: none;
+    }
 
     md-icon, span {
         width: 24px;


### PR DESCRIPTION
Fixes threema-ch#275

It does allow to select the percentage of the battery though, as I think this is a legitimate thing to select. (When you want to share your battery stats… :laughing:)