### PR TITLE
Fix TypeError when checking for file message caption

### DIFF
--- a/src/directives/message_text.ts
+++ b/src/directives/message_text.ts
@@ -40,8 +40,7 @@ export default [
                         break;
                     case 'file':
                         // Prefer caption for file messages, if available
-                        if (message.caption !== null
-                                && message.caption.length > 0) {
+                        if (message.caption && message.caption.length > 0) {
                             rawText = message.caption;
                         } else {
                             rawText = message.file.name;


### PR DESCRIPTION
When `message.caption` is `undefined`, a `TypeError` is logged to the console.

I think in this case the loosely typed equality check is fine (vs an explicit `=== undefined` check).