### PR TITLE
Fix group update

### DIFF
--- a/src/threema/container.ts
+++ b/src/threema/container.ts
@@ -200,17 +200,22 @@ class Receivers implements threema.Container.Receivers {
     }
 
     public extendGroup(data: threema.GroupReceiver): threema.GroupReceiver {
+        // Set defaults
+        setDefault(data, 'disabled', false);
+        setDefault(data, 'locked', false);
+        setDefault(data, 'visible', true);
+
+        // Look up group
         let groupReceiver  = this.groups.get(data.id);
+
+        // If group does not yet exist, create it
         if (groupReceiver === undefined) {
             data.type = 'group';
-            setDefault(data, 'disabled', false);
-            setDefault(data, 'locked', false);
-            setDefault(data, 'visible', true);
             this.groups.set(data.id, data);
             return data;
         }
 
-        // update existing object
+        // Otherwise, update existing object
         groupReceiver = angular.extend(groupReceiver, data);
         return groupReceiver;
     }


### PR DESCRIPTION
When a group update arrives, the fields are copied over the old field values. This is a problem if the updated group leaves out optional fields that have a default value that is different to the current value.

To fix this, the defaults always need to be set explicitly.

Fixes #563