### PR TITLE
nlToBr filter: Fallback if enable flag is not set

### DIFF
--- a/src/filters.ts
+++ b/src/filters.ts
@@ -41,11 +41,11 @@ angular.module('3ema.filters', [])
 })
 
 /**
- * Convert newline characters with a <br> tag.
+ * Replace newline characters with a <br> tag.
  */
 .filter('nlToBr', function() {
     return (text, enabled: boolean) => {
-        if (enabled) {
+        if (enabled || enabled === undefined) {
             text = text.replace(/\n/g, '<br>');
         }
         return text;

--- a/tests/filters.js
+++ b/tests/filters.js
@@ -199,4 +199,25 @@ describe('Filters', function() {
         });
     });
 
+    describe('nlToBr', function() {
+
+        this.testPatterns = (cases) => testPatterns('nlToBr', cases);
+
+        it('converts newlines (enabled=true)', () => {
+            const filter = $filter('nlToBr');
+            expect(filter('abc \n def', true)).toEqual('abc <br> def');
+            expect(filter('a\nb\nc\\n', true)).toEqual('a<br>b<br>c\\n');
+        });
+
+        it('does not converts newlines (enabled=false)', () => {
+            const filter = $filter('nlToBr');
+            expect(filter('abc\ndef', false)).toEqual('abc\ndef');
+        });
+
+        it('if enabled flag is not set, converts newlines', () => {
+            const filter = $filter('nlToBr');
+            expect(filter('abc\ndef')).toEqual('abc<br>def');
+        });
+    });
+
 });


### PR DESCRIPTION
If the enable flag is not specified, the filter should do it's job.

Fixes #413