### PR TITLE
Fix supportsPassive helper function

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -232,7 +232,7 @@ export function throttle(fn, threshold: number = 250, scope) {
  *
  * Taken from https://github.com/WICG/EventListenerOptions/blob/gh-pages/explainer.md
  */
-export function supportsPassive() {
+export function supportsPassive(): boolean {
     // Test via a getter in the options object to see if the passive property is accessed
     let support = false;
     try {
@@ -241,6 +241,7 @@ export function supportsPassive() {
         });
         window.addEventListener('test', null, opts);
     } catch (e) { /* do nothing */ }
+    return support;
 }
 
 /**

--- a/src/partials/messenger.ts
+++ b/src/partials/messenger.ts
@@ -299,7 +299,7 @@ class ConversationController {
                 $rootScope.$apply(() => {
                     this.updateScrollJump();
                 });
-            }, 100, this), supportsPassive() ? {passive: true} as any : false);
+            }, 100, this), supportsPassive() ? {passive: true} : false);
         }
 
         // Set receiver and type


### PR DESCRIPTION
Due to missing type annotations, we did not notice that no value was
returned. Thus passive event listeners were always turned off.

Fixing the detection might improve scroll performance on newer browsers.
See https://github.com/WICG/EventListenerOptions/blob/gh-pages/explainer.md