### PR TITLE
WIP: Improve UI Performance

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,6 +67,32 @@
         </div>
     </noscript>
 
+    <div id="filters">
+        emojify: <span class="emojify"></span>
+        | linkify: <span class="linkify"></span>
+        | markify: <span class="markify"></span>
+        | mentionify: <span class="mentionify"></span>
+        | enlargeSingleEmoji: <span class="enlargeSingleEmoji"></span>
+        | escapeHtml: <span class="escapeHtml"></span>
+        | nlToBr: <span class="nlToBr"></span>
+        | messageStateIcon: <span class="messageStateIcon"></span>
+        | messageStateTitleText: <span class="messageStateTitleText"></span>
+        | emptyToPlaceholder: <span class="emptyToPlaceholder"></span>
+        | reverse: <span class="reverse"></span>
+        | hasData: <span class="hasData"></span>
+        | hasContact: <span class="hasContact"></span>
+        | isNotMe: <span class="isNotMe"></span>
+        | duration: <span class="duration"></span>
+        | bufferToUrl: <span class="bufferToUrl"></span>
+        | mapLink: <span class="mapLink"></span>
+        | fileSize: <span class="fileSize"></span>
+        | mimeTypeLabel: <span class="mimeTypeLabel"></span>
+        | mimeTypeIcon: <span class="mimeTypeIcon"></span>
+        | idsToNames: <span class="idsToNames"></span>
+        | unixToTimestring: <span class="unixToTimestring"></span>
+        | dndModeSimplified: <span class="dndModeSimplified"></span>
+    </div>
+
     <div id="main-wrapper" ng-cloak ng-class="{wide: ctrl.wide()}">
         <header>
             <h1 id="title">

--- a/index.html
+++ b/index.html
@@ -90,7 +90,6 @@
         | mimeTypeIcon: <span class="mimeTypeIcon"></span>
         | idsToNames: <span class="idsToNames"></span>
         | unixToTimestring: <span class="unixToTimestring"></span>
-        | dndModeSimplified: <span class="dndModeSimplified"></span>
     </div>
 
     <div id="main-wrapper" ng-cloak ng-class="{wide: ctrl.wide()}">

--- a/src/directives/message_media.ts
+++ b/src/directives/message_media.ts
@@ -135,7 +135,8 @@ export default [
                     if (this.message.thumbnail !== undefined) {
                         this.thumbnailStyle = {
                             width: this.message.thumbnail.width + 'px',
-                            height: this.message.thumbnail.height + 'px' };
+                            height: this.message.thumbnail.height + 'px',
+                        };
                     }
 
                     let loadingThumbnailTimeout = null;

