### PR TITLE
show caption input only on file and image messages

### DIFF
--- a/src/partials/messenger.ts
+++ b/src/partials/messenger.ts
@@ -427,6 +427,7 @@ class ConversationController {
                 case 'file':
                     // Determine file type
                     let showSendAsFileCheckbox = false;
+                    let captionSupported = false;
                     for (let msg of contents as threema.FileMessageData[]) {
                         if (!msg.fileType) {
                             msg.fileType = 'application/octet-stream';
@@ -456,7 +457,7 @@ class ConversationController {
                             <md-dialog class="send-file-dialog">
                                 <md-dialog-content class="md-dialog-content">
                                     <h2 class="md-title">${title}</h2>
-                                    <md-input-container md-no-float class="input-caption md-prompt-input-container">
+                                    <md-input-container md-no-float class="input-caption md-prompt-input-container" ng-show="ctrl.sendAsFile || ${captionSupported}">
                                         <input md-autofocus ng-keypress="ctrl.keypress($event)" ng-model="ctrl.caption" placeholder="${placeholder}" aria-label="${placeholder}">
                                     </md-input-container>
                                     <md-input-container md-no-float class="input-send-as-file md-prompt-input-container" ng-show="${showSendAsFileCheckbox}">

--- a/src/partials/messenger.ts
+++ b/src/partials/messenger.ts
@@ -432,6 +432,7 @@ class ConversationController {
                         if (!msg.fileType) {
                             msg.fileType = 'application/octet-stream';
                         }
+                        captionSupported = this.mimeService.isImage(msg.fileType);
                         if (this.mimeService.isImage(msg.fileType)
                             || this.mimeService.isAudio(msg.fileType)
                             || this.mimeService.isVideo(msg.fileType)) {

--- a/src/partials/messenger.ts
+++ b/src/partials/messenger.ts
@@ -458,7 +458,7 @@ class ConversationController {
                             <md-dialog class="send-file-dialog">
                                 <md-dialog-content class="md-dialog-content">
                                     <h2 class="md-title">${title}</h2>
-                                    <md-input-container md-no-float class="input-caption md-prompt-input-container" ng-show="ctrl.sendAsFile || ${captionSupported}">
+                                    <md-input-container md-no-float class="input-caption md-prompt-input-container" ng-show="!${showSendAsFileCheckbox} || ctrl.sendAsFile || ${captionSupported}">
                                         <input md-autofocus ng-keypress="ctrl.keypress($event)" ng-model="ctrl.caption" placeholder="${placeholder}" aria-label="${placeholder}">
                                     </md-input-container>
                                     <md-input-container md-no-float class="input-send-as-file md-prompt-input-container" ng-show="${showSendAsFileCheckbox}">

--- a/src/sass/components/_dialogs.scss
+++ b/src/sass/components/_dialogs.scss
@@ -36,5 +36,6 @@ md-dialog.send-file-dialog {
     }
     md-input-container.input-send-as-file {
         margin-top: 0;
+        margin-bottom: 0;
     }
 }


### PR DESCRIPTION
Show caption input field only if the message should send as file or the media is a image.
The app only support captions in file and image messages (not in video or audio messages).
Fix #332