### PR TITLE
Link to changelog from version update alert dialog

### DIFF
--- a/public/i18n/de.json
+++ b/public/i18n/de.json
@@ -232,7 +232,7 @@
     },
     "version": {
         "NEW_VERSION": "Neue Version Verfügbar",
-        "NEW_VERSION_BODY": "Eine neue Version von Threema Web ({version}) ist verfügbar. Mehr Informationen finden Sie im {changelog}. Drücken Sie \"OK\" um die Seite neu zu laden."
+        "NEW_VERSION_BODY": "Eine neue Version von Threema Web ({version}) ist verfügbar. Mehr Informationen finden Sie im {changelog}. Drücken Sie \"OK\" um das Update zu aktivieren."
     },
     "voip": {
         "CALL_MISSED": "Verpasster Anruf",

--- a/public/i18n/de.json
+++ b/public/i18n/de.json
@@ -232,7 +232,7 @@
     },
     "version": {
         "NEW_VERSION": "Neue Version Verfügbar",
-        "NEW_VERSION_BODY": "Eine neue Version von Threema Web ({version}) ist verfügbar. Drücken Sie \"OK\" um die Seite neu zu laden."
+        "NEW_VERSION_BODY": "Eine neue Version von Threema Web ({version}) ist verfügbar. Mehr Informationen finden Sie im {changelog}. Drücken Sie \"OK\" um die Seite neu zu laden."
     },
     "voip": {
         "CALL_MISSED": "Verpasster Anruf",

--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -232,7 +232,7 @@
     },
     "version": {
         "NEW_VERSION": "New Version Available",
-        "NEW_VERSION_BODY": "A new version of Threema Web ({version}) is available. Check out the {changelog} for more information. Click \"OK\" to reload the page."
+        "NEW_VERSION_BODY": "A new version of Threema Web ({version}) is available. Check out the {changelog} for more information. Click \"OK\" to activate the update."
     },
     "voip": {
         "CALL_MISSED": "Missed call",

--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -232,7 +232,7 @@
     },
     "version": {
         "NEW_VERSION": "New Version Available",
-        "NEW_VERSION_BODY": "A new version of Threema Web ({version}) is available. Click \"OK\" to reload the page."
+        "NEW_VERSION_BODY": "A new version of Threema Web ({version}) is available. Check out the {changelog} for more information. Click \"OK\" to reload the page."
     },
     "voip": {
         "CALL_MISSED": "Missed call",

--- a/src/services/version.ts
+++ b/src/services/version.ts
@@ -119,9 +119,14 @@ export class VersionService {
             // Don't show again if dialog is already showing.
             return;
         }
+        const changelogUrl = 'https://github.com/threema-ch/threema-web/blob/master/CHANGELOG.md';
+        const changelogLink = '<a href="' + changelogUrl + '" target="_blank">Changelog</a>';
         const confirm = this.$mdDialog.alert()
-            .title(this.$translate.instant('version.NEW_VERSION', {version: version}))
-            .textContent(this.$translate.instant('version.NEW_VERSION_BODY', {version: version}))
+            .title(this.$translate.instant('version.NEW_VERSION'))
+            .htmlContent(this.$translate.instant('version.NEW_VERSION_BODY', {
+                version: version,
+                changelog: changelogLink,
+            }))
             .ok(this.$translate.instant('common.OK'));
         this.dialogShowing = true;
         this.$mdDialog.show(confirm).then(() => {


### PR DESCRIPTION
When notifying the user about a new version of Threema Web, link to the changelog.

![screenshot](https://tmp.dbrgn.ch/screenshots/20171025092902-kfsqdu5u.png)