### PR TITLE
Prevent drag of background image

### DIFF
--- a/src/sass/layout/_main.scss
+++ b/src/sass/layout/_main.scss
@@ -10,6 +10,7 @@
     -moz-user-select: none;
     -webkit-user-select: none;
     user-select: none;
+    pointer-events: none;
 }
 
 #main-wrapper {


### PR DESCRIPTION
There are many ways to do this (https://stackoverflow.com/questions/4211909/disable-dragging-an-image-from-an-html-page), so I just chose this one. It may also prevent other useless things of the background image.

Tested in Firefox 58.