### PR TITLE
Deal with unknown message types

### DIFF
--- a/public/i18n/de.json
+++ b/public/i18n/de.json
@@ -148,6 +148,7 @@
         "MESSAGE_TOO_LONG_SPLIT_SUBJECT": "Nachricht aufteilen.",
         "MESSAGE_TOO_LONG_SPLIT_BODY": "Es werden maximal {max} Zeichen pro Nachricht unterstützt, wollen Sie die Nachricht in {count} separate Nachrichten aufteilen?",
         "BALLOT_MESSAGES_NOT_SUPPORTED": "Umfragen werden in Threema Web derzeit nicht untersützt.",
+        "UNKNOWN_MESSAGE_TYPE": "Unbekannter Nachrichtentyp",
         "NICKNAME": "Nickname",
         "THREEMA_WORK_CONTACT": "Threema Work Nutzer"
     },

--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -149,6 +149,7 @@
         "MESSAGE_TOO_LONG_SPLIT_SUBJECT": "Split Message",
         "MESSAGE_TOO_LONG_SPLIT_BODY": "No more than {max} characters can be sent per message, do you want to split it into {count} separate messages?",
         "BALLOT_MESSAGES_NOT_SUPPORTED": "Ballot messages are not yet supported in Threema Web.",
+        "UNKNOWN_MESSAGE_TYPE": "Unknown message type",
         "NICKNAME": "Nickname",
         "THREEMA_WORK_CONTACT": "Threema Work user"
     },

--- a/src/directives/message_media.html
+++ b/src/directives/message_media.html
@@ -91,3 +91,4 @@
 </div>
 <!-- Ballot -->
 <span ng-if="ctrl.type === 'ballot'"><em translate>messenger.BALLOT_MESSAGES_NOT_SUPPORTED</em></span> <!-- TODO -->
+<span ng-if="ctrl.type === 'unknown'"><em translate>messenger.UNKNOWN_MESSAGE_TYPE</em></span> <!-- TODO -->

--- a/src/threema.d.ts
+++ b/src/threema.d.ts
@@ -42,8 +42,10 @@ declare namespace threema {
         data?: any;
     }
 
-    type MessageType = 'text' | 'image' | 'video' | 'audio' | 'location' | 'status' | 'ballot' | 'file' | 'voipStatus';
-    type MessageState = 'delivered' | 'read' | 'send-failed' | 'sent' | 'user-ack' | 'user-dec' | 'pending' | 'sending';
+    type MessageType = 'text' | 'image' | 'video' | 'audio' | 'location' | 'contact' |
+                       'status' | 'ballot' | 'file' | 'voipStatus' | 'unknown';
+    type MessageState = 'delivered' | 'read' | 'send-failed' | 'sent' | 'user-ack' |
+                        'user-dec' | 'pending' | 'sending';
     type InitializationStep = 'client info' | 'conversations' | 'receivers';
 
     interface InitializationStepRoutine {


### PR DESCRIPTION
If the app sends the message type `"unknown"`, render messages like this:

![screenshot](https://tmp.dbrgn.ch/screenshots/20170829133336-q4urhk36.png)

The alternative would be to simply ignore the messages, but I'm not sure if that's better.