### PR TITLE
Show a dialog when local storage cannot be accessed

### DIFF
--- a/public/i18n/de.json
+++ b/public/i18n/de.json
@@ -35,6 +35,7 @@
         "MANUAL_START_STEP3": "Wählen Sie im Menu \"Sitzung starten\"",
         "MORE_ABOUT_WEB": "Mehr über Threema Web",
         "LOCAL_STORAGE_MISSING_DETAILS": "Zugriff auf LocalStorage ist nicht möglich. Dieses Problem kann auftreten, wenn in Ihrem Browser Cookies blockiert werden, oder wenn ein Browser-Add-On installiert ist, welches den Zugriff auf LocalStorage blockiert. Bitte erlauben Sie die Nutzung von LocalStorage in Ihrem Browser oder deaktivieren Sie die installierten Browser-Add-Ons.",
+        "LOCAL_STORAGE_EXCEPTION_DETAILS": "Kritischer Fehler beim Zugriff auf LocalStorage: {errorMsg}.<br>Bitte starten Sie Ihren Browser neu.",
         "ALREADY_CONNECTED": "Bereits Verbunden",
         "ALREADY_CONNECTED_DETAILS": "Sie sind bereits in einem anderen Tab oder Fenster mit Threema Web verbunden!"
     },

--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -35,6 +35,7 @@
         "MANUAL_START_STEP3": "Select \"Start session\" to start the session",
         "MORE_ABOUT_WEB": "More about Threema Web",
         "LOCAL_STORAGE_MISSING_DETAILS": "Access to LocalStorage not possible. This can occur if your browser is configured to reject cookies, or if you installed a browser add-on that blocks access to LocalStorage. Please allow local storage in your browser settings or disable any add-ons you might have installed.",
+        "LOCAL_STORAGE_EXCEPTION_DETAILS": "Critical error when accessing LocalStorage: {errorMsg}.<br>Try restarting your browser.",
         "ALREADY_CONNECTED": "Already Connected",
         "ALREADY_CONNECTED_DETAILS": "You are already connected to Threema Web in another tab or window!"
     },

--- a/src/partials/welcome.ts
+++ b/src/partials/welcome.ts
@@ -158,13 +158,22 @@ class WelcomeController {
         // Clear cache
         this.webClientService.clearCache();
 
+        // Determine whether trusted key is available
+        let hasTrustedKey = null;
+        try {
+            hasTrustedKey = this.TrustedKeyStore.hasTrustedKey();
+        } catch (e) {
+            $log.error('Exception while accessing local storage:', e);
+            this.showLocalStorageException(e);
+        }
+
         // Determine connection mode
         if ($stateParams.initParams !== null) {
             this.mode = 'unlock';
             const keyStore = $stateParams.initParams.keyStore;
             const peerTrustedKey = $stateParams.initParams.peerTrustedKey;
             this.reconnect(keyStore, peerTrustedKey);
-        } else if (TrustedKeyStore.hasTrustedKey()) {
+        } else if (hasTrustedKey) {
             this.mode = 'unlock';
             this.unlock();
         } else {
@@ -372,6 +381,21 @@ class WelcomeController {
             const confirm = this.$mdDialog.alert()
                 .title(this.$translate.instant('common.ERROR'))
                 .htmlContent(this.$translate.instant('welcome.LOCAL_STORAGE_MISSING_DETAILS'))
+                .ok(this.$translate.instant('common.OK'));
+            this.$mdDialog.show(confirm);
+        });
+    }
+
+    /**
+     * Show a dialog indicating that local storage cannot be accessed.
+     */
+    private showLocalStorageException(e: Error): void {
+        this.$translate.onReady().then(() => {
+            const confirm = this.$mdDialog.alert()
+                .title(this.$translate.instant('common.ERROR'))
+                .htmlContent(this.$translate.instant('welcome.LOCAL_STORAGE_EXCEPTION_DETAILS', {
+                    errorMsg: e.name,
+                }))
                 .ok(this.$translate.instant('common.OK'));
             this.$mdDialog.show(confirm);
         });


### PR DESCRIPTION
It's possible that I/O errors happen when accessing the SQLite database backing the local storage. In that case, accessing the data will result in an exception.

It happened twice to me over the last few weeks or months, both times after a browser crash. In that case, the login form looks like this:

![screenshot](https://tmp.dbrgn.ch/white.png)

So instead we should show an error dialog:

![screenshot](https://tmp.dbrgn.ch/ioerror.png)

Restarting Firefox helped in this case.