### PR TITLE
Handshake & ACK protocol

### DIFF
--- a/index.html
+++ b/index.html
@@ -121,6 +121,7 @@
     <script src="libs/emojione/emojione.min.js?v=[[VERSION]]"></script>
     <script src="node_modules/angularjs-scroll-glue/src/scrollglue.js?v=[[VERSION]]"></script>
     <script src="libs/angular-inview/angular-inview.js?v=[[VERSION]]"></script>
+    <script src="libs/future.js?v=[[VERSION]]"></script>
 
     <!-- Translation -->
     <script src="node_modules/messageformat/messageformat.min.js?v=[[VERSION]]"></script>

--- a/public/i18n/de.json
+++ b/public/i18n/de.json
@@ -326,6 +326,7 @@
         "SESSION_STOPPED": "Die Sitzung wurde auf Ihrem Gerät gestoppt.",
         "SESSION_DELETED": "Die Sitzung wurde auf Ihrem Gerät gelöscht.",
         "WEBCLIENT_DISABLED": "Threema Web wurde auf Ihrem Gerät deaktiviert.",
-        "SESSION_REPLACED": "Die Sitzung wurde beendet, weil Sie eine andere Sitzung gestartet haben."
+        "SESSION_REPLACED": "Die Sitzung wurde beendet, weil Sie eine andere Sitzung gestartet haben.",
+        "SESSION_ERROR": "Die Sitzung wurde auf Grund eines Protokollfehlers beendet."
     }
 }

--- a/public/i18n/de.json
+++ b/public/i18n/de.json
@@ -52,7 +52,8 @@
         "WAITING_FOR_APP_MANUAL": "Google Play Services nicht installiert. Bitte starten Sie die Sitzung manuell.",
         "CONNECTING_TO_SERVER": "Verbinden mit Server\u2026",
         "CONNECTING_TO_APP": "Verbindung zu App wird aufgebaut\u2026",
-        "CONNECTION_CLOSED": "Server-Verbindung wurde geschlossen."
+        "CONNECTION_CLOSED": "Server-Verbindung wurde geschlossen.",
+        "RECONNECT_FAILED": "Verbindung zur App fehlgeschlagen."
     },
     "troubleshooting": {
         "SLOW_CONNECT": "Verbindungsaufbau scheint länger zu dauern<br>als normal …",

--- a/public/i18n/de.json
+++ b/public/i18n/de.json
@@ -327,6 +327,6 @@
         "SESSION_DELETED": "Die Sitzung wurde auf Ihrem Gerät gelöscht.",
         "WEBCLIENT_DISABLED": "Threema Web wurde auf Ihrem Gerät deaktiviert.",
         "SESSION_REPLACED": "Die Sitzung wurde beendet, weil Sie eine andere Sitzung gestartet haben.",
-        "SESSION_ERROR": "Die Sitzung wurde auf Grund eines Protokollfehlers beendet."
+        "SESSION_ERROR": "Die Sitzung wurde aufgrund eines Protokollfehlers beendet."
     }
 }

--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -52,7 +52,8 @@
         "WAITING_FOR_APP_MANUAL": "Google Play Services not installed. Please start the session manually.",
         "CONNECTING_TO_SERVER": "Connecting to server\u2026",
         "CONNECTING_TO_APP": "Connection to app is being established\u2026",
-        "CONNECTION_CLOSED": "Connection to server has been closed."
+        "CONNECTION_CLOSED": "Connection to server has been closed.",
+        "RECONNECT_FAILED": "Connecting to app failed."
     },
     "troubleshooting": {
         "SLOW_CONNECT": "Connecting seems to take longer than usual …",

--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -325,6 +325,7 @@
         "SESSION_STOPPED": "The session was stopped on your device.",
         "SESSION_DELETED": "The session was deleted on your device.",
         "WEBCLIENT_DISABLED": "Threema Web was disabled on your device.",
-        "SESSION_REPLACED": "This session was stopped because you started a Threema Web session in another browser window."
+        "SESSION_REPLACED": "This session was stopped because you started a Threema Web session in another browser window.",
+        "SESSION_ERROR": "The session was stopped due to a protocol error."
     }
 }

--- a/public/libs/future.js
+++ b/public/libs/future.js
@@ -1,0 +1,45 @@
+'use strict';
+
+/**
+ * A future similar to Python's asyncio.Future. Allows to resolve or reject
+ * outside of the executor and query the current status.
+ */
+class Future extends Promise {
+    constructor(executor) {
+        let resolve, reject;
+        super((resolve_, reject_) => {
+            resolve = resolve_;
+            reject = reject_;
+            if (executor) {
+                return executor(resolve_, reject_);
+            }
+        });
+
+        this._done = false;
+        this._resolve = resolve;
+        this._reject = reject;
+    }
+
+    /**
+     * Return whether the future is done (resolved or rejected).
+     */
+    get done() {
+        return this._done;
+    }
+
+    /**
+     * Resolve the future.
+     */
+    resolve(...args) {
+        this._done = true;
+        return this._resolve(...args);
+    }
+
+    /**
+     * Reject the future.
+     */
+    reject(...args) {
+        this._done = true;
+        return this._reject(...args);
+    }
+}

