### PR TITLE
Don't reload data on ICE reconnect

### DIFF
--- a/src/services/webclient.ts
+++ b/src/services/webclient.ts
@@ -413,13 +413,6 @@ export class WebClientService {
 
             // On state changes in the PeerConnectionHelper class, let state service know about it
             this.pcHelper.onConnectionStateChange = (state: threema.RTCConnectionState) => {
-                if (state === 'connected' && this.stateService.wasConnected) {
-                    // This happens if a lost connection could be restored
-                    // without resetting the peer connection.
-                    // Request initial data again, since some packets could have been lost
-                    // while the connection was gone.
-                    this._requestInitialData();
-                }
                 this.stateService.updateRtcConnectionState(state);
             };
 


### PR DESCRIPTION
If the ICE connection manages to reconnect, no data loss should occur on
a reliable DataChannel connection. Therefore we don't need to reload the
initial data again.

Thanks @lgrahl for spotting :)