### PR TITLE
Fix contact selector

### DIFF
--- a/src/directives/member_list_editor.ts
+++ b/src/directives/member_list_editor.ts
@@ -57,7 +57,7 @@ export default [
                         return [];
                     } else {
                         // search for contacts, do not show selected contacts
-                        const lowercaseQuery = angular.lowercase(query);
+                        const lowercaseQuery = query.toLowerCase();
                         const result = this.allContacts.filter((contactReceiver: threema.ContactReceiver) => {
                             return this.members.filter((identity: string) => {
                                     return identity === contactReceiver.id;


### PR DESCRIPTION
The `angular.lowercase` function was removed in AngularJS 1.7.

Fixes #549.