### PR TITLE
Fix cut off emoji in media box caption

### DIFF
--- a/src/sass/components/_mediabox.scss
+++ b/src/sass/components/_mediabox.scss
@@ -99,6 +99,7 @@ mediabox {
                 overflow: hidden;
                 white-space: nowrap;
                 text-overflow: ellipsis;
+                line-height: 1.3em;
             }
         }
     }


### PR DESCRIPTION
Before:

![screenshot](https://tmp.dbrgn.ch/screenshots/20171127110940-7aksp058.png)

After:

![screenshot](https://tmp.dbrgn.ch/screenshots/20171127111013-tx014ahh.png)