### PR TITLE
Use powershell to build the "dist" package on Windows

### DIFF
--- a/dist/build-package.js
+++ b/dist/build-package.js
@@ -1,15 +1,12 @@
-var exec = require('child_process').exec;
-function puts(error, stdout, stderr) { console.log(stdout) }
-
+var spawn = require('child_process').spawn;
 var os = require('os');
-//control OS
-//then run command depengin on the OS
 
-if (os.type() === 'Linux') 
-   exec("dist/package.sh", puts); 
-else if (os.type() === 'Darwin') 
-   exec("dist/package.sh", puts); 
-else if (os.type() === 'Windows_NT') 
-   exec("powershell dist/package.sh", puts);
-else
+if (os.type() === 'Linux') {
+   spawn('bash', ['dist/package.sh'], {stdio: 'inherit'});
+} else if (os.type() === 'Darwin') {
+   spawn('bash', ['dist/package.sh'], {stdio: 'inherit'});
+} else if (os.type() === 'Windows_NT') {
+   spawn('powershell', ['dist/package.sh'], {stdio: 'inherit'});
+} else {
    throw new Error("Unsupported OS found: " + os.type());
+}

--- a/dist/build-package.js
+++ b/dist/build-package.js
@@ -1,0 +1,15 @@
+var exec = require('child_process').exec;
+function puts(error, stdout, stderr) { console.log(stdout) }
+
+var os = require('os');
+//control OS
+//then run command depengin on the OS
+
+if (os.type() === 'Linux') 
+   exec("dist/package.sh", puts); 
+else if (os.type() === 'Darwin') 
+   exec("dist/package.sh", puts); 
+else if (os.type() === 'Windows_NT') 
+   exec("powershell dist/package.sh", puts);
+else
+   throw new Error("Unsupported OS found: " + os.type());

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build:js": "browserify -p tsify src/app.ts -t [ babelify --presets [ es2015 ] --extensions .ts ] -p [ browserify-header --file header.js ] -o dist/app.js",
     "build:css": "node-sass -o public/css/ --output-style compressed src/sass/",
     "build:css:watch": "node-sass -w -r --source-map true --source-map-embed true -o public/css/ --output-style compressed src/sass/",
-    "dist": "npm run build && echo \"\" && dist/package.sh",
+    "dist": "npm run build && echo \"\" && node dist/build-package.js",
     "serve": "npm run build:css && budo src/app.ts:dist/app.js -- -d -p tsify -t [ babelify --presets [ es2015 ] --extensions .ts ]",
     "serve:live": "npm run build:css && concurrently --kill-others --names \"css,server\" -p name \"npm run build:css:watch\" \"budo src/app.ts:dist/app.js -d . -d public -d src --live -- -d -p tsify -t [ babelify --presets [ es2015 ] --extensions .ts ]\"",
     "test": "karma start --single-run --log-level=debug --colors",


### PR DESCRIPTION
Hi,
I started to work with the repository on my Windows system today and noticed that it was not possible to build the web package with "npm run dist", because the script were not able to invoke the "package.sh" in the "dist" folder. However, if I invoked it manually from my Powershell window, it is working fine (it invokes the bash in the Ubuntu subsystem that I have installed on my system).
To build the distribution package on my system I added the "build-package.js" in the "dist" directory that decides how the "package.sh" script shall be invoked on the different systems and added "powershell" to the command invokation on Windows systems. The "dist" script in the "package.json" was modified to invoke the "build-package.js" script with Node.js. Now it should build fine on Windows systems, too.

CU Tim