### PR TITLE
Add gray background to video play icon

### DIFF
--- a/src/sass/components/_message_media.scss
+++ b/src/sass/components/_message_media.scss
@@ -122,6 +122,8 @@ $loading-ring-thickness: 5px;
                     position: absolute;
                     top: calc(50% - #{$circle-size/2});
                     left: calc(50% - #{$circle-size/2});
+                    background: rgba(128, 128, 128, 0.6);
+                    border-radius: $circle-size - (2 * $loading-ring-thickness);
                 }
             }
         }


### PR DESCRIPTION
Old:
![b](https://user-images.githubusercontent.com/8258609/36372355-164faac2-1565-11e8-9570-e68f256f455b.png)
New:
![a](https://user-images.githubusercontent.com/8258609/36372347-129f4b6c-1565-11e8-8d25-b6c37cce6061.png)

It makes the play icon visible if the video thumbnail is white.
Not sure if I put the changes to the right place, please check.