--- a/src/filters.ts
+++ b/src/filters.ts
@@ -490,22 +490,6 @@ angular.module('3ema.filters', [])
 }])
 
 /**
- * Return a simplified DND mode.
- *
- * This will return either 'on', 'off' or 'mention'.
- * The 'until' mode will be processed depending on the expiration timestamp.
- */
-.filter('dndModeSimplified', ['NotificationService', function(notificationService: NotificationService) {
-    return timeIt('dndModeSimplified', (conversation: threema.Conversation) => {
-        const simplified = notificationService.getAppNotificationSettings(conversation);
-        if (simplified.dnd.enabled) {
-            return simplified.dnd.mentionOnly ? 'mention' : 'on';
-        }
-        return 'off';
-    });
-}])
-
-/**
  * Mark data as trusted.
  */
 .filter('unsafeResUrl', ['$sce', function($sce: ng.ISCEService) {

--- a/src/partials/messenger.navigation.html
+++ b/src/partials/messenger.navigation.html
@@ -67,6 +67,7 @@
     <p class="empty" ng-if="ctrl.conversations().length === 0" translate>messenger.NO_CONVERSATIONS_FOUND</p>
     <ul>
         <li ng-repeat="conversation in ctrl.conversations() | filter:ctrl.searchConversation"
+            ng-init="dndModeSimplified = ctrl.dndModeSimplified(conversation)"
             ui-sref="messenger.home.conversation({ type: conversation.type, id: conversation.id, initParams: null })"
             class="conversation-wrapper" ng-if="ctrl.isVisible(conversation)">
 
@@ -84,13 +85,13 @@
                     <section class="receiver-box">
                         <span class="title" ng-class="{'disabled': conversation.receiver.disabled === true}" ng-bind-html="conversation.receiver.displayName | escapeHtml | emojify">
                         </span>
-                        <span class="notification-settings" ng-show="(conversation | dndModeSimplified) === 'on'">
+                        <span class="notification-settings" ng-if="dndModeSimplified === 'on'">
                             <img height="16" width="16" src="img/ic_dnd_total_silence.svg" translate translate-attr-title="messenger.MUTED_NONE">
                         </span>
-                        <span class="notification-settings" ng-show="(conversation | dndModeSimplified) === 'mention'">
+                        <span class="notification-settings" ng-if="dndModeSimplified === 'mention'">
                             <img height="16" width="16" src="img/ic_dnd_mention.svg" translate translate-attr-title="messenger.MUTED_MENTION_ONLY">
                         </span>
-                        <span class="notification-settings" ng-show="(conversation | dndModeSimplified) === 'off' && conversation.notifications && conversation.notifications.sound.mode === 'muted'">
+                        <span class="notification-settings" ng-if="dndModeSimplified === 'off' && conversation.notifications && conversation.notifications.sound.mode === 'muted'">
                             <img height="16" width="16" src="img/ic_notifications_off.svg" translate translate-attr-title="messenger.MUTED_SILENT">
                         </span>
                         <span class="badge unread-count" ng-show="conversation.unreadCount > 0">

--- a/src/partials/messenger.ts
+++ b/src/partials/messenger.ts
@@ -848,6 +848,7 @@ class NavigationController {
     private receiverService: ReceiverService;
     private stateService: StateService;
     private trustedKeyStoreService: TrustedKeyStoreService;
+    private notificationService: NotificationService;
 
     private activeTab: 'contacts' | 'conversations' = 'conversations';
     private searchVisible = false;
@@ -859,13 +860,13 @@ class NavigationController {
 
     public static $inject = [
         '$log', '$state', '$mdDialog', '$translate',
-        'WebClientService', 'StateService', 'ReceiverService', 'TrustedKeyStore',
+        'WebClientService', 'StateService', 'ReceiverService', 'NotificationService', 'TrustedKeyStore',
     ];
 
     constructor($log: ng.ILogService, $state: UiStateService,
                 $mdDialog: ng.material.IDialogService, $translate: ng.translate.ITranslateService,
                 webClientService: WebClientService, stateService: StateService,
-                receiverService: ReceiverService,
+                receiverService: ReceiverService, notificationService: NotificationService,
                 trustedKeyStoreService: TrustedKeyStoreService) {
 
         // Redirect to welcome if necessary
@@ -879,6 +880,7 @@ class NavigationController {
         this.receiverService = receiverService;
         this.stateService = stateService;
         this.trustedKeyStoreService = trustedKeyStoreService;
+        this.notificationService = notificationService;
         this.$mdDialog = $mdDialog;
         this.$translate = $translate;
         this.$state = $state;
@@ -1068,6 +1070,20 @@ class NavigationController {
      */
     public showCreateDistributionListButton(): boolean {
         return this.webClientService.appCapabilities.distributionLists;
+    }
+
+    /**
+     * Return a simplified DND mode.
+     *
+     * This will return either 'on', 'off' or 'mention'.
+     * The 'until' mode will be processed depending on the expiration timestamp.
+     */
+    public dndModeSimplified(conversation: threema.Conversation): 'on' | 'mention' | 'off' {
+        const simplified = this.notificationService.getAppNotificationSettings(conversation);
+        if (simplified.dnd.enabled) {
+            return simplified.dnd.mentionOnly ? 'mention' : 'on';
+        }
+        return 'off';
     }
 
 }

--- a/src/sass/base/_colors.scss
+++ b/src/sass/base/_colors.scss
@@ -11,3 +11,7 @@ body {
 footer {
     color: white;
 }
+
+#filters {
+    color: orange;
+}

--- a/src/services/webclient.ts
+++ b/src/services/webclient.ts
@@ -3084,6 +3084,7 @@ export class WebClientService {
 
     /**
      * Receive a new incoming decrypted message.
+     * This method runs inside the digest loop.
      */
     private receive(message: threema.WireMessage): void {
         // Dispatch message


### PR DESCRIPTION
This is still work in progress.

I added a filter profiler that shows the call count & total duration for AngularJS filters. It's not pretty but it works for improving performance.

Initially (simply loading all my conversations):

![filters1](https://user-images.githubusercontent.com/105168/44352679-4e004600-a4a5-11e8-8d09-60349ad4d03f.png)

After processing text early in MessageText directive:

![filters2](https://user-images.githubusercontent.com/105168/44352697-58badb00-a4a5-11e8-9eea-d57ccc2beec9.png)

By not calculating the filters every digest cycle, we get the following call count improvements:

- emojify (548x -> 426x, 7ms -> 5ms)
- linkify (240x -> 120x, 107ms -> 26ms)
- escapeHtml (548 -> 426x, 6ms -> 3ms)

(Filters with less than 5ms total time aren't listed here)

More improvements are planned. In general, template filters should be avoided.