### PR TITLE
Fix size of buttons on connect error page

### DIFF
--- a/src/sass/sections/_welcome.scss
+++ b/src/sass/sections/_welcome.scss
@@ -153,11 +153,11 @@
             .forget {
                 margin-top: 8px;
             }
-            
+
             .reload-btn {
-            	margin: 20px 20px 0px;
-            	width: 130px;
-            	height: 35px;
+                margin: 20px 10px 0px;
+                width: 160px;
+                height: 35px;
             }
         }
     }

--- a/src/sass/sections/_welcome.scss
+++ b/src/sass/sections/_welcome.scss
@@ -156,7 +156,7 @@
 
             .reload-btn {
                 margin: 20px 10px 0px;
-                width: 160px;
+                padding: 0 10px;
                 height: 35px;
             }
         }


### PR DESCRIPTION
The buttons on the connect error page were fine in English...

![screenshot](https://tmp.dbrgn.ch/screenshots/20180821183950-ku55wj_b.png)

...but not in German:

![screenshot: buttons too small](https://tmp.dbrgn.ch/screenshots/20180821184014-wl3wuwox.png)

I made them a bit larger:

![screenshot: fixed](https://tmp.dbrgn.ch/screenshots/20180821184103-oislq82t.png)