### PR TITLE
Workaround for sending .ogg audio in Firefox

### DIFF
--- a/src/directives/compose_area.ts
+++ b/src/directives/compose_area.ts
@@ -354,6 +354,14 @@ export default [
                                 size: file.size,
                                 data: buffer,
                             };
+
+                            // Workaround for https://bugzilla.mozilla.org/show_bug.cgi?id=1240259
+                            if (browserService.getBrowser().firefox) {
+                                if (fileMessageData.name.endsWith('.ogg') && fileMessageData.fileType === 'video/ogg') {
+                                    fileMessageData.fileType = 'audio/ogg';
+                                }
+                            }
+
                             fileMessages.push(fileMessageData);
                         });
                         scope.submit('file', fileMessages);


### PR DESCRIPTION
Firefox detects any .ogg file as `video/ogg`, instead of `audio/ogg`.

While Ogg is a general purpose container format and may contain both
audio and video, in most cases it will probably contain audio. The
Xiph.org foundation recommends to use the extensions `.ogv` and `.oga`
which should clear up any confusion.

This is reported as Firefox bug 1240259:
https://bugzilla.mozilla.org/show_bug.cgi?id=1240259

As a workaround, simply convert `video/ogg` to `audio/ogg` when using
Firefox.