### PR TITLE
Don't linkify latest message excerpt in conversation list

### DIFF
--- a/src/directives/latest_message.html
+++ b/src/directives/latest_message.html
@@ -29,8 +29,7 @@
         </eee-message-voip-status>
 
         <!-- For text-messages, show message text excerpt. -->
-        <span eee-message-text class="message-text" eee-message="ctrl.message"
-            eee-multi-line="false"></span>
+        <span eee-message-text class="message-text" eee-message="ctrl.message" multi-line="false" linkify="false"></span>
 
     </div>
     <div class="left hidden no-typing">

--- a/src/directives/message_text.ts
+++ b/src/directives/message_text.ts
@@ -26,7 +26,8 @@ export default [
             scope: {},
             bindToController: {
                 message: '=eeeMessage',
-                multiLine: '=?eeeMultiLine',
+                multiLine: '@?multiLine',
+                linkify: '@?linkify',
             },
             controllerAs: 'ctrl',
             controller: ['WebClientService', '$filter', function(webClientService: WebClientService, $filter: ng.IFilterService) {
@@ -59,17 +60,22 @@ export default [
                 /**
                  * Apply filters to text.
                  */
-                function processText(text: string, largeSingleEmoji: boolean, multiLine: boolean): string {
-                    return nlToBr(linkify(mentionify(enlargeSingleEmoji(emojify(markify(escapeHtml(text))), enlargeSingleEmoji))), multiLine);
+                function processText(text: string, largeSingleEmoji: boolean, multiLine: boolean, linkifyText: boolean): string {
+                    const nonLinkified = mentionify(enlargeSingleEmoji(emojify(markify(escapeHtml(text))), enlargeSingleEmoji));
+                    const maybeLinkified = linkifyText ? linkify(nonLinkified) : nonLinkified;
+                    return nlToBr(maybeLinkified, multiLine);
                 }
 
                 this.enlargeSingleEmoji = webClientService.appConfig.largeSingleEmoji;
 
                 this.$onInit = function() {
-                    if (this.multiLine === undefined) {
-                        this.multiLine = true;
-                    }
-                    this.text = processText(getText(this.message), this.largeSingleEmoji, this.multiLine);
+                    // Because this.multiLine and this.linkify are bound using an `@` binding,
+                    // they are either undefined or a string. Convert to boolean.
+                    const multiLine = (this.multiLine === undefined || this.multiLine === 'true');
+                    const linkifyText = (this.linkify === undefined || this.linkify === 'true');
+
+                    // Process text once, apply all filter functions
+                    this.text = processText(getText(this.message), this.largeSingleEmoji, multiLine, linkifyText);
                 };
             }],
             template: `

--- a/src/directives/message_text.ts
+++ b/src/directives/message_text.ts
@@ -71,8 +71,8 @@ export default [
                 this.$onInit = function() {
                     // Because this.multiLine and this.linkify are bound using an `@` binding,
                     // they are either undefined or a string. Convert to boolean.
-                    const multiLine = (this.multiLine === undefined || this.multiLine === 'true');
-                    const linkifyText = (this.linkify === undefined || this.linkify === 'true');
+                    const multiLine = (this.multiLine === undefined || this.multiLine !== 'false');
+                    const linkifyText = (this.linkify === undefined || this.linkify !== 'false');
 
                     // Process text once, apply all filter functions
                     this.text = processText(getText(this.message), this.largeSingleEmoji, multiLine, linkifyText);


### PR DESCRIPTION
There's no need for linkifying text in the conversation list.

Fixes #544.