### PR TITLE
Change location of in-view-indicator

### DIFF
--- a/src/directives/message_media.html
+++ b/src/directives/message_media.html
@@ -1,6 +1,5 @@
 <!-- Thumbnail -->
 <!-- Images, Gifs & Videos -->
-<span class="in-view-indicator" ng-if="ctrl.type !== 'location'" in-view="ctrl.thumbnailInView($inview)"></span>
 
 <div ng-if="ctrl.uploading">
     <!-- Loading indicator -->
@@ -27,6 +26,7 @@
         </div>
 
         <!-- Thumbnails -->
+        <span class="in-view-indicator" ng-if="ctrl.type !== 'location'" in-view="ctrl.thumbnailInView($inview)"></span>
         <img ng-if="ctrl.thumbnail !== null" ng-src="{{ctrl.thumbnail}}">
         <div ng-if="ctrl.message.thumbnail != undefined" class="thumbnail-loader">
             <img ng-src="{{ ctrl.message.thumbnail.preview | bufferToUrl: 'image/png' }}">


### PR DESCRIPTION
The in-view-indicator covered the whole chat-bubble instead of the thumbnail thus overlaying the description (and possible links).

Fixes #303 