### PR TITLE
Deep copy objects printed to debug console

### DIFF
--- a/src/services/webclient.ts
+++ b/src/services/webclient.ts
@@ -494,7 +494,9 @@ export class WebClientService {
                 }
 
                 if (this.config.MSG_DEBUGGING) {
-                    this.$log.debug('[Message] Incoming:', message.type, '/', message.subType, message);
+                    // Deep copy message to prevent issues with JS debugger
+                    const deepcopy = JSON.parse(JSON.stringify(message));
+                    this.$log.debug('[Message] Incoming:', message.type, '/', message.subType, deepcopy);
                 }
 
                 // Process data


### PR DESCRIPTION
If this is not being done, then modifications done to the objects later on will be reflected in the object logged.

This cost me about 1.5h of totally confused debugging :woman_facepalming: 