### PR TITLE
Add gray background to download icon

### DIFF
--- a/src/sass/components/_message_media.scss
+++ b/src/sass/components/_message_media.scss
@@ -43,6 +43,8 @@ $loading-ring-thickness: 5px;
             color: white;
             margin: auto auto;
             position: relative;
+            background: rgba(128, 128, 128, .3);
+            border-radius: $material-radius;
         }
     }
 


### PR DESCRIPTION
Old:
![bildschirmfoto_2018-02-19_10-36-34](https://user-images.githubusercontent.com/8258609/36370932-d70c9694-1560-11e8-8a61-ec4111fbc4f9.png)
New:
![bildschirmfoto_2018-02-19_09-44-01](https://user-images.githubusercontent.com/8258609/36370887-a2dfd642-1560-11e8-929f-0e77302efad3.png)

I am not sure, if I put the changes into the right place. In my example it affected the `i` element, not ` img`. However, it was defined together so I  put it there. Please adjust if needed!