--- a/src/controllers/status.ts
+++ b/src/controllers/status.ts
@@ -197,7 +197,11 @@ export class StatusController {
 
         // Function to soft-reconnect. Does not reset the loaded data.
         const doSoftReconnect = () => {
-            this.webClientService.stop(threema.DisconnectReason.SessionStopped, true, false, false);
+            this.webClientService.stop(threema.DisconnectReason.SessionStopped, {
+                send: true,
+                close: false,
+                redirect: false,
+            });
             this.webClientService.init(originalKeyStore, originalPeerPermanentKeyBytes, true);
             this.webClientService.start().then(
                 () => {
@@ -267,7 +271,11 @@ export class StatusController {
         // TODO: Make this more robust and hopefully faster
         const startTimeout = 500;
         this.$log.debug(this.logTag, 'Stopping old connection');
-        this.webClientService.stop(threema.DisconnectReason.SessionStopped, true, false, false);
+        this.webClientService.stop(threema.DisconnectReason.SessionStopped, {
+            send: true,
+            close: false,
+            redirect: false,
+        });
         this.$timeout(() => {
             this.$log.debug(this.logTag, 'Starting new connection');
             this.webClientService.init(originalKeyStore, originalPeerPermanentKeyBytes, true);

--- a/src/controllers/status.ts
+++ b/src/controllers/status.ts
@@ -197,10 +197,8 @@ export class StatusController {
 
         // Function to soft-reconnect. Does not reset the loaded data.
         const doSoftReconnect = () => {
-            const resetPush = false;
-            const redirect = false;
-            this.webClientService.stop(true, threema.DisconnectReason.SessionStopped, resetPush, redirect);
-            this.webClientService.init(originalKeyStore, originalPeerPermanentKeyBytes, false);
+            this.webClientService.stop(threema.DisconnectReason.SessionStopped, true, false, false);
+            this.webClientService.init(originalKeyStore, originalPeerPermanentKeyBytes, true);
             this.webClientService.start().then(
                 () => {
                     // Cancel timeout
@@ -264,15 +262,15 @@ export class StatusController {
             });
         };
 
-        const resetPush = false;
         const skipPush = true;
-        const redirect = false;
-        const startTimeout = 500; // Delay connecting a bit to wait for old websocket to close
+        // Delay connecting a bit to wait for old websocket to close
+        // TODO: Make this more robust and hopefully faster
+        const startTimeout = 500;
         this.$log.debug(this.logTag, 'Stopping old connection');
-        this.webClientService.stop(true, threema.DisconnectReason.SessionStopped, resetPush, redirect);
+        this.webClientService.stop(threema.DisconnectReason.SessionStopped, true, false, false);
         this.$timeout(() => {
             this.$log.debug(this.logTag, 'Starting new connection');
-            this.webClientService.init(originalKeyStore, originalPeerPermanentKeyBytes, false);
+            this.webClientService.init(originalKeyStore, originalPeerPermanentKeyBytes, true);
             this.webClientService.start(skipPush).then(
                 () => { /* ok */ },
                 (error) => {

--- a/src/controllers/status.ts
+++ b/src/controllers/status.ts
@@ -29,7 +29,7 @@ import DisconnectReason = threema.DisconnectReason;
  *
  * It also controls auto-reconnecting and the connection status indicator bar.
  *
- * Status updates should be done through the status service.
+ * Status updates should be done through the state service.
  */
 export class StatusController {
 
@@ -275,9 +275,12 @@ export class StatusController {
             this.$state.go('welcome');
         };
 
+        // Only send a push if never left the 'welcome' page or if there are
+        // one or more cached chunks that require immediate sending.
+        const skipPush = !this.$state.includes('welcome') && !this.webClientService.immediateChunksPending;
+
         // Delay connecting a bit to wait for old websocket to close
         // TODO: Make this more robust and hopefully faster
-        const skipPush = !this.$state.includes('welcome');
         const startTimeout = 500;
         this.$log.debug(this.logTag, 'Stopping old connection');
         this.webClientService.stop({

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -338,3 +338,19 @@ export function hasValue(val: any): boolean {
 export function sleep(ms: number): Promise<void> {
     return new Promise((resolve) => setTimeout(resolve, ms));
 }
+
+/**
+ * Compare two Uint8Array instances. Return true if all elements are equal
+ * (compared using ===).
+ */
+export function arraysAreEqual(a1: Uint8Array, a2: Uint8Array): boolean {
+    if (a1.length !== a2.length) {
+        return false;
+    }
+    for (let i = 0; i < a1.length; i++) {
+        if (a1[i] !== a2[i]) {
+            return false;
+        }
+    }
+    return true;
+}

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -258,7 +258,7 @@ export function escapeRegExp(str: string) {
  * msgpack encoded data.
  */
 export function msgpackVisualizer(bytes: Uint8Array): string {
-    return 'https://msgpack.dbrgn.ch#base64=' + encodeURIComponent(btoa(bytes as any));
+    return 'https://msgpack.dbrgn.ch#base64=' + encodeURIComponent(btoa(String.fromCharCode.apply(null, bytes)));
 }
 
 /**

--- a/src/partials/messenger.ts
+++ b/src/partials/messenger.ts
@@ -585,6 +585,9 @@ class ConversationController {
                         `,
                         // tslint:enable:max-line-length
                     }).then((data) => {
+                        // TODO: This should probably be moved into the
+                        //       WebClientService as a specific method for the
+                        //       type.
                         const caption = data.caption;
                         const sendAsFile = data.sendAsFile;
                         contents.forEach((msg: threema.FileMessageData, index: number) => {
@@ -592,7 +595,7 @@ class ConversationController {
                                 msg.caption = caption;
                             }
                             msg.sendAsFile = sendAsFile;
-                            this.webClientService.sendMessage(this.$stateParams, type, msg)
+                            this.webClientService.sendMessage(this.$stateParams, type, true, msg)
                                 .then(() => {
                                     nextCallback(index);
                                 })
@@ -612,7 +615,10 @@ class ConversationController {
                         // remove quote
                         this.webClientService.setQuote(this.receiver);
                         // send message
-                        this.webClientService.sendMessage(this.$stateParams, type, msg)
+                        // TODO: This should probably be moved into the
+                        //       WebClientService as a specific method for the
+                        //       type.
+                        this.webClientService.sendMessage(this.$stateParams, type, true, msg)
                             .then(() => {
                                 nextCallback(index);
                             })

--- a/src/partials/messenger.ts
+++ b/src/partials/messenger.ts
@@ -1009,7 +1009,8 @@ class NavigationController {
             .ok(this.$translate.instant('common.YES'))
             .cancel(this.$translate.instant('common.CANCEL'));
         this.$mdDialog.show(confirm).then(() => {
-            this.webClientService.stop(threema.DisconnectReason.SessionStopped, {
+            this.webClientService.stop({
+                reason: threema.DisconnectReason.SessionStopped,
                 send: true,
                 close: true,
                 redirect: true,
@@ -1031,7 +1032,8 @@ class NavigationController {
             .ok(this.$translate.instant('common.YES'))
             .cancel(this.$translate.instant('common.CANCEL'));
         this.$mdDialog.show(confirm).then(() => {
-            this.webClientService.stop(threema.DisconnectReason.SessionDeleted, {
+            this.webClientService.stop({
+                reason: threema.DisconnectReason.SessionDeleted,
                 send: true,
                 close: true,
                 redirect: true,

--- a/src/partials/messenger.ts
+++ b/src/partials/messenger.ts
@@ -1009,7 +1009,11 @@ class NavigationController {
             .ok(this.$translate.instant('common.YES'))
             .cancel(this.$translate.instant('common.CANCEL'));
         this.$mdDialog.show(confirm).then(() => {
-            this.webClientService.stop(threema.DisconnectReason.SessionStopped, true, true, true);
+            this.webClientService.stop(threema.DisconnectReason.SessionStopped, {
+                send: true,
+                close: true,
+                redirect: true,
+            });
             this.receiverService.setActive(undefined);
         }, () => {
             // do nothing
@@ -1027,7 +1031,11 @@ class NavigationController {
             .ok(this.$translate.instant('common.YES'))
             .cancel(this.$translate.instant('common.CANCEL'));
         this.$mdDialog.show(confirm).then(() => {
-            this.webClientService.stop(threema.DisconnectReason.SessionDeleted, true, true, true);
+            this.webClientService.stop(threema.DisconnectReason.SessionDeleted, {
+                send: true,
+                close: true,
+                redirect: true,
+            });
             this.receiverService.setActive(undefined);
         }, () => {
             // do nothing

--- a/src/partials/messenger.ts
+++ b/src/partials/messenger.ts
@@ -1003,9 +1003,7 @@ class NavigationController {
             .ok(this.$translate.instant('common.YES'))
             .cancel(this.$translate.instant('common.CANCEL'));
         this.$mdDialog.show(confirm).then(() => {
-            const resetPush = true;
-            const redirect = true;
-            this.webClientService.stop(true, threema.DisconnectReason.SessionStopped, resetPush, redirect);
+            this.webClientService.stop(threema.DisconnectReason.SessionStopped, true, true, true);
             this.receiverService.setActive(undefined);
         }, () => {
             // do nothing
@@ -1023,9 +1021,7 @@ class NavigationController {
             .ok(this.$translate.instant('common.YES'))
             .cancel(this.$translate.instant('common.CANCEL'));
         this.$mdDialog.show(confirm).then(() => {
-            const resetPush = true;
-            const redirect = true;
-            this.webClientService.stop(true, threema.DisconnectReason.SessionDeleted, resetPush, redirect);
+            this.webClientService.stop(threema.DisconnectReason.SessionDeleted, true, true, true);
             this.receiverService.setActive(undefined);
         }, () => {
             // do nothing

--- a/src/partials/messenger.ts
+++ b/src/partials/messenger.ts
@@ -1012,10 +1012,10 @@ class NavigationController {
             this.webClientService.stop({
                 reason: threema.DisconnectReason.SessionStopped,
                 send: true,
-                close: true,
-                redirect: true,
+                // TODO: Use welcome.stopped once we have it
+                close: 'welcome',
+                connectionBuildupState: 'closed',
             });
-            this.receiverService.setActive(undefined);
         }, () => {
             // do nothing
         });
@@ -1035,10 +1035,10 @@ class NavigationController {
             this.webClientService.stop({
                 reason: threema.DisconnectReason.SessionDeleted,
                 send: true,
-                close: true,
-                redirect: true,
+                // TODO: Use welcome.deleted once we have it
+                close: 'welcome',
+                connectionBuildupState: 'closed',
             });
-            this.receiverService.setActive(undefined);
         }, () => {
             // do nothing
         });

--- a/src/partials/welcome.html
+++ b/src/partials/welcome.html
@@ -31,7 +31,7 @@
             </div>
         </div>
 
-        <div ng-if="ctrl.state === 'connecting' && ctrl.mode === 'unlock'" class="unlock">
+        <div ng-if="(ctrl.state === 'new' || ctrl.state === 'connecting') && ctrl.mode === 'unlock'" class="unlock">
             <h2 class="instructions" translate>welcome.PLEASE_UNLOCK</h2>
             <div class="password-entry">
                 <label>

--- a/src/partials/welcome.html
+++ b/src/partials/welcome.html
@@ -138,5 +138,16 @@
             </md-button>
         </div>
 
+        <div ng-if="ctrl.state === 'reconnect_failed'">
+            <p class="state error">
+                <strong><span translate>common.ERROR</span>:</strong> <span translate>connecting.RECONNECT_FAILED</span><br>
+                <span translate>welcome.PLEASE_RELOAD</span>
+            </p>
+            <br>
+            <md-button class="md-raised md-primary" ng-click="ctrl.reload()">
+                <i class="material-icons">refresh</i> <span translate>welcome.RELOAD</span>
+            </md-button>
+        </div>
+
     </div>
 </div>

--- a/src/partials/welcome.ts
+++ b/src/partials/welcome.ts
@@ -258,6 +258,7 @@ class WelcomeController {
             reason: DisconnectReason.SessionStopped,
             send: false,
             close: 'welcome',
+            connectionBuildupState: this.stateService.connectionBuildupState,
         });
         this.webClientService.init({
             resume: false,
@@ -280,6 +281,7 @@ class WelcomeController {
      * Initiate a new session by unlocking a trusted key.
      */
     private unlock(): void {
+        this.stateService.reset('new');
         this.$log.info(this.logTag, 'Initialize session by unlocking trusted key...');
     }
 
@@ -383,6 +385,7 @@ class WelcomeController {
             reason: DisconnectReason.SessionStopped,
             send: false,
             close: 'welcome',
+            connectionBuildupState: this.stateService.connectionBuildupState,
         });
 
         // Initialize push service

--- a/src/partials/welcome.ts
+++ b/src/partials/welcome.ts
@@ -302,14 +302,8 @@ class WelcomeController {
         // Set up the broadcast channel that checks whether we're already connected in another tab
         this.setupBroadcastChannel(keyStore.publicKeyHex);
 
-        // Initialize push service
-        if (decrypted.pushToken !== null && decrypted.pushTokenType !== null) {
-            this.webClientService.updatePushToken(decrypted.pushToken, decrypted.pushTokenType);
-            this.pushService.init(decrypted.pushToken, decrypted.pushTokenType);
-        }
-
         // Reconnect
-        this.reconnect(keyStore, decrypted.peerPublicKey);
+        this.reconnect(keyStore, decrypted);
     }
 
     /**
@@ -381,19 +375,29 @@ class WelcomeController {
     }
 
     /**
-     * Reconnect using a specific keypair and peer public key.
+     * Reconnect using a specific keypair and the decrypted data from the trusted keystore.
      */
-    private reconnect(keyStore: saltyrtc.KeyStore, peerTrustedKey: Uint8Array): void {
+    private reconnect(keyStore: saltyrtc.KeyStore, decrypted: threema.TrustedKeyStoreData): void {
+        // Reset state
         this.webClientService.stop({
             reason: DisconnectReason.SessionStopped,
             send: false,
             close: 'welcome',
         });
+
+        // Initialize push service
+        if (decrypted.pushToken !== null && decrypted.pushTokenType !== null) {
+            this.webClientService.updatePushToken(decrypted.pushToken, decrypted.pushTokenType);
+            this.pushService.init(decrypted.pushToken, decrypted.pushTokenType);
+        }
+
+        // Initialize webclient service
         this.webClientService.init({
             keyStore: keyStore,
-            peerTrustedKey: peerTrustedKey,
+            peerTrustedKey: decrypted.peerPublicKey,
             resume: false,
         });
+
         this.start();
     }
 

--- a/src/partials/welcome.ts
+++ b/src/partials/welcome.ts
@@ -476,9 +476,7 @@ class WelcomeController {
 
         this.$mdDialog.show(confirm).then(() =>  {
             // Force-stop the webclient
-            const resetPush = true;
-            const redirect = false;
-            this.webClientService.stop(true, threema.DisconnectReason.SessionDeleted, resetPush, redirect);
+            this.webClientService.stop(threema.DisconnectReason.SessionDeleted, true, true, false);
 
             // Reset state
             this.stateService.updateConnectionBuildupState('new');

--- a/src/partials/welcome.ts
+++ b/src/partials/welcome.ts
@@ -250,15 +250,14 @@ class WelcomeController {
     /**
      * Initiate a new session by scanning a new QR code.
      */
-    private scan(): void {
+    private scan(stopArguments?: threema.WebClientServiceStopArguments): void {
         this.$log.info(this.logTag, 'Initialize session by scanning QR code...');
 
         // Initialize webclient with new keystore
-        this.webClientService.stop({
+        this.webClientService.stop(stopArguments !== undefined ? stopArguments : {
             reason: DisconnectReason.SessionStopped,
             send: false,
-            close: true,
-            redirect: false,
+            close: 'welcome',
         });
         this.webClientService.init({
             resume: false,
@@ -388,8 +387,7 @@ class WelcomeController {
         this.webClientService.stop({
             reason: DisconnectReason.SessionStopped,
             send: false,
-            close: true,
-            redirect: false,
+            close: 'welcome',
         });
         this.webClientService.init({
             keyStore: keyStore,
@@ -486,21 +484,17 @@ class WelcomeController {
              .cancel(this.$translate.instant('common.CANCEL'));
 
         this.$mdDialog.show(confirm).then(() =>  {
-            // Force-stop the webclient
-            this.webClientService.stop({
-                reason: DisconnectReason.SessionDeleted,
-                send: true,
-                close: true,
-                redirect: false,
-            });
-
             // Go back to scan mode
             this.mode = 'scan';
             this.password = '';
             this.formLocked = false;
 
-            // Initiate scan
-            this.scan();
+            // Force-stop the webclient and initiate scan
+            this.scan({
+                reason: DisconnectReason.SessionDeleted,
+                send: true,
+                close: 'welcome',
+            });
         }, () => {
             // do nothing
         });

--- a/src/partials/welcome.ts
+++ b/src/partials/welcome.ts
@@ -476,7 +476,11 @@ class WelcomeController {
 
         this.$mdDialog.show(confirm).then(() =>  {
             // Force-stop the webclient
-            this.webClientService.stop(threema.DisconnectReason.SessionDeleted, true, true, false);
+            this.webClientService.stop(threema.DisconnectReason.SessionDeleted, {
+                send: true,
+                close: true,
+                redirect: false,
+            });
 
             // Reset state
             this.stateService.updateConnectionBuildupState('new');

--- a/src/protocol/cache.ts
+++ b/src/protocol/cache.ts
@@ -70,7 +70,9 @@ export class ChunkCache {
     public append(chunk: CachedChunk): void {
         // Update sequence number, update size & append chunk
         this._sequenceNumber.increment();
-        this._size += chunk.byteLength;
+        if (chunk !== null) {
+            this._size += chunk.byteLength;
+        }
         this.cache.push(chunk);
     }
 
@@ -95,6 +97,8 @@ export class ChunkCache {
 
         // Slice our cache & recalculate size
         this.cache = endOffset === 0 ? [] : this.cache.slice(endOffset);
-        this._size = this.cache.reduce((sum, chunk) => sum + chunk.byteLength, 0);
+        this._size = this.cache
+            .filter((chunk) => chunk !== null)
+            .reduce((sum, chunk) => sum + chunk.byteLength, 0);
     }
 }

--- a/src/protocol/cache.ts
+++ b/src/protocol/cache.ts
@@ -39,14 +39,14 @@ export class ChunkCache {
     }
 
     /**
-     * Get the size of currently stored chunks.
+     * Get the size of currently cached chunks.
      */
     public get size(): number {
         return this._size;
     }
 
     /**
-     * Get the currently cached chunks.
+     * Get a reference to the currently cached chunks.
      */
     public get chunks(): CachedChunk[] {
         return this.cache;
@@ -57,10 +57,9 @@ export class ChunkCache {
      */
     public transfer(cache: CachedChunk[]): void {
         // Add chunks but remove all which should not be retransmitted
+        cache = cache.filter((chunk) => chunk !== null);
         for (const chunk of cache) {
-            if (chunk !== null) {
-                this.append(chunk);
-            }
+            this.append(chunk);
         }
     }
 
@@ -77,9 +76,9 @@ export class ChunkCache {
     }
 
     /**
-     * Acknowledge cached chunks and remove those from the cache.
+     * Prune cached chunks that have been acknowledged.
      */
-    public acknowledge(theirSequenceNumber: number): void {
+    public prune(theirSequenceNumber: number): void {
         try {
             this._sequenceNumber.validate(theirSequenceNumber);
         } catch (error) {

--- a/src/protocol/cache.ts
+++ b/src/protocol/cache.ts
@@ -24,7 +24,7 @@ export type CachedChunk = Uint8Array | null;
  */
 export class ChunkCache {
     private _sequenceNumber: SequenceNumber;
-    private _size = 0;
+    private _byteLength = 0;
     private cache: CachedChunk[] = [];
 
     constructor(sequenceNumber: SequenceNumber) {
@@ -39,10 +39,10 @@ export class ChunkCache {
     }
 
     /**
-     * Get the size of currently cached chunks.
+     * Get the total size of currently cached chunks in bytes.
      */
-    public get size(): number {
-        return this._size;
+    public get byteLength(): number {
+        return this._byteLength;
     }
 
     /**
@@ -70,7 +70,7 @@ export class ChunkCache {
         // Update sequence number, update size & append chunk
         this._sequenceNumber.increment();
         if (chunk !== null) {
-            this._size += chunk.byteLength;
+            this._byteLength += chunk.byteLength;
         }
         this.cache.push(chunk);
     }
@@ -96,7 +96,7 @@ export class ChunkCache {
 
         // Slice our cache & recalculate size
         this.cache = endOffset === 0 ? [] : this.cache.slice(endOffset);
-        this._size = this.cache
+        this._byteLength = this.cache
             .filter((chunk) => chunk !== null)
             .reduce((sum, chunk) => sum + chunk.byteLength, 0);
     }

--- a/src/protocol/cache.ts
+++ b/src/protocol/cache.ts
@@ -87,15 +87,15 @@ export class ChunkCache {
 
         // Calculate the slice start index for the chunk cache
         // Important: Our sequence number is one chunk ahead!
-        const endOffset = theirSequenceNumber + 1 - this._sequenceNumber.get();
-        if (endOffset > 0) {
+        const beginOffset = theirSequenceNumber + 1 - this._sequenceNumber.get();
+        if (beginOffset > 0) {
             throw new Error('Remote travelled through time and acknowledged a chunk which is in the future');
-        } else if (-endOffset > this.cache.length) {
+        } else if (-beginOffset > this.cache.length) {
             throw new Error('Remote travelled back in time and acknowledged a chunk it has already acknowledged');
         }
 
         // Slice our cache & recalculate size
-        this.cache = endOffset === 0 ? [] : this.cache.slice(endOffset);
+        this.cache = beginOffset === 0 ? [] : this.cache.slice(beginOffset);
         this._byteLength = this.cache
             .filter((chunk) => chunk !== null)
             .reduce((sum, chunk) => sum + chunk.byteLength, 0);

--- a/src/protocol/cache.ts
+++ b/src/protocol/cache.ts
@@ -1,0 +1,92 @@
+/**
+ * This file is part of Threema Web.
+ *
+ * Threema Web is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Threema Web. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export type CachedChunk = Uint8Array | null;
+
+/**
+ * Contains messages that have not yet been acknowledged,
+ */
+export class ChunkCache {
+    private readonly sequenceNumberMax: number;
+    private _sequenceNumber = 0;
+    private cache: CachedChunk[] = [];
+
+    constructor(sequenceNumberMax: number) {
+        this.sequenceNumberMax = sequenceNumberMax;
+    }
+
+    /**
+     * Get the current sequence number (e.g. of the **next** chunk to be added).
+     */
+    public get sequenceNumber(): number {
+        return this._sequenceNumber;
+    }
+
+    /**
+     * Get the currently cached chunks.
+     */
+    public get chunks(): CachedChunk[] {
+        return this.cache;
+    }
+
+    /**
+     * Transfer an array of cached chunks to this cache instance.
+     */
+    public transfer(cache: CachedChunk[]): void {
+        // Add chunks but remove all which are blacklisted
+        for (const chunk of cache) {
+            if (chunk !== null) {
+                this.append(chunk);
+            }
+        }
+    }
+
+    /**
+     * Append a chunk to the chunk cache.
+     */
+    public append(chunk: CachedChunk): void {
+        // Check if the sequence number would overflow
+        if (this._sequenceNumber >= this.sequenceNumberMax) {
+            throw Error('Sequence number overflow');
+        }
+
+        // Update sequence number & append chunk
+        ++this._sequenceNumber;
+        this.cache.push(chunk);
+    }
+
+    /**
+     * Acknowledge cached chunks and remove those from the cache.
+     */
+    public acknowledge(theirSequenceNumber: number): void {
+        if (theirSequenceNumber < 0 || theirSequenceNumber > this.sequenceNumberMax) {
+            throw new Error(`Remote sent us an invalid sequence number: ${theirSequenceNumber}`);
+        }
+
+        // Calculate the slice start index for the chunk cache
+        // Important: Our sequence number is one chunk ahead!
+        const endOffset = theirSequenceNumber + 1 - this._sequenceNumber;
+        if (endOffset > 0) {
+            throw new Error('Remote travelled through time and acknowledged a chunk which is in the future');
+        } else if (-endOffset > this.cache.length) {
+            throw new Error('Remote travelled back in time and acknowledged a chunk it has already acknowledged');
+        }
+
+        // Slice our cache
+        this.cache = endOffset === 0 ? [] : this.cache.slice(endOffset);
+    }
+}

--- a/src/protocol/sequence_number.ts
+++ b/src/protocol/sequence_number.ts
@@ -59,13 +59,15 @@ export class SequenceNumber {
     }
 
     /**
-     * Increment the sequence number and return the resulting number.
+     * Increment the sequence number and return the sequence number as it was
+     * before it has been incremented.
      */
     public increment(by: number = 1): number {
         if (by < 0) {
             throw new Error('Cannot decrement the sequence number');
         }
-        this.set(this.value + by);
-        return this.get();
+        const value = this.value;
+        this.set(value + by);
+        return value;
     }
 }

--- a/src/protocol/sequence_number.ts
+++ b/src/protocol/sequence_number.ts
@@ -1,0 +1,71 @@
+/**
+ * This file is part of Threema Web.
+ *
+ * Threema Web is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Threema Web. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * A generic sequence number with specific boundaries.
+ *
+ * Does not allow for wrapping.
+ */
+export class SequenceNumber {
+    private readonly minValue: number;
+    private readonly maxValue: number;
+    private value: number;
+
+    constructor(initialValue: number = 0, minValue: number, maxValue: number) {
+        this.minValue = minValue;
+        this.maxValue = maxValue;
+        this.value = initialValue;
+    }
+
+    /**
+     * Validate a specific sequence number.
+     */
+    public validate(other: number) {
+        if (other < this.minValue) {
+            throw new Error(`Invalid sequence number: ${other} < 0`);
+        }
+        if (other > this.maxValue) {
+            throw new Error(`Invalid sequence number: ${other} > ${this.maxValue}`);
+        }
+    }
+
+    /**
+     * Get the current value of the sequence number.
+     */
+    public get(): number {
+        return this.value;
+    }
+
+    /**
+     * Set the new value of the sequence number.
+     */
+    public set(value: number): void {
+        this.validate(value);
+        this.value = value;
+    }
+
+    /**
+     * Increment the sequence number and return the resulting number.
+     */
+    public increment(by: number = 1): number {
+        if (by < 0) {
+            throw new Error('Cannot decrement the sequence number');
+        }
+        this.set(this.value + by);
+        return this.get();
+    }
+}

--- a/src/services/push.ts
+++ b/src/services/push.ts
@@ -74,7 +74,7 @@ export class PushService {
      * Send a push notification for the specified session (public permanent key
      * of the initiator). The promise is always resolved to a boolean.
      */
-    public async sendPush(session: Uint8Array, wakeupType: threema.WakeupType): Promise<boolean> {
+    public async sendPush(session: Uint8Array): Promise<boolean> {
         if (!this.isAvailable()) {
             return false;
         }
@@ -87,7 +87,8 @@ export class PushService {
             [PushService.ARG_TYPE]: this.pushType,
             [PushService.ARG_SESSION]: sessionHash,
             [PushService.ARG_VERSION]: this.version,
-            [PushService.ARG_WAKEUP_TYPE]: wakeupType,
+            // Note: Wakeup type has been obsoleted by connectionInfo
+            [PushService.ARG_WAKEUP_TYPE]: '0',
         };
         if (this.pushType === threema.PushTokenType.Apns) {
             // APNS token format: "<hex-deviceid>;<endpoint>;<bundle-id>"

--- a/src/services/state.ts
+++ b/src/services/state.ts
@@ -43,7 +43,7 @@ export class StateService {
     public taskConnectionState: TaskConnectionState;
 
     // Connection buildup state
-    public connectionBuildupState: threema.ConnectionBuildupState = 'connecting';
+    public connectionBuildupState: threema.ConnectionBuildupState;
     public progress = 0;
     private progressInterval: ng.IPromise<any> = null;
     public slowConnect = false;
@@ -238,8 +238,8 @@ export class StateService {
     /**
      * Reset all states.
      */
-    public reset(): void {
-        this.$log.debug(this.logTag, 'Reset');
+    public reset(connectionBuildupState: threema.ConnectionBuildupState = 'new'): void {
+        this.$log.debug(this.logTag, 'Reset states');
 
         // Reset state
         this.signalingConnectionState = 'new';
@@ -247,6 +247,7 @@ export class StateService {
         this.stage = Stage.Signaling;
         this.state = GlobalConnectionState.Error;
         this.wasConnected = false;
-        this.connectionBuildupState = 'connecting';
+        this.connectionBuildupState = connectionBuildupState;
+        this.progress = 0;
     }
 }

--- a/src/services/webclient.ts
+++ b/src/services/webclient.ts
@@ -615,9 +615,12 @@ export class WebClientService {
         this.$log.debug(this.logTag, 'Sending connection info');
         if (resumeSession) {
             this._sendConnectionInfo(
-                this.currentConnectionId, this.previousConnectionId, this.previousChunkCache.sequenceNumber);
+                this.currentConnectionId.buffer,
+                this.previousConnectionId.buffer,
+                this.previousChunkCache.sequenceNumber
+            );
         } else {
-            this._sendConnectionInfo(this.currentConnectionId);
+            this._sendConnectionInfo(this.currentConnectionId.buffer);
         }
 
         // Receive connection info
@@ -721,7 +724,8 @@ export class WebClientService {
         // Derive connection ID
         // Note: We need to make sure this is done before any ARP messages can be received
         const box = this.salty.encryptForPeer(new Uint8Array(0), WebClientService.CONNECTION_ID_NONCE);
-        this.currentConnectionId = box.data;
+        // Note: We explicitly copy the data here to be able to use the underlying buffer directly
+        this.currentConnectionId = new Uint8Array(box.data);
 
         // If the WebRTC task was chosen, initialize the data channel
         if (this.chosenTask === threema.ChosenTask.WebRTC) {
@@ -1018,7 +1022,7 @@ export class WebClientService {
     /**
      * Send a connection info update.
      */
-    private _sendConnectionInfo(connectionId: Uint8Array, resumeId?: Uint8Array, sequenceNumber?: number): void {
+    private _sendConnectionInfo(connectionId: ArrayBuffer, resumeId?: ArrayBuffer, sequenceNumber?: number): void {
         const args = undefined;
         const data = {id: connectionId};
         if (resumeId !== undefined && sequenceNumber !== undefined) {

--- a/src/services/webclient.ts
+++ b/src/services/webclient.ts
@@ -216,7 +216,7 @@ export class WebClientService {
     private drafts: threema.Container.Drafts;
     private pcHelper: PeerConnectionHelper = null;
     private trustedKeyStore: TrustedKeyStoreService;
-    public clientInfo: threema.ClientInfo;
+    public clientInfo: threema.ClientInfo = null;
     public version = null;
     private batteryStatusTimeout: ng.IPromise<void> = null;
 
@@ -779,11 +779,14 @@ export class WebClientService {
 
         // Redirect to the conversation overview in case resuming was enabled
         // but the session could not be resumed
-        if (resumeSession && !sessionWasResumed) {
+        if (resumeSession && !sessionWasResumed && this.clientInfo !== null) {
             this.$rootScope.$apply(() => {
                 // TODO: Remove this conditional once we have session
                 //       resumption for Android!
-                if (this.chosenTask === threema.ChosenTask.RelayedData) {
+                if (this.chosenTask !== threema.ChosenTask.RelayedData) {
+                    return;
+                }
+                if (this.$state.includes('messenger')) {
                     this.$state.go('messenger.home');
                 }
             });
@@ -1015,6 +1018,7 @@ export class WebClientService {
 
         // Invalidate and clear caches
         if (close) {
+            this.clientInfo = null;
             this.previousConnectionId = null;
             this.currentConnectionId = null;
             this.previousIncomingChunkSequenceNumber = null;

--- a/src/services/webclient.ts
+++ b/src/services/webclient.ts
@@ -1086,7 +1086,6 @@ export class WebClientService {
         // Clear stored data (trusted key, push token, etc) if deleting the session
         if (remove) {
             this.trustedKeyStore.clearTrustedKey();
-            this.pushService.reset();
         }
 
         // Invalidate and clear caches

--- a/src/services/webclient.ts
+++ b/src/services/webclient.ts
@@ -2194,7 +2194,6 @@ export class WebClientService {
             send: false,
             // TODO: Use welcome.{reason} once we have it
             close: 'welcome',
-            connectionBuildupState: 'closed',
         });
         this.showAlert(alertMessage);
     }

--- a/src/services/webclient.ts
+++ b/src/services/webclient.ts
@@ -1086,6 +1086,7 @@ export class WebClientService {
         // Clear stored data (trusted key, push token, etc) if deleting the session
         if (remove) {
             this.trustedKeyStore.clearTrustedKey();
+            this.pushService.reset();
         }
 
         // Invalidate and clear caches

--- a/src/services/webclient.ts
+++ b/src/services/webclient.ts
@@ -565,7 +565,7 @@ export class WebClientService {
         // Stop session
         this.stop(DisconnectReason.SessionError, true, true, true);
 
-        // Show an error dialog
+        // Show an alert
         this.showAlert('connection.SESSION_ERROR');
     }
 
@@ -3305,17 +3305,20 @@ export class WebClientService {
      */
     private receive(message: threema.WireMessage): void {
         // Intercept handshake message
-        // TODO: Remove this after the current iOS beta has been closed
         if (!this.connectionInfoFuture.done) {
-            if (message.type !== WebClientService.TYPE_UPDATE
-                && message.subType !== WebClientService.SUB_TYPE_CONNECTION_INFO) {
-                // We did not receive a handshake message, so we cannot resume a session
-                const warning = `Resumption cancelled, received message ${message.type}/${message.subType}`;
-                this.$log.warn(this.logTag, warning);
-                this.connectionInfoFuture.resolve(null);
-            } else {
-                this._receiveConnectionInfo(message);
+            // Check for unexpected messages
+            if (message.type !== WebClientService.TYPE_UPDATE ||
+                message.subType !== WebClientService.SUB_TYPE_CONNECTION_INFO) {
+                // TODO: Reactivate this and remove the special stop + alert
+                //       once the iOS beta has been closed
+                // this.failSession();
+                this.stop(DisconnectReason.SessionStopped, true, true, true);
+                this.showAlert('Please update the Threema app to use the latest iOS beta version');
+                return;
             }
+
+            // Dispatch and return
+            this._receiveConnectionInfo(message);
             return;
         }
 

--- a/src/threema.d.ts
+++ b/src/threema.d.ts
@@ -401,10 +401,11 @@ declare namespace threema {
      * - loading: Loading initial data
      * - done: Initial loading is finished
      * - closed: Connection is closed
+     * - reconnect_failed: Reconnecting failed after several attempts
      *
      */
     type ConnectionBuildupState = 'new' | 'connecting' | 'push' | 'manual_start' | 'already_connected'
-        | 'waiting' | 'peer_handshake' | 'loading' | 'done' | 'closed';
+        | 'waiting' | 'peer_handshake' | 'loading' | 'done' | 'closed' | 'reconnect_failed';
 
     interface ConnectionBuildupStateChange {
         state: ConnectionBuildupState;

--- a/src/threema.d.ts
+++ b/src/threema.d.ts
@@ -753,6 +753,7 @@ declare namespace threema {
         SessionDeleted = 'delete',
         WebclientDisabled = 'disable',
         SessionReplaced = 'replace',
+        SessionError = 'error',
     }
 
     namespace Container {

--- a/src/threema.d.ts
+++ b/src/threema.d.ts
@@ -529,11 +529,6 @@ declare namespace threema {
         textInfo?: string;
     }
 
-    interface PromiseCallbacks {
-        resolve: (arg: any) => void;
-        reject: (arg: any) => void;
-    }
-
     interface PromiseRequestResult<T> {
         success: boolean;
         error?: string;
@@ -741,6 +736,13 @@ declare namespace threema {
         word: string;
         // The length of the untrimmed word
         realLength: number;
+    }
+
+    interface WebClientServiceStopArguments {
+        reason: DisconnectReason,
+        send: boolean,
+        close: boolean | string,
+        connectionBuildupState?: ConnectionBuildupState,
     }
 
     const enum ChosenTask {

--- a/src/types/future.d.ts
+++ b/src/types/future.d.ts
@@ -1,0 +1,45 @@
+/**
+ * This file is part of Threema Web.
+ *
+ * Threema Web is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Threema Web. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * A future similar to Python's asyncio.Future. Allows to resolve or reject
+ * outside of the executor and query the current status.
+ */
+interface Future<T> extends Promise<T> {
+    /**
+     * Return whether the future is done (resolved or rejected).
+     */
+    readonly done: boolean;
+
+    /**
+     * Resolve the future.
+     */
+    resolve(value?: T | PromiseLike<T>): void;
+
+    /**
+     * Reject the future.
+     */
+    reject(reason?: any): void;
+}
+
+interface FutureStatic {
+    new<T>(executor?: (resolveFn: (value?: T | PromiseLike<T>) => void,
+                       rejectFn: (reason?: any) => void) => void,
+    ): Future<T>
+}
+
+declare var Future: FutureStatic;


### PR DESCRIPTION
Notable changes:

- Chunks will now be buffered until they are explicitly acknowledged. On resumption, missing chunks will be retransmitted. Resolves (iOS only at the moment) #498.
- Changes the reconnect behaviour: The loading indicator now resets instead of staying at 99% when retrying a connection. After all tries failed, a new *reconnect failed* page will be displayed.
- Prevent events from previous connections leaking into new connections (which could result in race conditions), resolves #533.

To do:

- [x] Rebase against master
  - See changes from #569
- [x] Test with iOS implementation (not perfect, needs more work but good enough for beta)
- [x] Apparently, more testing...

Fixes #532, fixes #505 