### PR TITLE
Fix multiple issues with compose area and drafts

### DIFF
--- a/src/partials/messenger.ts
+++ b/src/partials/messenger.ts
@@ -549,7 +549,7 @@ class ConversationController {
     /**
      * We started typing.
      */
-    public startTyping = (text: string) => {
+    public startTyping = () => {
         if (this.stopTypingTimer === null) {
             // Notify app
             this.webClientService.sendMeIsTyping(this.$stateParams, true);


### PR DESCRIPTION
- Sometimes the compose area would think it's non empty even when it is (e.g. when inserting a newline and deleting it again)
- Drafts did not store emoji
- Sometimes it was possible to submit text only consisting of whitespace characters, resulting in an error message

The empty checking is now unified and always uses the `getText()` function.