### PR TITLE
Firefox: Workaround for missing caret between emoji

### DIFF
--- a/src/sass/sections/_compose_area.scss
+++ b/src/sass/sections/_compose_area.scss
@@ -32,14 +32,16 @@
                     top: 0;
                     left: 0;
                     outline: none;
-                    line-height: 1.3em;
+                    line-height: 20px;
                     max-height: calc(1.3em * 5);
-                    min-height: 1.3em;
+                    min-height: 22px;
                     cursor: text;
 
-                    img {
+                    img.e1 {
                         vertical-align: middle;
-                        margin: -3px 1px;
+                        margin: 0 1px;
+                        transform: none; // https://github.com/threema-ch/threema-web/issues/262
+                        height: 20px;
                     }
                 }
             }


### PR DESCRIPTION
In Firefox, the caret between images inside a contenteditable div
disappears when the images are scaled using CSS transforms.

As a workaround, use regular height.

Firefox:

![ff](https://user-images.githubusercontent.com/105168/32774029-53ea9d0a-c92b-11e7-9d65-8f85c6deb705.png)

Chromium:

![chromium](https://user-images.githubusercontent.com/105168/32774035-563bd060-c92b-11e7-8a2e-3d6da5ec4f78.png)

The caret is still a bit offset to the bottom of the emoji (at least in Firefox), I didn't really find a fix for that. But it's barely visible.

Fixes #262 