### PR TITLE
Refactor browser detection

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -73,7 +73,7 @@ angular.module('3ema', [
     FF: 50,
     CHROME: 45,
     OPERA: 32,
-    SAFARI: 11,
+    SAFARI: 10,
 })
 
 // Set default route

--- a/src/directives/compose_area.ts
+++ b/src/directives/compose_area.ts
@@ -367,7 +367,7 @@ export default [
                             };
 
                             // Workaround for https://bugzilla.mozilla.org/show_bug.cgi?id=1240259
-                            if (browserService.getBrowser().firefox) {
+                            if (browserService.getBrowser().isFirefox(false)) {
                                 if (fileMessageData.name.endsWith('.ogg') && fileMessageData.fileType === 'video/ogg') {
                                     fileMessageData.fileType = 'audio/ogg';
                                 }
@@ -634,7 +634,7 @@ export default [
                         span.setAttribute('contenteditable', false);
                     }
 
-                    if (browserService.getBrowser().firefox) {
+                    if (browserService.getBrowser().isFirefox(false)) {
                         // disable object resizing is the only way to disable resizing of
                         // emoji (contenteditable must be true, otherwise the emoji can not
                         // be removed with backspace (in FF))

--- a/src/helpers/browser_info.ts
+++ b/src/helpers/browser_info.ts
@@ -1,0 +1,99 @@
+/**
+ * This file is part of Threema Web.
+ *
+ * Threema Web is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Threema Web. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export class BrowserInfo {
+    private userAgent: string;
+
+    public readonly name: threema.BrowserName | null;
+    public readonly version: number | null;
+    public readonly mobile: boolean;
+
+    constructor(
+        userAgent: string,
+        name: threema.BrowserName | null,
+        version: number | null,
+        mobile: boolean = false,
+    ) {
+        this.userAgent = userAgent;
+        this.name = name;
+        this.version = version;
+        this.mobile = mobile;
+    }
+
+    public wasDetermined(): boolean {
+        return this.name !== null && this.version !== null;
+    }
+
+    public description(): string {
+        if (this.name === null) {
+            return 'Unknown';
+        }
+        let description = '';
+        switch (this.name) {
+            case threema.BrowserName.Chrome:
+                description = 'Chrome ' + this.version;
+                break;
+            case threema.BrowserName.ChromeIos:
+                description = 'Chrome (iOS) ' + this.version;
+                break;
+            case threema.BrowserName.Firefox:
+                description = 'Firefox ' + this.version;
+                break;
+            case threema.BrowserName.FirefoxIos:
+                description = 'Firefox (iOS) ' + this.version;
+                break;
+            case threema.BrowserName.Edge:
+                description = 'Edge ' + this.version;
+                break;
+            case threema.BrowserName.InternetExplorer:
+                description = 'Internet Explorer ' + this.version;
+                break;
+            case threema.BrowserName.Opera:
+                description = 'Opera ' + this.version;
+                break;
+            case threema.BrowserName.Safari:
+                description = 'Safari ' + this.version;
+                break;
+        }
+        if (this.mobile) {
+            description += ' [Mobile]';
+        }
+        return description;
+    }
+
+    /**
+     * Return whether the current browser supports the WebRTC task or not.
+     */
+    public supportsWebrtcTask(): boolean {
+        switch (this.name) {
+            case threema.BrowserName.Safari:
+            case threema.BrowserName.FirefoxIos:
+            case threema.BrowserName.ChromeIos:
+                return false;
+            default:
+                return true;
+        }
+    }
+
+    public isFirefox(requireVersion: boolean): boolean {
+        return this.name === threema.BrowserName.Firefox && (!requireVersion || this.version !== null);
+    }
+
+    public isSafari(requireVersion: boolean): boolean {
+        return this.name === threema.BrowserName.Safari && (!requireVersion || this.version !== null);
+    }
+}

--- a/src/partials/welcome.ts
+++ b/src/partials/welcome.ts
@@ -25,6 +25,7 @@ import {
     StateService as UiStateService,
 } from '@uirouter/angularjs';
 
+import {BrowserInfo} from '../helpers/browser_info';
 import {BrowserService} from '../services/browser';
 import {ControllerService} from '../services/controller';
 import {TrustedKeyStoreService} from '../services/keystore';
@@ -89,7 +90,7 @@ class WelcomeController {
     private password: string = '';
     private formLocked: boolean = false;
     private pleaseUpdateAppMsg: string = null;
-    private browser: threema.BrowserInfo;
+    private browser: BrowserInfo;
     private browserWarningShown: boolean = false;
 
     public static $inject = [
@@ -132,26 +133,26 @@ class WelcomeController {
         // Determine whether browser warning should be shown
         this.browser = browserService.getBrowser();
         const version = this.browser.version;
-        $log.debug('Detected browser:', this.browser.textInfo);
-        if (version === undefined) {
+        $log.debug('Detected browser:', this.browser.description());
+        if (!this.browser.wasDetermined()) {
             $log.warn('Could not determine browser version');
             this.showBrowserWarning();
-        } else if (this.browser.chrome === true) {
+        } else if (this.browser.name === threema.BrowserName.Chrome) {
             if (version < minVersions.CHROME) {
                 $log.warn('Chrome is too old (' + version + ' < ' + minVersions.CHROME + ')');
                 this.showBrowserWarning();
             }
-        } else if (this.browser.firefox === true) {
+        } else if (this.browser.name === threema.BrowserName.Firefox) {
             if (version < minVersions.FF) {
                 $log.warn('Firefox is too old (' + version + ' < ' + minVersions.FF + ')');
                 this.showBrowserWarning();
             }
-        } else if (this.browser.opera === true) {
+        } else if (this.browser.name === threema.BrowserName.Opera) {
             if (version < minVersions.OPERA) {
                 $log.warn('Opera is too old (' + version + ' < ' + minVersions.OPERA + ')');
                 this.showBrowserWarning();
             }
-        } else if (this.browser.safari === true) {
+        } else if (this.browser.name === threema.BrowserName.Safari) {
             if (version < minVersions.SAFARI) {
                 $log.warn('Safari is too old (' + version + ' < ' + minVersions.SAFARI + ')');
                 this.showBrowserWarning();

--- a/src/services/browser.ts
+++ b/src/services/browser.ts
@@ -99,17 +99,20 @@ export class BrowserService {
 
             const uagent = this.$window.navigator.userAgent.toLowerCase();
 
-            this.browser.chrome  = /webkit/.test(uagent)  && /chrome/.test(uagent) && !/edge/.test(uagent);
+            this.browser.chrome  = /webkit/.test(uagent) && /chrome/.test(uagent) && !/edge/.test(uagent);
             this.browser.firefox = /mozilla/.test(uagent) && /firefox/.test(uagent);
             this.browser.ie      = (/msie/.test(uagent) || /trident/.test(uagent)) && !/edge/.test(uagent);
             this.browser.edge    = /edge/.test(uagent);
-            this.browser.safari  = /safari/.test(uagent)  && /applewebkit/.test(uagent) && !/chrome/.test(uagent);
+            this.browser.safari  = /safari/.test(uagent) && /applewebkit/.test(uagent) && !/chrome/.test(uagent);
             this.browser.opera   = /mozilla/.test(uagent) && /applewebkit/.test(uagent)
                 && /chrome/.test(uagent) && /safari/.test(uagent) && /opr/.test(uagent);
 
             if (this.browser.opera && this.browser.chrome) {
                 this.browser.chrome = false;
             }
+
+            // Mobile detection
+            this.browser.mobile = this.browser.safari && /mobile/.test(uagent);
 
             for (const x in this.browser) {
                 if (this.browser[x]) {
@@ -164,6 +167,9 @@ export class BrowserService {
             if (this.browser.opera) {
                 this.browser.name = BrowserName.Opera;
                 this.browser.textInfo = 'Opera ' + this.browser.version;
+            }
+            if (this.browser.textInfo && this.browser.mobile) {
+                this.browser.textInfo += ' Mobile';
             }
         }
 

--- a/src/services/browser.ts
+++ b/src/services/browser.ts
@@ -15,12 +15,14 @@
  * along with Threema Web. If not, see <http://www.gnu.org/licenses/>.
  */
 
+import {BrowserInfo} from '../helpers/browser_info';
+
 import BrowserName = threema.BrowserName;
 
 export class BrowserService {
     private logTag: string = '[BrowserService]';
 
-    private browser: threema.BrowserInfo;
+    private browser: BrowserInfo;
     private $log: ng.ILogService;
     private $window: ng.IWindowService;
     private isPageVisible = true;
@@ -86,44 +88,39 @@ export class BrowserService {
         }
     }
 
-    public getBrowser(): threema.BrowserInfo {
+    public getBrowser(): BrowserInfo {
         if (this.browser === undefined) {
-            this.browser = {
+            const browser = {
                 chrome: false,
+                chromeIos: false,
                 firefox: false,
-                fxios: false,
+                firefoxIos: false,
                 ie: false,
                 edge: false,
                 opera: false,
                 safari: false,
-            } as threema.BrowserInfo;
+            };
 
             const uagent = this.$window.navigator.userAgent.toLowerCase();
 
-            this.browser.chrome = /webkit/.test(uagent) && /chrome/.test(uagent) && !/edge/.test(uagent);
-            this.browser.firefox = /mozilla/.test(uagent) && /firefox/.test(uagent);
-            this.browser.fxios = /mozilla/.test(uagent) && /fxios/.test(uagent);
-            this.browser.ie = (/msie/.test(uagent) || /trident/.test(uagent)) && !/edge/.test(uagent);
-            this.browser.edge = /edge/.test(uagent);
-            this.browser.safari = /safari/.test(uagent) && /applewebkit/.test(uagent)
-                               && !/chrome/.test(uagent) && !/fxios/.test(uagent);
-            this.browser.opera = /mozilla/.test(uagent) && /applewebkit/.test(uagent)
+            browser.chrome = /webkit/.test(uagent) && /chrome/.test(uagent) && !/edge/.test(uagent);
+            browser.chromeIos = /mozilla/.test(uagent) && /crios/.test(uagent);
+            browser.firefox = /mozilla/.test(uagent) && /firefox/.test(uagent);
+            browser.firefoxIos = /mozilla/.test(uagent) && /fxios/.test(uagent);
+            browser.ie = (/msie/.test(uagent) || /trident/.test(uagent)) && !/edge/.test(uagent);
+            browser.edge = /edge/.test(uagent);
+            browser.safari = /safari/.test(uagent) && /applewebkit/.test(uagent)
+                          && !/chrome/.test(uagent) && !/fxios/.test(uagent) && !/crios/.test(uagent);
+            browser.opera = /mozilla/.test(uagent) && /applewebkit/.test(uagent)
                 && /chrome/.test(uagent) && /safari/.test(uagent) && /opr/.test(uagent);
 
-            if (this.browser.opera && this.browser.chrome) {
-                this.browser.chrome = false;
+            if (browser.opera && browser.chrome) {
+                browser.chrome = false;
             }
 
-            // Mobile detection
-            this.browser.mobile = false;
-            if (this.browser.safari && /mobile/.test(uagent)) {
-                this.browser.mobile = true;
-            } else if (this.browser.fxios) {
-                this.browser.mobile = true;
-            }
-
-            for (const x in this.browser) {
-                if (this.browser[x]) {
+            let version = null;
+            for (const x in browser) {
+                if (browser[x]) {
                     let b;
                     if (x === 'ie') {
                         b = 'msie';
@@ -131,6 +128,10 @@ export class BrowserService {
                         b = 'edge';
                     } else if (x === 'opera') {
                         b = 'opr';
+                    } else if (x === 'firefoxIos') {
+                        b = 'fxios';
+                    } else if (x === 'chromeIos') {
+                        b = 'crios';
                     } else if (x === 'safari') {
                         b = 'version';
                     } else {
@@ -138,50 +139,44 @@ export class BrowserService {
                     }
                     let match = uagent.match(new RegExp('(' + b + ')( |\/)([0-9]+)'));
 
-                    let version;
+                    let versionString;
                     if (match) {
-                        version = match[3];
+                        versionString = match[3];
                     } else {
                         match = uagent.match(new RegExp('rv:([0-9]+)'));
-                        version = match ? match[1] : '';
+                        versionString = match ? match[1] : '';
                     }
-                    const versionInt: number = parseInt(match[3], 10);
-                    this.browser.version = isNaN(versionInt) ? undefined : versionInt;
+                    const versionInt: number = parseInt(versionString, 10);
+                    version = isNaN(versionInt) ? undefined : versionInt;
 
                     break;
                 }
             }
 
-            if (this.browser.chrome) {
-                this.browser.name = BrowserName.Chrome;
-                this.browser.textInfo = 'Chrome ' + this.browser.version;
+            if (browser.chrome) {
+                this.browser = new BrowserInfo(uagent, BrowserName.Chrome, version);
             }
-            if (this.browser.firefox) {
-                this.browser.name = BrowserName.Firefox;
-                this.browser.textInfo = 'Firefox ' + this.browser.version;
+            if (browser.chromeIos) {
+                this.browser = new BrowserInfo(uagent, BrowserName.ChromeIos, version, true);
             }
-            if (this.browser.fxios) {
-                this.browser.name = BrowserName.FirefoxIos;
-                this.browser.textInfo = 'Firefox (iOS) ' + this.browser.version;
+            if (browser.firefox) {
+                this.browser = new BrowserInfo(uagent, BrowserName.Firefox, version);
             }
-            if (this.browser.ie) {
-                this.browser.name = BrowserName.InternetExplorer;
-                this.browser.textInfo = 'Internet Explorer ' + this.browser.version;
+            if (browser.firefoxIos) {
+                this.browser = new BrowserInfo(uagent, BrowserName.FirefoxIos, version, true);
             }
-            if (this.browser.edge) {
-                this.browser.name = BrowserName.Edge;
-                this.browser.textInfo = 'Edge ' + this.browser.version;
+            if (browser.ie) {
+                this.browser = new BrowserInfo(uagent, BrowserName.InternetExplorer, version);
             }
-            if (this.browser.safari) {
-                this.browser.name = BrowserName.Safari;
-                this.browser.textInfo = 'Safari ' + this.browser.version;
+            if (browser.edge) {
+                this.browser = new BrowserInfo(uagent, BrowserName.Edge, version);
             }
-            if (this.browser.opera) {
-                this.browser.name = BrowserName.Opera;
-                this.browser.textInfo = 'Opera ' + this.browser.version;
+            if (browser.safari) {
+                const mobile = /mobile/.test(uagent);
+                this.browser = new BrowserInfo(uagent, BrowserName.Safari, version, mobile);
             }
-            if (this.browser.textInfo && this.browser.mobile) {
-                this.browser.textInfo += ' [Mobile]';
+            if (browser.opera) {
+                this.browser = new BrowserInfo(uagent, BrowserName.Opera, version);
             }
         }
 
@@ -199,10 +194,7 @@ export class BrowserService {
         if (this.browser === undefined) {
             this.getBrowser();
         }
-        if (this.browser.safari || this.browser.fxios) {
-            return false;
-        }
-        return true;
+        return this.browser.supportsWebrtcTask();
     }
 
     /**

--- a/src/services/browser.ts
+++ b/src/services/browser.ts
@@ -91,6 +91,7 @@ export class BrowserService {
             this.browser = {
                 chrome: false,
                 firefox: false,
+                fxios: false,
                 ie: false,
                 edge: false,
                 opera: false,
@@ -99,12 +100,14 @@ export class BrowserService {
 
             const uagent = this.$window.navigator.userAgent.toLowerCase();
 
-            this.browser.chrome  = /webkit/.test(uagent) && /chrome/.test(uagent) && !/edge/.test(uagent);
+            this.browser.chrome = /webkit/.test(uagent) && /chrome/.test(uagent) && !/edge/.test(uagent);
             this.browser.firefox = /mozilla/.test(uagent) && /firefox/.test(uagent);
-            this.browser.ie      = (/msie/.test(uagent) || /trident/.test(uagent)) && !/edge/.test(uagent);
-            this.browser.edge    = /edge/.test(uagent);
-            this.browser.safari  = /safari/.test(uagent) && /applewebkit/.test(uagent) && !/chrome/.test(uagent);
-            this.browser.opera   = /mozilla/.test(uagent) && /applewebkit/.test(uagent)
+            this.browser.fxios = /mozilla/.test(uagent) && /fxios/.test(uagent);
+            this.browser.ie = (/msie/.test(uagent) || /trident/.test(uagent)) && !/edge/.test(uagent);
+            this.browser.edge = /edge/.test(uagent);
+            this.browser.safari = /safari/.test(uagent) && /applewebkit/.test(uagent)
+                               && !/chrome/.test(uagent) && !/fxios/.test(uagent);
+            this.browser.opera = /mozilla/.test(uagent) && /applewebkit/.test(uagent)
                 && /chrome/.test(uagent) && /safari/.test(uagent) && /opr/.test(uagent);
 
             if (this.browser.opera && this.browser.chrome) {
@@ -112,7 +115,12 @@ export class BrowserService {
             }
 
             // Mobile detection
-            this.browser.mobile = this.browser.safari && /mobile/.test(uagent);
+            this.browser.mobile = false;
+            if (this.browser.safari && /mobile/.test(uagent)) {
+                this.browser.mobile = true;
+            } else if (this.browser.fxios) {
+                this.browser.mobile = true;
+            }
 
             for (const x in this.browser) {
                 if (this.browser[x]) {
@@ -152,6 +160,10 @@ export class BrowserService {
                 this.browser.name = BrowserName.Firefox;
                 this.browser.textInfo = 'Firefox ' + this.browser.version;
             }
+            if (this.browser.fxios) {
+                this.browser.name = BrowserName.FirefoxIos;
+                this.browser.textInfo = 'Firefox (iOS) ' + this.browser.version;
+            }
             if (this.browser.ie) {
                 this.browser.name = BrowserName.InternetExplorer;
                 this.browser.textInfo = 'Internet Explorer ' + this.browser.version;
@@ -169,7 +181,7 @@ export class BrowserService {
                 this.browser.textInfo = 'Opera ' + this.browser.version;
             }
             if (this.browser.textInfo && this.browser.mobile) {
-                this.browser.textInfo += ' Mobile';
+                this.browser.textInfo += ' [Mobile]';
             }
         }
 
@@ -187,7 +199,7 @@ export class BrowserService {
         if (this.browser === undefined) {
             this.getBrowser();
         }
-        if (this.browser.safari) {
+        if (this.browser.safari || this.browser.fxios) {
             return false;
         }
         return true;

--- a/src/services/webclient.ts
+++ b/src/services/webclient.ts
@@ -326,7 +326,7 @@ export class WebClientService {
         this.stateService.reset();
 
         // Create WebRTC task instance
-        const maxPacketSize = this.browserService.getBrowser().firefox ? 16384 : 65536;
+        const maxPacketSize = this.browserService.getBrowser().isFirefox(false) ? 16384 : 65536;
         this.webrtcTask = new saltyrtcTaskWebrtc.WebRTCTask(true, maxPacketSize);
 
         // Create Relayed Data task instance
@@ -437,12 +437,12 @@ export class WebClientService {
                 const browser = this.browserService.getBrowser();
 
                 // Firefox <53 does not yet support TLS. Skip it, to save allocations.
-                if (browser.firefox && browser.version && browser.version < 53) {
+                if (browser.isFirefox(true) && browser.version < 53) {
                     this.skipIceTls();
                 }
 
                 // Safari does not support our dual-stack TURN servers.
-                if (browser.safari) {
+                if (browser.isSafari(false)) {
                     this.skipIceDs();
                 }
 

--- a/src/threema.d.ts
+++ b/src/threema.d.ts
@@ -504,8 +504,9 @@ declare namespace threema {
 
     const enum BrowserName {
         Chrome = 'chrome',
+        ChromeIos = 'chromeIos',
         Firefox = 'firefox',
-        FirefoxIos = 'fxios',
+        FirefoxIos = 'firefoxIos',
         InternetExplorer = 'ie',
         Edge = 'edge',
         Opera = 'opera',
@@ -514,8 +515,9 @@ declare namespace threema {
 
     interface BrowserInfo {
         chrome: boolean;
+        chromeIos: boolean;
         firefox: boolean;
-        fxios: boolean;
+        firefoxIos: boolean;
         ie: boolean;
         edge: boolean;
         opera: boolean;

--- a/src/threema.d.ts
+++ b/src/threema.d.ts
@@ -505,6 +505,7 @@ declare namespace threema {
     const enum BrowserName {
         Chrome = 'chrome',
         Firefox = 'firefox',
+        FirefoxIos = 'fxios',
         InternetExplorer = 'ie',
         Edge = 'edge',
         Opera = 'opera',
@@ -514,6 +515,7 @@ declare namespace threema {
     interface BrowserInfo {
         chrome: boolean;
         firefox: boolean;
+        fxios: boolean;
         ie: boolean;
         edge: boolean;
         opera: boolean;

--- a/src/threema.d.ts
+++ b/src/threema.d.ts
@@ -519,6 +519,7 @@ declare namespace threema {
         opera: boolean;
         safari: boolean;
         name?: BrowserName;
+        mobile?: boolean;
         version?: number;
         textInfo?: string;
     }

--- a/tests/service/browser.js
+++ b/tests/service/browser.js
@@ -26,6 +26,7 @@ describe('BrowserService', function() {
         expect(browser.safari).toBe(false);
         expect(browser.name).toEqual('firefox');
         expect(browser.version).toEqual(59);
+        expect(browser.mobile).toBe(false);
         expect(browser.textInfo).toEqual('Firefox 59');
     });
 
@@ -41,6 +42,7 @@ describe('BrowserService', function() {
         expect(browser.safari).toBe(false);
         expect(browser.name).toEqual('chrome');
         expect(browser.version).toEqual(65);
+        expect(browser.mobile).toBe(false);
         expect(browser.textInfo).toEqual('Chrome 65');
     });
 
@@ -56,6 +58,7 @@ describe('BrowserService', function() {
         expect(browser.safari).toBe(false);
         expect(browser.name).toEqual('ie');
         expect(browser.version).toEqual(9);
+        expect(browser.mobile).toBe(false);
         expect(browser.textInfo).toEqual('Internet Explorer 9');
     });
 
@@ -71,6 +74,7 @@ describe('BrowserService', function() {
         expect(browser.safari).toBe(false);
         expect(browser.name).toEqual('ie');
         expect(browser.version).toEqual(11);
+        expect(browser.mobile).toBe(false);
         expect(browser.textInfo).toEqual('Internet Explorer 11');
     });
 
@@ -86,6 +90,7 @@ describe('BrowserService', function() {
         expect(browser.safari).toBe(false);
         expect(browser.name).toEqual('edge');
         expect(browser.version).toEqual(12);
+        expect(browser.mobile).toBe(false);
         expect(browser.textInfo).toEqual('Edge 12');
     });
 
@@ -101,6 +106,7 @@ describe('BrowserService', function() {
         expect(browser.safari).toBe(false);
         expect(browser.name).toEqual('opera');
         expect(browser.version).toEqual(51);
+        expect(browser.mobile).toBe(false);
         expect(browser.textInfo).toEqual('Opera 51');
     });
 
@@ -116,6 +122,7 @@ describe('BrowserService', function() {
         expect(browser.safari).toBe(true);
         expect(browser.name).toEqual('safari');
         expect(browser.version).toEqual(7);
+        expect(browser.mobile).toBe(false);
         expect(browser.textInfo).toEqual('Safari 7');
     });
 
@@ -131,7 +138,24 @@ describe('BrowserService', function() {
         expect(browser.safari).toBe(true);
         expect(browser.name).toEqual('safari');
         expect(browser.version).toEqual(11);
+        expect(browser.mobile).toBe(false);
         expect(browser.textInfo).toEqual('Safari 11');
+    });
+
+    it('safari10Mobile', () => {
+        const ua = 'Mozilla/5.0 (iPad; CPU OS 10_0_1 like Mac OS X) AppleWebKit/602.1.50 (KHTML, like Gecko) Version/10.0 Mobile/14A403 Safari/602.1';
+        const service = testUserAgent(ua);
+        const browser = service.getBrowser();
+        expect(browser.chrome).toBe(false);
+        expect(browser.firefox).toBe(false);
+        expect(browser.ie).toBe(false);
+        expect(browser.edge).toBe(false);
+        expect(browser.opera).toBe(false);
+        expect(browser.safari).toBe(true);
+        expect(browser.name).toEqual('safari');
+        expect(browser.version).toEqual(10);
+        expect(browser.mobile).toBe(true);
+        expect(browser.textInfo).toEqual('Safari 10 Mobile');
     });
 
 });

--- a/tests/service/browser.js
+++ b/tests/service/browser.js
@@ -20,6 +20,7 @@ describe('BrowserService', function() {
         const browser = service.getBrowser();
         expect(browser.chrome).toBe(false);
         expect(browser.firefox).toBe(true);
+        expect(browser.fxios).toBe(false);
         expect(browser.ie).toBe(false);
         expect(browser.edge).toBe(false);
         expect(browser.opera).toBe(false);
@@ -28,6 +29,23 @@ describe('BrowserService', function() {
         expect(browser.version).toEqual(59);
         expect(browser.mobile).toBe(false);
         expect(browser.textInfo).toEqual('Firefox 59');
+    });
+
+    it('fxiosMobile', () => {
+        const ua = 'Mozilla/5.0 (iPad; CPU OS 10_0_1 like Mac OS X) AppleWebKit/602.1.50 (KHTML, like Gecko) FxiOS/8.3b5826 Mobile/14A403 Safari/602.1.50';
+        const service = testUserAgent(ua);
+        const browser = service.getBrowser();
+        expect(browser.chrome).toBe(false);
+        expect(browser.firefox).toBe(false);
+        expect(browser.fxios).toBe(true);
+        expect(browser.ie).toBe(false);
+        expect(browser.edge).toBe(false);
+        expect(browser.opera).toBe(false);
+        expect(browser.safari).toBe(false);
+        expect(browser.name).toEqual('fxios');
+        expect(browser.version).toEqual(8);
+        expect(browser.mobile).toBe(true);
+        expect(browser.textInfo).toEqual('Firefox (iOS) 8 [Mobile]');
     });
 
     it('chrome', () => {
@@ -52,6 +70,7 @@ describe('BrowserService', function() {
         const browser = service.getBrowser();
         expect(browser.chrome).toBe(false);
         expect(browser.firefox).toBe(false);
+        expect(browser.fxios).toBe(false);
         expect(browser.ie).toBe(true);
         expect(browser.edge).toBe(false);
         expect(browser.opera).toBe(false);
@@ -68,6 +87,7 @@ describe('BrowserService', function() {
         const browser = service.getBrowser();
         expect(browser.chrome).toBe(false);
         expect(browser.firefox).toBe(false);
+        expect(browser.fxios).toBe(false);
         expect(browser.ie).toBe(true);
         expect(browser.edge).toBe(false);
         expect(browser.opera).toBe(false);
@@ -84,6 +104,7 @@ describe('BrowserService', function() {
         const browser = service.getBrowser();
         expect(browser.chrome).toBe(false);
         expect(browser.firefox).toBe(false);
+        expect(browser.fxios).toBe(false);
         expect(browser.ie).toBe(false);
         expect(browser.edge).toBe(true);
         expect(browser.opera).toBe(false);
@@ -100,6 +121,7 @@ describe('BrowserService', function() {
         const browser = service.getBrowser();
         expect(browser.chrome).toBe(false);
         expect(browser.firefox).toBe(false);
+        expect(browser.fxios).toBe(false);
         expect(browser.ie).toBe(false);
         expect(browser.edge).toBe(false);
         expect(browser.opera).toBe(true);
@@ -116,6 +138,7 @@ describe('BrowserService', function() {
         const browser = service.getBrowser();
         expect(browser.chrome).toBe(false);
         expect(browser.firefox).toBe(false);
+        expect(browser.fxios).toBe(false);
         expect(browser.ie).toBe(false);
         expect(browser.edge).toBe(false);
         expect(browser.opera).toBe(false);
@@ -132,6 +155,7 @@ describe('BrowserService', function() {
         const browser = service.getBrowser();
         expect(browser.chrome).toBe(false);
         expect(browser.firefox).toBe(false);
+        expect(browser.fxios).toBe(false);
         expect(browser.ie).toBe(false);
         expect(browser.edge).toBe(false);
         expect(browser.opera).toBe(false);
@@ -148,6 +172,7 @@ describe('BrowserService', function() {
         const browser = service.getBrowser();
         expect(browser.chrome).toBe(false);
         expect(browser.firefox).toBe(false);
+        expect(browser.fxios).toBe(false);
         expect(browser.ie).toBe(false);
         expect(browser.edge).toBe(false);
         expect(browser.opera).toBe(false);
@@ -155,7 +180,7 @@ describe('BrowserService', function() {
         expect(browser.name).toEqual('safari');
         expect(browser.version).toEqual(10);
         expect(browser.mobile).toBe(true);
-        expect(browser.textInfo).toEqual('Safari 10 Mobile');
+        expect(browser.textInfo).toEqual('Safari 10 [Mobile]');
     });
 
 });

--- a/tests/service/browser.js
+++ b/tests/service/browser.js
@@ -1,3 +1,14 @@
+const BrowserName = {
+    Chrome: 'chrome',
+    ChromeIos: 'chromeIos',
+    Firefox: 'firefox',
+    FirefoxIos: 'firefoxIos',
+    InternetExplorer: 'ie',
+    Edge: 'edge',
+    Opera: 'opera',
+    Safari: 'safari',
+};
+
 describe('BrowserService', function() {
 
     function testUserAgent(agent) {
@@ -18,169 +29,110 @@ describe('BrowserService', function() {
         const ua = 'Mozilla/5.0 (X11; Linux x86_64; rv:59.0) Gecko/20100101 Firefox/59.0';
         const service = testUserAgent(ua);
         const browser = service.getBrowser();
-        expect(browser.chrome).toBe(false);
-        expect(browser.firefox).toBe(true);
-        expect(browser.fxios).toBe(false);
-        expect(browser.ie).toBe(false);
-        expect(browser.edge).toBe(false);
-        expect(browser.opera).toBe(false);
-        expect(browser.safari).toBe(false);
-        expect(browser.name).toEqual('firefox');
+        expect(browser.name).toEqual(BrowserName.Firefox);
         expect(browser.version).toEqual(59);
         expect(browser.mobile).toBe(false);
-        expect(browser.textInfo).toEqual('Firefox 59');
+        expect(browser.description()).toEqual('Firefox 59');
     });
 
-    it('fxiosMobile', () => {
+    it('firefoxIosMobile', () => {
         const ua = 'Mozilla/5.0 (iPad; CPU OS 10_0_1 like Mac OS X) AppleWebKit/602.1.50 (KHTML, like Gecko) FxiOS/8.3b5826 Mobile/14A403 Safari/602.1.50';
         const service = testUserAgent(ua);
         const browser = service.getBrowser();
-        expect(browser.chrome).toBe(false);
-        expect(browser.firefox).toBe(false);
-        expect(browser.fxios).toBe(true);
-        expect(browser.ie).toBe(false);
-        expect(browser.edge).toBe(false);
-        expect(browser.opera).toBe(false);
-        expect(browser.safari).toBe(false);
-        expect(browser.name).toEqual('fxios');
+        expect(browser.name).toBe(BrowserName.FirefoxIos);
         expect(browser.version).toEqual(8);
         expect(browser.mobile).toBe(true);
-        expect(browser.textInfo).toEqual('Firefox (iOS) 8 [Mobile]');
+        expect(browser.description()).toEqual('Firefox (iOS) 8 [Mobile]');
     });
 
     it('chrome', () => {
         const ua = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.162 Safari/537.36';
         const service = testUserAgent(ua);
         const browser = service.getBrowser();
-        expect(browser.chrome).toBe(true);
-        expect(browser.firefox).toBe(false);
-        expect(browser.ie).toBe(false);
-        expect(browser.edge).toBe(false);
-        expect(browser.opera).toBe(false);
-        expect(browser.safari).toBe(false);
-        expect(browser.name).toEqual('chrome');
+        expect(browser.name).toBe(BrowserName.Chrome);
         expect(browser.version).toEqual(65);
         expect(browser.mobile).toBe(false);
-        expect(browser.textInfo).toEqual('Chrome 65');
+        expect(browser.description()).toEqual('Chrome 65');
+    });
+
+    it('chromeIosMobile', () => {
+        const ua = 'Mozilla/5.0 (iPad; CPU OS 10_0_1 like Mac OS X) AppleWebKit/602.1.50 (KHTML, like Gecko) CriOS/68.0.3440.83 Mobile/14A403 Safari/602.1';
+        const service = testUserAgent(ua);
+        const browser = service.getBrowser();
+        expect(browser.name).toBe(BrowserName.ChromeIos);
+        expect(browser.version).toEqual(68);
+        expect(browser.mobile).toBe(true);
+        expect(browser.description()).toEqual('Chrome (iOS) 68 [Mobile]');
     });
 
     it('ie9', () => {
         const ua = 'Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 7.1; Trident/5.0)';
         const service = testUserAgent(ua);
         const browser = service.getBrowser();
-        expect(browser.chrome).toBe(false);
-        expect(browser.firefox).toBe(false);
-        expect(browser.fxios).toBe(false);
-        expect(browser.ie).toBe(true);
-        expect(browser.edge).toBe(false);
-        expect(browser.opera).toBe(false);
-        expect(browser.safari).toBe(false);
-        expect(browser.name).toEqual('ie');
+        expect(browser.name).toBe(BrowserName.InternetExplorer);
         expect(browser.version).toEqual(9);
         expect(browser.mobile).toBe(false);
-        expect(browser.textInfo).toEqual('Internet Explorer 9');
+        expect(browser.description()).toEqual('Internet Explorer 9');
     });
 
     it('ie11', () => {
         const ua = 'Mozilla/5.0 (compatible, MSIE 11, Windows NT 6.3; Trident/7.0; rv:11.0) like Gecko';
         const service = testUserAgent(ua);
         const browser = service.getBrowser();
-        expect(browser.chrome).toBe(false);
-        expect(browser.firefox).toBe(false);
-        expect(browser.fxios).toBe(false);
-        expect(browser.ie).toBe(true);
-        expect(browser.edge).toBe(false);
-        expect(browser.opera).toBe(false);
-        expect(browser.safari).toBe(false);
-        expect(browser.name).toEqual('ie');
+        expect(browser.name).toBe(BrowserName.InternetExplorer);
         expect(browser.version).toEqual(11);
         expect(browser.mobile).toBe(false);
-        expect(browser.textInfo).toEqual('Internet Explorer 11');
+        expect(browser.description()).toEqual('Internet Explorer 11');
     });
 
     it('edge12', () => {
         const ua = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.246';
         const service = testUserAgent(ua);
         const browser = service.getBrowser();
-        expect(browser.chrome).toBe(false);
-        expect(browser.firefox).toBe(false);
-        expect(browser.fxios).toBe(false);
-        expect(browser.ie).toBe(false);
-        expect(browser.edge).toBe(true);
-        expect(browser.opera).toBe(false);
-        expect(browser.safari).toBe(false);
-        expect(browser.name).toEqual('edge');
+        expect(browser.name).toBe(BrowserName.Edge);
         expect(browser.version).toEqual(12);
         expect(browser.mobile).toBe(false);
-        expect(browser.textInfo).toEqual('Edge 12');
+        expect(browser.description()).toEqual('Edge 12');
     });
 
     it('opera', () => {
         const ua = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.186 Safari/537.36 OPR/51.0.2830.55';
         const service = testUserAgent(ua);
         const browser = service.getBrowser();
-        expect(browser.chrome).toBe(false);
-        expect(browser.firefox).toBe(false);
-        expect(browser.fxios).toBe(false);
-        expect(browser.ie).toBe(false);
-        expect(browser.edge).toBe(false);
-        expect(browser.opera).toBe(true);
-        expect(browser.safari).toBe(false);
-        expect(browser.name).toEqual('opera');
+        expect(browser.name).toBe(BrowserName.Opera);
         expect(browser.version).toEqual(51);
         expect(browser.mobile).toBe(false);
-        expect(browser.textInfo).toEqual('Opera 51');
+        expect(browser.description()).toEqual('Opera 51');
     });
 
     it('safari7', () => {
         const ua = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_3) AppleWebKit/537.75.14 (KHTML, like Gecko) Version/7.0.3 Safari/7046A194A';
         const service = testUserAgent(ua);
         const browser = service.getBrowser();
-        expect(browser.chrome).toBe(false);
-        expect(browser.firefox).toBe(false);
-        expect(browser.fxios).toBe(false);
-        expect(browser.ie).toBe(false);
-        expect(browser.edge).toBe(false);
-        expect(browser.opera).toBe(false);
-        expect(browser.safari).toBe(true);
-        expect(browser.name).toEqual('safari');
+        expect(browser.name).toBe(BrowserName.Safari);
         expect(browser.version).toEqual(7);
         expect(browser.mobile).toBe(false);
-        expect(browser.textInfo).toEqual('Safari 7');
+        expect(browser.description()).toEqual('Safari 7');
     });
 
     it('safari11', () => {
         const ua = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/604.5.6 (KHTML, like Gecko) Version/11.0.3 Safari/604.5.6';
         const service = testUserAgent(ua);
         const browser = service.getBrowser();
-        expect(browser.chrome).toBe(false);
-        expect(browser.firefox).toBe(false);
-        expect(browser.fxios).toBe(false);
-        expect(browser.ie).toBe(false);
-        expect(browser.edge).toBe(false);
-        expect(browser.opera).toBe(false);
-        expect(browser.safari).toBe(true);
-        expect(browser.name).toEqual('safari');
+        expect(browser.name).toBe(BrowserName.Safari);
         expect(browser.version).toEqual(11);
         expect(browser.mobile).toBe(false);
-        expect(browser.textInfo).toEqual('Safari 11');
+        expect(browser.description()).toEqual('Safari 11');
     });
 
     it('safari10Mobile', () => {
         const ua = 'Mozilla/5.0 (iPad; CPU OS 10_0_1 like Mac OS X) AppleWebKit/602.1.50 (KHTML, like Gecko) Version/10.0 Mobile/14A403 Safari/602.1';
         const service = testUserAgent(ua);
         const browser = service.getBrowser();
-        expect(browser.chrome).toBe(false);
-        expect(browser.firefox).toBe(false);
-        expect(browser.fxios).toBe(false);
-        expect(browser.ie).toBe(false);
-        expect(browser.edge).toBe(false);
-        expect(browser.opera).toBe(false);
-        expect(browser.safari).toBe(true);
-        expect(browser.name).toEqual('safari');
+        expect(browser.name).toBe(BrowserName.Safari);
         expect(browser.version).toEqual(10);
         expect(browser.mobile).toBe(true);
-        expect(browser.textInfo).toEqual('Safari 10 [Mobile]');
+        expect(browser.description()).toEqual('Safari 10 [Mobile]');
     });
 
 });


### PR DESCRIPTION
Since we won't support the buggy Safari 10 data channel implementation with Android for the time being, we can also add Safari 10 support (e.g. on older iPads) for connection with iOS devices.

What this change does is hiding the "browser is not supported" warning in the beginning. There is still a note saying that Safari is not compatible with Android devices.

Additionally, Firefox and Chrome on iOS are explicitly not supported.