### PR TITLE
Consistent message acknowledgements

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,5 +1,8 @@
 # Releasing
 
+Major release with backwards incompatible changes? Check for `TODO` comments
+with deprecations. Remove them if possible.
+
 Set variables:
 
     $ export VERSION=X.Y.Z

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "private": true,
   "homepage": "https://threema.ch/",
   "dependencies": {
-    "@saltyrtc/client": "^0.12.4",
+    "@saltyrtc/client": "^0.13.0",
     "@saltyrtc/task-relayed-data": "^0.3.1",
     "@saltyrtc/task-webrtc": "^0.12.1",
     "@types/angular": "^1.6.50",

--- a/src/controller_model/avatar.ts
+++ b/src/controller_model/avatar.ts
@@ -39,7 +39,7 @@ export class AvatarControllerModel {
                 $log.debug(this.logTag, 'loadAvatar: Requesting high res avatar from app');
                 webClientService.requestAvatar(receiver, true)
                     .then((data: ArrayBuffer) => resolve(data))
-                    .catch(() => reject());
+                    .catch((error) => reject(error));
             } else {
                 $log.debug(this.logTag, 'loadAvatar: Returning cached version');
                 resolve(receiver.avatar.high);

--- a/src/controller_model/contact.ts
+++ b/src/controller_model/contact.ts
@@ -141,7 +141,9 @@ export class ContactControllerModel implements threema.ControllerModel<threema.C
             .then(() => {
                 this.isLoading = false;
             })
-            .catch(() => {
+            .catch((error) => {
+                // TODO: Handle this properly / show an error message
+                this.$log.error(`Cleaning receiver conversation failed: ${error}`);
                 this.isLoading = false;
             });
     }

--- a/src/controller_model/distributionList.ts
+++ b/src/controller_model/distributionList.ts
@@ -125,7 +125,9 @@ export class DistributionListControllerModel implements threema.ControllerModel<
             .then(() => {
                 this.isLoading = false;
             })
-            .catch(() => {
+            .catch((error) => {
+                // TODO: Handle this properly / show an error message
+                this.$log.error(`Cleaning receiver conversation failed: ${error}`);
                 this.isLoading = false;
             });
     }
@@ -163,7 +165,9 @@ export class DistributionListControllerModel implements threema.ControllerModel<
         this.isLoading = true;
         this.webClientService.deleteDistributionList(this.distributionList).then(() => {
             this.isLoading = false;
-        }).catch(() => {
+        }).catch((error) => {
+            // TODO: Handle this properly / show an error message
+            this.$log.error(`Deleting distribution list failed: ${error}`);
             this.isLoading = false;
         });
     }

--- a/src/controller_model/group.ts
+++ b/src/controller_model/group.ts
@@ -140,7 +140,9 @@ export class GroupControllerModel implements threema.ControllerModel<threema.Gro
             .then(() => {
                 this.isLoading = false;
             })
-            .catch(() => {
+            .catch((error) => {
+                // TODO: Handle this properly / show an error message
+                this.$log.error(`Cleaning receiver conversation failed: ${error}`);
                 this.isLoading = false;
             });
     }
@@ -178,7 +180,9 @@ export class GroupControllerModel implements threema.ControllerModel<threema.Gro
             .then(() => {
                 this.isLoading = false;
             })
-            .catch(() => {
+            .catch((error) => {
+                // TODO: Handle this properly / show an error message
+                this.$log.error(`Leaving group failed: ${error}`);
                 this.isLoading = false;
             });
     }
@@ -212,7 +216,9 @@ export class GroupControllerModel implements threema.ControllerModel<threema.Gro
                     this.onRemovedCallback(this.group.id);
                 }
             })
-            .catch(() => {
+            .catch((error) => {
+                // TODO: Handle this properly / show an error message
+                this.$log.error(`Deleting group failed: ${error}`);
                 this.isLoading = false;
             });
     }

--- a/src/controller_model/me.ts
+++ b/src/controller_model/me.ts
@@ -156,7 +156,7 @@ export class MeControllerModel implements threema.ControllerModel<threema.MeRece
                 return this.webClientService.modifyProfile(
                     this.nickname,
                     this.avatarController.avatarChanged ? this.avatarController.getAvatar() : undefined,
-                ).then((val) => {
+                ).then(() => {
                     // Profile was successfully updated. Update local data.
                     this.webClientService.me.publicNickname = this.nickname;
                     if (this.avatarController.avatarChanged) {

--- a/src/controllers/status.ts
+++ b/src/controllers/status.ts
@@ -278,12 +278,12 @@ export class StatusController {
                 };
             }
 
-            // ... if there is at least one pending request.
-            const pendingRequests = this.webClientService.pendingRequests;
-            if (pendingRequests > 0) {
+            // ... if there is at least one unacknowledged wire message.
+            const pendingWireMessages = this.webClientService.unacknowledgedWireMessages;
+            if (pendingWireMessages > 0) {
                 return {
                     send: true,
-                    reason: `${pendingRequests} pending requests`,
+                    reason: `${pendingWireMessages} unacknowledged wire messages`,
                 };
             }
 

--- a/src/controllers/status.ts
+++ b/src/controllers/status.ts
@@ -125,6 +125,9 @@ export class StatusController {
                     }
                     this.reconnectAndroid();
                 }
+                if (this.stateService.wasConnected && isRelayedData) {
+                    this.reconnectIos();
+                }
                 break;
             default:
                 this.$log.error(this.logTag, 'Invalid state change: From', oldValue, 'to', newValue);

--- a/src/directives/avatar.ts
+++ b/src/directives/avatar.ts
@@ -153,7 +153,9 @@ export default [
                                         $rootScope.$apply(() => {
                                             this.isLoading = false;
                                         });
-                                    }).catch(() => {
+                                    }).catch((error) => {
+                                        // TODO: Handle this properly / show an error message
+                                        $log.error(this.logTag, `Avatar request has been rejected: ${error}`);
                                         $rootScope.$apply(() => {
                                             this.isLoading = false;
                                         });

--- a/src/directives/message.ts
+++ b/src/directives/message.ts
@@ -159,7 +159,8 @@ export default [
                                 });
                             })
                             .catch((error) => {
-                                $log.error(this.logTag, 'Error downloading blob:', error);
+                                // TODO: Handle this properly / show an error message
+                                $log.error(this.logTag, `Error downloading blob: ${error}`);
                                 this.downloading = false;
                             });
                     };

--- a/src/directives/message_media.ts
+++ b/src/directives/message_media.ts
@@ -175,7 +175,12 @@ export default [
                                             .then((img) => $timeout(() => {
                                                 setThumbnail(img);
                                                 this.thumbnailDownloading = false;
-                                            }));
+                                            }))
+                                            .catch((error) => {
+                                                // TODO: Handle this properly / show an error message
+                                                const message = `Thumbnail request has been rejected: ${error}`;
+                                                this.$log.error(this.logTag, message);
+                                            });
                                     }, 1000);
                                 }
                             }

--- a/src/partials/messenger.ts
+++ b/src/partials/messenger.ts
@@ -595,7 +595,7 @@ class ConversationController {
                                 msg.caption = caption;
                             }
                             msg.sendAsFile = sendAsFile;
-                            this.webClientService.sendMessage(this.$stateParams, type, true, msg)
+                            this.webClientService.sendMessage(this.$stateParams, type, msg)
                                 .then(() => {
                                     nextCallback(index);
                                 })
@@ -618,7 +618,7 @@ class ConversationController {
                         // TODO: This should probably be moved into the
                         //       WebClientService as a specific method for the
                         //       type.
-                        this.webClientService.sendMessage(this.$stateParams, type, true, msg)
+                        this.webClientService.sendMessage(this.$stateParams, type, msg)
                             .then(() => {
                                 nextCallback(index);
                             })
@@ -1225,8 +1225,9 @@ class ReceiverDetailController {
                     this.hasSystemEmails = contactReceiver.systemContact.emails.length > 0;
                     this.hasSystemPhones = contactReceiver.systemContact.phoneNumbers.length > 0;
                 })
-                .catch(() => {
-                    // do nothing
+                .catch((error) => {
+                    // TODO: Redirect or show an alert?
+                    $log.error(this.logTag, `Contact detail request has been rejected: ${error}`);
                 });
 
             this.isWorkReceiver = contactReceiver.identityType === threema.IdentityType.Work;

--- a/src/services/message.ts
+++ b/src/services/message.ts
@@ -140,13 +140,16 @@ export class MessageService {
     }
 
     /**
-     * Create a message object with a temporaryId
+     * Create a message object with a temporary id
      */
-    public createTemporary(receiver: threema.Receiver, msgType: string,
-                           messageData: threema.MessageData): threema.Message {
-        const now = new Date();
+    public createTemporary(
+        temporaryId: string,
+        receiver: threema.Receiver,
+        msgType: string,
+        messageData: threema.MessageData,
+    ): threema.Message {
         const message = {
-            temporaryId: receiver.type + receiver.id + Math.random(),
+            temporaryId: temporaryId,
             type: msgType,
             isOutbox: true,
             state: 'pending',
@@ -165,6 +168,7 @@ export class MessageService {
         }
 
         // Add delay for timeout checking
+        // TODO: This should be removed. It either works or it doesn't. There's nothing in between.
         this.$timeout(() => {
             // Set the state to timeout if it is still pending.
             // Note: If sending the message worked, by now the message object

--- a/src/services/state.ts
+++ b/src/services/state.ts
@@ -228,7 +228,7 @@ export class StateService {
     public readyToSubmit(chosenTask: ChosenTask): boolean {
         switch (chosenTask) {
             case ChosenTask.RelayedData:
-                return this.state === GlobalConnectionState.Ok || this.state === GlobalConnectionState.Warning;
+                return true;
             case ChosenTask.WebRTC:
             default:
                 return this.state === GlobalConnectionState.Ok;

--- a/src/services/webclient.ts
+++ b/src/services/webclient.ts
@@ -3726,15 +3726,6 @@ export class WebClientService {
         callback();
     }
 
-    private currentController: string;
-    public setControllerName(name: string): void {
-        this.currentController = name;
-    }
-
-    public getControllerName(): string {
-        return this.currentController;
-    }
-
     /**
      * Update the unread count in the window title.
      */

--- a/src/services/webclient.ts
+++ b/src/services/webclient.ts
@@ -1485,8 +1485,8 @@ export class WebClientService {
         type: threema.MessageContentType,
         retransmit: boolean,
         message: threema.MessageData,
-    ): Promise<Promise<any>> {
-        return new Promise<any> (
+    ): Promise<void> {
+        return new Promise<void> (
             (resolve, reject) => {
                 // Try to load receiver object
                 const receiverObject = this.receivers.getData(receiver);

--- a/src/services/webclient.ts
+++ b/src/services/webclient.ts
@@ -3459,20 +3459,6 @@ export class WebClientService {
         this._receivePromise(message, receiveResult);
     }
 
-    private _receiveDelete(type, message): void {
-        let receiveResult;
-        switch (type) {
-            case WebClientService.SUB_TYPE_CONTACT_DETAIL:
-                receiveResult = this._receiveUpdateReceiver(message);
-                break;
-            default:
-                this.$log.warn('Ignored delete with type:', type);
-                return;
-        }
-
-        this._receivePromise(message, receiveResult);
-    }
-
     /**
      * Encode an object using the msgpack format.
      */

--- a/src/services/webclient.ts
+++ b/src/services/webclient.ts
@@ -3219,7 +3219,6 @@ export class WebClientService {
     private _sendPromiseMessage(
         message: threema.WireMessage,
         retransmit: boolean,
-        timeout: number = null,
     ): Promise<any> {
         // Create arguments on wired message
         if (message.args === undefined || message.args === null) {
@@ -3236,14 +3235,6 @@ export class WebClientService {
         const promise = new Future();
         this.requestPromises.set(promiseId, promise);
 
-        // Schedule rejection (if timeout set)
-        if (timeout !== null && timeout > 0) {
-            this.$timeout(() => {
-                promise.reject('timeout');
-                this.requestPromises.delete(promiseId);
-            }, timeout);
-        }
-
         // Send request & return promise
         this.send(message, retransmit);
         return promise;
@@ -3253,24 +3244,25 @@ export class WebClientService {
      * Send a request and return a promise.
      *
      * The promise will be resolved if a response arrives with the same temporary ID.
-     *
-     * @param timeout Optional request timeout in ms
      */
-    private _sendRequestPromise(type, retransmit: boolean, args = null, timeout: number = null): Promise<any> {
+    private _sendRequestPromise(
+        type: string,
+        retransmit: boolean,
+        args = null,
+    ): Promise<any> {
         const message: threema.WireMessage = {
             type: WebClientService.TYPE_REQUEST,
             subType: type,
             args: args,
         };
-        return this._sendPromiseMessage(message, retransmit, timeout);
+        return this._sendPromiseMessage(message, retransmit);
     }
 
     private _sendCreatePromise(
-        type,
+        type: string,
         retransmit: boolean,
         args = null,
         data: any = null,
-        timeout: number = null,
     ): Promise<any> {
         const message: threema.WireMessage = {
             type: WebClientService.TYPE_CREATE,
@@ -3278,15 +3270,14 @@ export class WebClientService {
             args: args,
             data: data,
         };
-        return this._sendPromiseMessage(message, retransmit, timeout);
+        return this._sendPromiseMessage(message, retransmit);
     }
 
     private _sendUpdatePromise(
-        type,
+        type: string,
         retransmit: boolean,
         args = null,
         data: any = null,
-        timeout: number = null,
     ): Promise<any> {
         const message: threema.WireMessage = {
             type: WebClientService.TYPE_UPDATE,
@@ -3294,36 +3285,14 @@ export class WebClientService {
             data: data,
             args: args,
         };
-        return this._sendPromiseMessage(message, retransmit, timeout);
-    }
-
-    private _sendCreate(type, retransmit: boolean, data, args = null): void {
-        const message: threema.WireMessage = {
-            type: WebClientService.TYPE_CREATE,
-            subType: type,
-            data: data,
-        };
-        if (args) {
-            message.args = args;
-        }
-        this.send(message, retransmit);
-    }
-
-    private _sendDelete(type, retransmit: boolean, args, data = null): void {
-        const message: threema.WireMessage = {
-            type: WebClientService.TYPE_DELETE,
-            subType: type,
-            data: data,
-            args: args,
-        };
-        this.send(message, retransmit);
+        return this._sendPromiseMessage(message, retransmit);
     }
 
     private _sendDeletePromise(
-        type, retransmit: boolean,
-        args,
+        type: string,
+        retransmit: boolean,
+        args = null,
         data: any = null,
-        timeout: number = null,
     ): Promise<any> {
         const message: threema.WireMessage = {
             type: WebClientService.TYPE_DELETE,
@@ -3331,7 +3300,7 @@ export class WebClientService {
             data: data,
             args: args,
         };
-        return this._sendPromiseMessage(message, retransmit, timeout);
+        return this._sendPromiseMessage(message, retransmit);
     }
 
     private _receiveRequest(type, message): void {

--- a/src/services/webclient.ts
+++ b/src/services/webclient.ts
@@ -22,7 +22,9 @@
 import {StateService as UiStateService} from '@uirouter/angularjs';
 
 import * as msgpack from 'msgpack-lite';
-import {arraysAreEqual, hasFeature, hasValue, hexToU8a, msgpackVisualizer, stringToUtf8a} from '../helpers';
+import {
+    arraysAreEqual, hasFeature, hasValue, hexToU8a, msgpackVisualizer, randomString, stringToUtf8a,
+} from '../helpers';
 import {isContactReceiver, isDistributionListReceiver, isGroupReceiver, isValidReceiverType} from '../typeguards';
 import {BatteryStatusService} from './battery';
 import {BrowserService} from './browser';
@@ -106,7 +108,8 @@ export class WebClientService {
     private static SUB_TYPE_GROUP_SYNC = 'groupSync';
     private static SUB_TYPE_BATTERY_STATUS = 'batteryStatus';
     private static SUB_TYPE_CLEAN_RECEIVER_CONVERSATION = 'cleanReceiverConversation';
-    private static SUB_TYPE_CONFIRM_ACTION = 'confirmAction';
+    private static SUB_TYPE_CONFIRM = 'confirm';
+    private static SUB_TYPE_CONFIRM_ACTION = 'confirmAction'; // TODO: deprecated
     private static SUB_TYPE_PROFILE = 'profile';
     private static SUB_TYPE_CONNECTION_ACK = 'connectionAck';
     private static SUB_TYPE_CONNECTION_DISCONNECT = 'connectionDisconnect';
@@ -117,7 +120,7 @@ export class WebClientService {
     private static ARGUMENT_MODE_REMOVED = 'removed';
     private static ARGUMENT_RECEIVER_TYPE = 'type';
     private static ARGUMENT_RECEIVER_ID = 'id';
-    private static ARGUMENT_TEMPORARY_ID = 'temporaryId';
+    private static ARGUMENT_TEMPORARY_ID = 'temporaryId'; // TODO: deprecated
     private static ARGUMENT_REFERENCE_MSG_ID = 'refMsgId';
     private static ARGUMENT_AVATAR = 'avatar';
     private static ARGUMENT_AVATAR_HIGH_RESOLUTION = 'highResolution';
@@ -127,15 +130,14 @@ export class WebClientService {
     private static ARGUMENT_HAS_MORE = 'more';
     private static ARGUMENT_MESSAGE_ACKNOWLEDGED = 'acknowledged';
     private static ARGUMENT_IDENTITY = 'identity';
-    private static ARGUMENT_SUCCESS = 'success';
-    private static ARGUMENT_MESSAGE = 'message';
+    private static ARGUMENT_SUCCESS = 'success'; // TODO: deprecated
     private static ARGUMENT_SYSTEM_CONTACT = 'systemContact';
     private static ARGUMENT_NAME = 'name';
     private static ARGUMENT_MEMBERS = 'members';
     private static ARGUMENT_FIRST_NAME = 'firstName';
     private static ARGUMENT_LAST_NAME = 'lastName';
     private static ARGUMENT_DELETE_TYPE = 'deleteType';
-    private static ARGUMENT_ERROR = 'error';
+    private static ARGUMENT_ERROR = 'error'; // TODO: deprecated
     private static ARGUMENT_MAX_SIZE = 'maxSize';
     private static ARGUMENT_USER_AGENT = 'userAgent';
     private static ARGUMENT_BROWSER_NAME = 'browserName';
@@ -233,8 +235,8 @@ export class WebClientService {
         codec: msgpack.createCodec({binarraybuffer: true}),
     };
 
-    // pending rtc promises
-    private requestPromises: Map<string, Future<any>> = new Map();
+    // Messages that require acknowledgement
+    private wireMessageFutures: Map<string, Future<any>> = new Map();
 
     public static $inject = [
         '$log', '$rootScope', '$q', '$state', '$window', '$translate', '$filter', '$timeout', '$mdDialog',
@@ -353,10 +355,15 @@ export class WebClientService {
     }
 
     /**
-     * Return the amount of pending requests.
+     * Return the amount of unacknowledged wire messages.
      */
-    get pendingRequests(): number {
-        return this.requestPromises.size;
+    get unacknowledgedWireMessages(): number {
+        return this.wireMessageFutures.size;
+    }
+
+    // TODO: Deprecated - remove this attribute and update all references
+    get requiresTemporaryIdBackwardsCompatibility(): boolean {
+        return this.chosenTask !== threema.ChosenTask.RelayedData;
     }
 
     /**
@@ -391,7 +398,7 @@ export class WebClientService {
         // should explicitly not be resumed
         if (!resume) {
             this.clearCache();
-            this.requestPromises.clear();
+            this.wireMessageFutures.clear();
         }
 
         // Only move the previous connection's instances if the previous
@@ -664,6 +671,25 @@ export class WebClientService {
     }
 
     /**
+     * Fail the session on a rejection of a Promise associated to a message.
+     */
+    private failSessionOnReject(type: string, subType: string) {
+        return ((error) => {
+            this.logOnReject(type, subType)(error);
+            this.failSession();
+        });
+    }
+
+    /**
+     * Log a rejection of a Promise associated to a message.
+     */
+    private logOnReject(type: string, subType: string) {
+        return ((error) => {
+            this.$log.error(this.logTag, `Message ${type}/${subType} has been rejected: ${error}`);
+        });
+    }
+
+    /**
      * Resume a session via the previous connection's ID and chunk cache.
      *
      * Returns whether the connection has been resumed.
@@ -836,7 +862,7 @@ export class WebClientService {
             // Reset fields, blob cache & pending requests in case the session
             // cannot be resumed
             this.clearCache();
-            this.requestPromises.clear();
+            this.wireMessageFutures.clear();
 
             // Set required initialisation steps if we have finished the
             // previous connection
@@ -1069,7 +1095,9 @@ export class WebClientService {
 
         // Send disconnect reason to the remote peer if requested
         if (args.send && this.stateService.state === threema.GlobalConnectionState.Ok) {
-            this._sendUpdate(WebClientService.SUB_TYPE_CONNECTION_DISCONNECT, false, undefined, {reason: args.reason});
+            // noinspection JSIgnoredPromiseFromCall
+            this.sendUpdateWireMessage(WebClientService.SUB_TYPE_CONNECTION_DISCONNECT, false, undefined,
+                {reason: args.reason});
         }
 
         // Stop ack timer
@@ -1108,7 +1136,7 @@ export class WebClientService {
             this.clearCache();
 
             // Remove all pending promises
-            this.requestPromises.clear();
+            this.wireMessageFutures.clear();
 
             // Reset the push service
             this.pushService.reset();
@@ -1244,14 +1272,16 @@ export class WebClientService {
                 sequenceNumber: sequenceNumber,
             };
         }
-        this._sendUpdate(WebClientService.SUB_TYPE_CONNECTION_INFO, false, args, data);
+        // noinspection JSIgnoredPromiseFromCall
+        this.sendUpdateWireMessage(WebClientService.SUB_TYPE_CONNECTION_INFO, false, args, data);
     }
 
     /**
      * Request a connection ack update.
      */
     private _requestConnectionAck(): void {
-        this._sendRequest(WebClientService.SUB_TYPE_CONNECTION_ACK, false);
+        // noinspection JSIgnoredPromiseFromCall
+        this.sendRequestWireMessage(WebClientService.SUB_TYPE_CONNECTION_ACK, false);
     }
 
     /**
@@ -1259,7 +1289,8 @@ export class WebClientService {
      */
     private _sendConnectionAck(): void {
         // Send the current incoming sequence number for chunks
-        this._sendUpdate(WebClientService.SUB_TYPE_CONNECTION_ACK, false, undefined, {
+        // noinspection JSIgnoredPromiseFromCall
+        this.sendUpdateWireMessage(WebClientService.SUB_TYPE_CONNECTION_ACK, false, undefined, {
             sequenceNumber: this.currentIncomingChunkSequenceNumber.get(),
         });
 
@@ -1284,7 +1315,9 @@ export class WebClientService {
         if (browser.version) {
             data[WebClientService.ARGUMENT_BROWSER_VERSION] = browser.version;
         }
-        this._sendRequest(WebClientService.SUB_TYPE_CLIENT_INFO, true, undefined, data);
+        const subType = WebClientService.SUB_TYPE_CLIENT_INFO;
+        this.sendRequestWireMessage(subType, !this.requiresTemporaryIdBackwardsCompatibility, undefined, data)
+            .catch(this.failSessionOnReject(WebClientService.TYPE_REQUEST, subType)); // critical request
     }
 
     /**
@@ -1292,7 +1325,9 @@ export class WebClientService {
      */
     public requestReceivers(): void {
         this.$log.debug('Sending receivers request');
-        this._sendRequest(WebClientService.SUB_TYPE_RECEIVERS, true);
+        const subType = WebClientService.SUB_TYPE_RECEIVERS;
+        this.sendRequestWireMessage(subType, !this.requiresTemporaryIdBackwardsCompatibility)
+            .catch(this.failSessionOnReject(WebClientService.TYPE_REQUEST, subType)); // critical request
     }
 
     /**
@@ -1300,9 +1335,10 @@ export class WebClientService {
      */
     public requestConversations(): void {
         this.$log.debug('Sending conversation request');
-        this._sendRequest(WebClientService.SUB_TYPE_CONVERSATIONS, true, {
-            [WebClientService.ARGUMENT_MAX_SIZE]: WebClientService.AVATAR_LOW_MAX_SIZE,
-        });
+        const subType = WebClientService.SUB_TYPE_CONVERSATIONS;
+        const args = {[WebClientService.ARGUMENT_MAX_SIZE]: WebClientService.AVATAR_LOW_MAX_SIZE};
+        this.sendRequestWireMessage(subType, !this.requiresTemporaryIdBackwardsCompatibility, args)
+            .catch(this.failSessionOnReject(WebClientService.TYPE_REQUEST, subType)); // critical request
     }
 
     /**
@@ -1310,7 +1346,9 @@ export class WebClientService {
      */
     public requestBatteryStatus(): void {
         this.$log.debug('Sending battery status request');
-        this._sendRequest(WebClientService.SUB_TYPE_BATTERY_STATUS, true);
+        const subType = WebClientService.SUB_TYPE_BATTERY_STATUS;
+        this.sendRequestWireMessage(subType, !this.requiresTemporaryIdBackwardsCompatibility)
+            .catch(this.failSessionOnReject(WebClientService.TYPE_REQUEST, subType)); // critical request
     }
 
     /**
@@ -1318,7 +1356,9 @@ export class WebClientService {
      */
     public requestProfile(): void {
         this.$log.debug('Sending profile request');
-        this._sendRequest(WebClientService.SUB_TYPE_PROFILE, true);
+        const subType = WebClientService.SUB_TYPE_PROFILE;
+        this.sendRequestWireMessage(subType, !this.requiresTemporaryIdBackwardsCompatibility)
+            .catch(this.failSessionOnReject(WebClientService.TYPE_REQUEST, subType)); // critical request
     }
 
     /**
@@ -1348,7 +1388,6 @@ export class WebClientService {
         const refMsgId = this.messages.getReferenceMsgId(receiver);
 
         // Set requested
-        // TODO: Add timeout to reset flag
         this.messages.setRequested(receiver);
 
         // Create arguments
@@ -1366,8 +1405,10 @@ export class WebClientService {
         // Send request
         this.$log.debug('Sending message request for', receiver.type, receiver.id,
             'with message id', msgId);
-
-        this._sendRequest(WebClientService.SUB_TYPE_MESSAGES, true, args);
+        const subType = WebClientService.SUB_TYPE_MESSAGES;
+        // TODO: Return the promise instead to unset the 'requested' flag?
+        this.sendRequestWireMessage(subType, !this.requiresTemporaryIdBackwardsCompatibility, args)
+            .catch(this.logOnReject(WebClientService.TYPE_REQUEST, subType));
 
         return refMsgId;
     }
@@ -1402,11 +1443,12 @@ export class WebClientService {
         }
 
         this.$log.debug('Sending', resolution, 'res avatar request for', receiver.type, receiver.id);
-        return this._sendRequestPromise(WebClientService.SUB_TYPE_AVATAR, true, args, 10000);
+        const subType = WebClientService.SUB_TYPE_AVATAR;
+        return this.sendRequestWireMessage(subType, true, args);
     }
 
     /**
-     * Send an thumbnail request for the specified receiver.
+     * Send a thumbnail request for the specified receiver.
      */
     public requestThumbnail(receiver: threema.Receiver, message: threema.Message): Promise<any> {
         // Check if the receiver has an avatar or the avatar already exists
@@ -1423,8 +1465,9 @@ export class WebClientService {
             [WebClientService.ARGUMENT_RECEIVER_ID]: receiver.id,
         };
 
-        this.$log.debug('Sending', 'thumbnail request for', receiver.type, message.id);
-        return this._sendRequestPromise(WebClientService.SUB_TYPE_THUMBNAIL, true, args, 10000);
+        this.$log.debug('Sending thumbnail request for', receiver.type, message.id);
+        const subType = WebClientService.SUB_TYPE_THUMBNAIL;
+        return this.sendRequestWireMessage(subType, true, args);
     }
 
     /**
@@ -1444,7 +1487,7 @@ export class WebClientService {
             [WebClientService.ARGUMENT_MESSAGE_ID]: msgId,
         };
         this.$log.debug('Sending blob request for message', msgId);
-        return this._sendRequestPromise(WebClientService.SUB_TYPE_BLOB, true, args);
+        return this.sendRequestWireMessage(WebClientService.SUB_TYPE_BLOB, true, args);
     }
 
     /**
@@ -1468,13 +1511,16 @@ export class WebClientService {
             [WebClientService.ARGUMENT_MESSAGE_ID]: newestMessage.id.toString(),
         };
         this.$log.debug('Sending read request for', receiver.type, receiver.id, '(msg ' + newestMessage.id + ')');
-        this._sendRequest(WebClientService.SUB_TYPE_READ, true, args);
+        const subType = WebClientService.SUB_TYPE_READ;
+        this.sendRequestWireMessage(subType, !this.requiresTemporaryIdBackwardsCompatibility, args)
+            .catch(this.logOnReject(WebClientService.TYPE_REQUEST, subType));
     }
 
     public requestContactDetail(contactReceiver: threema.ContactReceiver): Promise<any> {
-        return this._sendRequestPromise(WebClientService.SUB_TYPE_CONTACT_DETAIL, true, {
+        const args = {
             [WebClientService.ARGUMENT_IDENTITY]: contactReceiver.id,
-        });
+        };
+        return this.sendRequestWireMessage(WebClientService.SUB_TYPE_CONTACT_DETAIL, true, args);
     }
 
     /**
@@ -1483,7 +1529,6 @@ export class WebClientService {
     public sendMessage(
         receiver,
         type: threema.MessageContentType,
-        retransmit: boolean,
         message: threema.MessageData,
     ): Promise<void> {
         return new Promise<void> (
@@ -1598,42 +1643,43 @@ export class WebClientService {
                         return reject();
                 }
 
-                const temporaryMessage = this.messageService.createTemporary(receiver, type, message);
+                const id = this.createRandomWireMessageId();
+                const temporaryMessage = this.messageService.createTemporary(id, receiver, type, message);
                 this.messages.addNewer(receiver, [temporaryMessage]);
 
                 const args = {
                     [WebClientService.ARGUMENT_RECEIVER_TYPE]: receiver.type,
                     [WebClientService.ARGUMENT_RECEIVER_ID]: receiver.id,
-                    [WebClientService.ARGUMENT_TEMPORARY_ID]: temporaryMessage.temporaryId,
                 };
 
-                // Send message and handling error promise
-                this._sendCreatePromise(subType, retransmit, args, message).catch((error) => {
-                    this.$log.error('Error sending message:', error);
+                // Send message
+                this.sendCreateWireMessage(subType, true, args, message, id)
+                    .catch((error) => {
+                        this.$log.error('Error sending message:', error);
 
-                    // Remove temporary message
-                    this.messages.removeTemporary(receiver, temporaryMessage.temporaryId);
+                        // Remove temporary message
+                        this.messages.removeTemporary(receiver, temporaryMessage.temporaryId);
 
-                    // Determine error message
-                    let errorMessage;
-                    switch (error) {
-                        case 'file_too_large':
-                            errorMessage = this.$translate.instant('error.FILE_TOO_LARGE_GENERIC');
-                            break;
-                        case 'blocked':
-                            errorMessage = this.$translate.instant('error.CONTACT_BLOCKED');
-                            break;
-                        default:
-                            errorMessage = this.$translate.instant('error.ERROR_OCCURRED');
-                    }
+                        // Determine error message
+                        let errorMessage;
+                        switch (error) {
+                            case 'file_too_large':
+                                errorMessage = this.$translate.instant('error.FILE_TOO_LARGE_GENERIC');
+                                break;
+                            case 'blocked':
+                                errorMessage = this.$translate.instant('error.CONTACT_BLOCKED');
+                                break;
+                            default:
+                                errorMessage = this.$translate.instant('error.ERROR_OCCURRED');
+                        }
 
-                    // Show alert
-                    this.alerts.push({
-                        source: 'sendMessage',
-                        type: 'alert',
-                        message: errorMessage,
-                    } as threema.Alert);
-                });
+                        // Show alert
+                        this.alerts.push({
+                            source: 'sendMessage',
+                            type: 'alert',
+                            message: errorMessage,
+                        } as threema.Alert);
+                    });
                 resolve();
             });
     }
@@ -1656,7 +1702,9 @@ export class WebClientService {
             [WebClientService.ARGUMENT_MESSAGE_ID]: message.id.toString(),
             [WebClientService.ARGUMENT_MESSAGE_ACKNOWLEDGED]: acknowledged,
         };
-        this._sendRequest(WebClientService.SUB_TYPE_ACK, true, args);
+        const subType = WebClientService.SUB_TYPE_ACK;
+        this.sendRequestWireMessage(subType, !this.requiresTemporaryIdBackwardsCompatibility, args)
+            .catch(this.logOnReject(WebClientService.TYPE_REQUEST, subType));
     }
 
     /**
@@ -1673,17 +1721,24 @@ export class WebClientService {
             [WebClientService.ARGUMENT_RECEIVER_ID]: receiver.id,
             [WebClientService.ARGUMENT_MESSAGE_ID]: message.id.toString(),
         };
-        this._sendDeletePromise(WebClientService.SUB_TYPE_MESSAGE, true, args);
+        const subType = WebClientService.SUB_TYPE_MESSAGE;
+        // TODO: ARP defines error codes but they aren't handled by the caller
+        this.sendDeleteWireMessage(subType, true, args)
+            .catch(this.logOnReject(WebClientService.TYPE_DELETE, subType));
     }
 
     public sendMeIsTyping(receiver: threema.ContactReceiver, isTyping: boolean): void {
         const args = {[WebClientService.ARGUMENT_RECEIVER_ID]: receiver.id};
         const data = {[WebClientService.ARGUMENT_IS_TYPING]: isTyping};
-        this._sendUpdate(WebClientService.SUB_TYPE_TYPING, false, args, data);
+        // noinspection JSIgnoredPromiseFromCall
+        this.sendUpdateWireMessage(WebClientService.SUB_TYPE_TYPING, false, args, data);
     }
 
     public sendKeyPersisted(): void {
-        this._sendRequest(WebClientService.SUB_TYPE_KEY_PERSISTED, true);
+        // TODO: This message is not defined in ARP. Remove?
+        const subType = WebClientService.SUB_TYPE_KEY_PERSISTED;
+        this.sendRequestWireMessage(subType, !this.requiresTemporaryIdBackwardsCompatibility)
+            .catch(this.logOnReject(WebClientService.TYPE_REQUEST, subType));
     }
 
     /**
@@ -1694,16 +1749,19 @@ export class WebClientService {
         const data = {
             [WebClientService.ARGUMENT_IDENTITY]: threemaId,
         };
-        return this._sendCreatePromise(WebClientService.SUB_TYPE_CONTACT, true, args, data);
+        const subType = WebClientService.SUB_TYPE_CONTACT;
+        return this.sendCreateWireMessage(subType, true, args, data);
     }
 
     /**
-     * Modify a contact name or a avatar
+     * Modify a contact name or an avatar
      */
-    public modifyContact(threemaId: string,
-                         firstName?: string,
-                         lastName?: string,
-                         avatar?: ArrayBuffer): Promise<threema.ContactReceiver> {
+    public modifyContact(
+        threemaId: string,
+        firstName?: string,
+        lastName?: string,
+        avatar?: ArrayBuffer,
+    ): Promise<threema.ContactReceiver> {
         // Prepare payload data
         const data = {};
         if (firstName !== undefined) {
@@ -1729,11 +1787,13 @@ export class WebClientService {
         const args = {
             [WebClientService.ARGUMENT_IDENTITY]: threemaId,
         };
-        const promise = this._sendUpdatePromise(WebClientService.SUB_TYPE_CONTACT, true, args, data);
+        const subType = WebClientService.SUB_TYPE_CONTACT;
+        const promise = this.sendUpdateWireMessage(subType, true, args, data);
 
         // If necessary, force an avatar reload
         if (avatar !== undefined) {
             this.contacts.get(threemaId).avatar = {};
+            // noinspection JSIgnoredPromiseFromCall
             this.requestAvatar(contact, false);
         }
 
@@ -1758,16 +1818,19 @@ export class WebClientService {
             data[WebClientService.ARGUMENT_AVATAR] = avatar;
         }
 
-        return this._sendCreatePromise(WebClientService.SUB_TYPE_GROUP, true, args, data);
+        const subType = WebClientService.SUB_TYPE_GROUP;
+        return this.sendCreateWireMessage(subType, true, args, data);
     }
 
     /**
      * Modify a group receiver.
      */
-    public modifyGroup(id: string,
-                       members: string[],
-                       name?: string,
-                       avatar?: ArrayBuffer): Promise<threema.GroupReceiver> {
+    public modifyGroup(
+        id: string,
+        members: string[],
+        name?: string,
+        avatar?: ArrayBuffer,
+    ): Promise<threema.GroupReceiver> {
         // Prepare payload data
         const data = {
             [WebClientService.ARGUMENT_MEMBERS]: members,
@@ -1783,7 +1846,8 @@ export class WebClientService {
         const args = {
             [WebClientService.ARGUMENT_RECEIVER_ID]: id,
         };
-        const promise = this._sendUpdatePromise(WebClientService.SUB_TYPE_GROUP, true, args, data);
+        const subType = WebClientService.SUB_TYPE_GROUP;
+        const promise = this.sendUpdateWireMessage(subType, true, args, data);
 
         // If necessary, reset avatar to force a avatar reload
         if (avatar !== undefined) {
@@ -1794,31 +1858,30 @@ export class WebClientService {
 
     public leaveGroup(group: threema.GroupReceiver): Promise<any> {
         if (group === null || group === undefined || !group.access.canLeave) {
-            return new Promise((resolve, reject) => reject('not allowed'));
+            // TODO: Not a valid error code (see ARP)
+            return Promise.reject('not allowed');
         }
 
         const args = {
             [WebClientService.ARGUMENT_RECEIVER_ID]: group.id,
             [WebClientService.ARGUMENT_DELETE_TYPE]: WebClientService.DELETE_GROUP_TYPE_LEAVE,
         };
-
-        return this._sendDeletePromise(WebClientService.SUB_TYPE_GROUP, true, args);
+        const subType = WebClientService.SUB_TYPE_GROUP;
+        return this.sendDeleteWireMessage(subType, true, args);
     }
 
     public deleteGroup(group: threema.GroupReceiver): Promise<any> {
         if (group === null || group === undefined || !group.access.canDelete) {
-            return new Promise<any> (
-                (resolve, reject) => {
-                    reject('not allowed');
-                });
+            // TODO: Not a valid error code (see ARP)
+            return Promise.reject('not allowed');
         }
 
         const args = {
             [WebClientService.ARGUMENT_RECEIVER_ID]: group.id,
             [WebClientService.ARGUMENT_DELETE_TYPE]: WebClientService.DELETE_GROUP_TYPE_DELETE,
         };
-
-        return this._sendDeletePromise(WebClientService.SUB_TYPE_GROUP, true, args);
+        const subType = WebClientService.SUB_TYPE_GROUP;
+        return this.sendDeleteWireMessage(subType, true, args);
     }
 
     /**
@@ -1826,14 +1889,15 @@ export class WebClientService {
      */
     public syncGroup(group: threema.GroupReceiver): Promise<any> {
         if (group === null || group === undefined || !group.access.canSync) {
+            // TODO: Not a valid error code (see ARP)
             return Promise.reject('not allowed');
         }
 
         const args = {
             [WebClientService.ARGUMENT_RECEIVER_ID]: group.id,
         };
-
-        return this._sendRequestPromise(WebClientService.SUB_TYPE_GROUP_SYNC, true, args, 10000);
+        const subType = WebClientService.SUB_TYPE_GROUP_SYNC;
+        return this.sendRequestWireMessage(subType, true, args);
     }
 
     /**
@@ -1848,33 +1912,37 @@ export class WebClientService {
             [WebClientService.ARGUMENT_MEMBERS]: members,
             [WebClientService.ARGUMENT_NAME]: name,
         };
-
-        return this._sendCreatePromise(WebClientService.SUB_TYPE_DISTRIBUTION_LIST, true, args, data);
+        const subType = WebClientService.SUB_TYPE_DISTRIBUTION_LIST;
+        return this.sendCreateWireMessage(subType, true, args, data);
     }
 
-    public modifyDistributionList(id: string,
-                                  members: string[],
-                                  name: string = null): Promise<threema.DistributionListReceiver> {
+    public modifyDistributionList(
+        id: string,
+        members: string[],
+        name: string = null,
+    ): Promise<threema.DistributionListReceiver> {
+        const args = {
+            [WebClientService.ARGUMENT_RECEIVER_ID]: id,
+        };
         const data = {
             [WebClientService.ARGUMENT_MEMBERS]: members,
             [WebClientService.ARGUMENT_NAME]: name,
         } as any;
-
-        return this._sendUpdatePromise(WebClientService.SUB_TYPE_DISTRIBUTION_LIST, true, {
-            [WebClientService.ARGUMENT_RECEIVER_ID]: id,
-        }, data);
+        const subType = WebClientService.SUB_TYPE_DISTRIBUTION_LIST;
+        return this.sendUpdateWireMessage(subType, true, args, data);
     }
 
     public deleteDistributionList(distributionList: threema.DistributionListReceiver): Promise<any> {
         if (distributionList === null || distributionList === undefined || !distributionList.access.canDelete) {
-            return new Promise((resolve, reject) => reject('not allowed'));
+            // TODO: Not a valid error code (see ARP)
+            return Promise.reject('not allowed');
         }
 
         const args = {
             [WebClientService.ARGUMENT_RECEIVER_ID]: distributionList.id,
         };
-
-        return this._sendDeletePromise(WebClientService.SUB_TYPE_DISTRIBUTION_LIST, true, args);
+        const subType = WebClientService.SUB_TYPE_DISTRIBUTION_LIST;
+        return this.sendDeleteWireMessage(subType, true, args);
     }
 
     /**
@@ -1884,23 +1952,21 @@ export class WebClientService {
      */
     public cleanReceiverConversation(receiver: threema.Receiver): Promise<any> {
         if (receiver === null || receiver === undefined) {
-            return new Promise((resolve, reject) => reject('invalid receiver'));
+            return Promise.reject('invalidIdentity');
         }
 
         const args = {
             [WebClientService.ARGUMENT_RECEIVER_TYPE]: receiver.type,
             [WebClientService.ARGUMENT_RECEIVER_ID]: receiver.id,
         };
-
-        return this._sendDeletePromise(WebClientService.SUB_TYPE_CLEAN_RECEIVER_CONVERSATION, true, args);
+        const subType = WebClientService.SUB_TYPE_CLEAN_RECEIVER_CONVERSATION;
+        return this.sendDeleteWireMessage(subType, true, args);
     }
 
     /**
      * Modify own profile.
      */
-    public modifyProfile(nickname?: string,
-                         avatar?: ArrayBuffer): Promise<null> {
-
+    public modifyProfile(nickname?: string, avatar?: ArrayBuffer): Promise<null> {
         // Prepare payload data
         const data = {};
         if (nickname !== undefined && nickname !== null) {
@@ -1916,8 +1982,8 @@ export class WebClientService {
             return Promise.resolve(null);
         }
 
-        // Send update, get back promise
-        return this._sendUpdatePromise(WebClientService.SUB_TYPE_PROFILE, true, null, data);
+        const subType = WebClientService.SUB_TYPE_PROFILE;
+        return this.sendUpdateWireMessage(subType, true, undefined, data);
     }
 
     /**
@@ -2021,86 +2087,69 @@ export class WebClientService {
         this.requestBatteryStatus();
     }
 
-    /**
-     * Return a PromiseRequestResult with success=false and the specified error code.
-     */
-    private promiseRequestError(error: string): threema.PromiseRequestResult<undefined> {
-        return {
-            success: false,
-            error: error,
-        };
-    }
-
-    private _receiveResponseConfirmAction(message: threema.WireMessage): threema.PromiseRequestResult<void> {
-        this.$log.debug('Received receiver response');
-
-        // Unpack and validate args
-        const args = message.args;
-        if (args === undefined) {
-            this.$log.error('Invalid confirmAction response, args missing');
-            return this.promiseRequestError('invalidResponse');
-        }
-
-        switch (args[WebClientService.ARGUMENT_SUCCESS]) {
-            case true:
-                return { success: true };
-            case false:
-                return this.promiseRequestError(args[WebClientService.ARGUMENT_ERROR]);
-            default:
-                this.$log.error('Invalid confirmAction response, success field is not a boolean');
-                return this.promiseRequestError('invalidResponse');
+    // TODO: Deprecated, remove soon.
+    private _receiveResponseConfirmAction(message: threema.WireMessage): void {
+        this.$log.debug('Received confirmAction response');
+        const future = this.popWireMessageFuture(message);
+        if (!message.ack.success) {
+            future.reject(message.ack.error);
+        } else {
+            future.resolve();
         }
     }
 
     private _receiveResponseReceivers(message: threema.WireMessage): void {
         this.$log.debug('Received receivers response');
+        const future = this.popWireMessageFuture(message, this.requiresTemporaryIdBackwardsCompatibility);
+
+        // Handle error (if any)
+        if ((!this.requiresTemporaryIdBackwardsCompatibility && message.ack !== undefined) && !message.ack.success) {
+            future.reject(message.ack.error);
+        }
 
         // Unpack and validate data
         const data = message.data;
         if (data === undefined) {
             this.$log.warn('Invalid receivers response, data missing');
-            return;
+            return future.reject('invalidResponse');
         }
 
         // Store receivers
         this.sortContacts(data.contact);
         this.receivers.set(data);
         this.registerInitializationStep(InitializationStep.Receivers);
+        future.resolve();
     }
 
-    private _receiveResponseContactDetail(message: threema.WireMessage): threema.PromiseRequestResult<any> {
-        this.$log.debug('Received contact detail');
+    private _receiveResponseContactDetail(message: threema.WireMessage): void {
+        this.$log.debug('Received contact detail response');
+        const future = this.popWireMessageFuture(message);
+
+        // Handle error (if any)
+        if (!message.ack.success) {
+            return future.reject(message.ack.error);
+        }
 
         // Unpack and validate data
         const args = message.args;
         const data = message.data;
         if (args === undefined || data === undefined) {
             this.$log.error('Invalid contact response, args or data missing');
-            return this.promiseRequestError('invalidResponse');
+            return future.reject('invalidResponse');
         }
 
-        switch (args[WebClientService.ARGUMENT_SUCCESS]) {
-            case true:
-                const contactReceiver = this.receivers.contacts
-                    .get(args[WebClientService.ARGUMENT_IDENTITY]) as threema.ContactReceiver;
-                if (data[WebClientService.SUB_TYPE_RECEIVER]) {
-                    contactReceiver.systemContact =
-                        data[WebClientService.SUB_TYPE_RECEIVER][WebClientService.ARGUMENT_SYSTEM_CONTACT];
-                }
-                return {
-                    success: true,
-                    data: contactReceiver,
-                };
-            case false:
-                return this.promiseRequestError(args[WebClientService.ARGUMENT_ERROR]);
-            default:
-                this.$log.error('Invalid contact response, success field is not a boolean');
-                return this.promiseRequestError('invalidResponse');
+        // Set contact detail
+        const contactReceiver = this.receivers.contacts
+            .get(args[WebClientService.ARGUMENT_IDENTITY]) as threema.ContactReceiver;
+        if (hasValue(data[WebClientService.SUB_TYPE_RECEIVER])) {
+            contactReceiver.systemContact =
+                data[WebClientService.SUB_TYPE_RECEIVER][WebClientService.ARGUMENT_SYSTEM_CONTACT];
         }
+        future.resolve(contactReceiver);
     }
 
-    private _receiveAlert(message: threema.WireMessage): void {
-        this.$log.debug('Received alert from device');
+    private _receiveUpdateAlert(message: threema.WireMessage): void {
+        this.$log.debug('Received alert');
         this.alerts.push({
             source: message.args.source,
             type: message.args.type,
@@ -2120,6 +2169,7 @@ export class WebClientService {
      * A connectionAck update arrived.
      */
     private _receiveUpdateConnectionAck(message: threema.WireMessage) {
+        this.$log.debug('Received connection ack');
         if (!hasValue(message.data)) {
             this.$log.warn(this.logTag, 'Invalid connectionAck message: data missing');
             return;
@@ -2157,8 +2207,8 @@ export class WebClientService {
     /**
      * A connectionDisconnect message arrived.
      */
-    private _receiveConnectionDisconnect(message: threema.WireMessage) {
-        this.$log.debug(this.logTag, 'Received connectionDisconnect from device');
+    private _receiveUpdateConnectionDisconnect(message: threema.WireMessage) {
+        this.$log.debug(this.logTag, 'Received connectionDisconnect');
 
         if (!hasValue(message.data) || !hasValue(message.data.reason)) {
             this.$log.warn(this.logTag, 'Invalid connectionDisconnect message: data or reason missing');
@@ -2254,131 +2304,120 @@ export class WebClientService {
     }
 
     /**
-     * Process an incoming contact, group or distributionList response.
+     * Process an incoming 'contact', 'group' or 'distributionList' message as
+     * a reply to a previous 'create' or 'update' message of that sub-type.
      */
-    private _receiveResponseReceiver<T extends threema.Receiver>(
+    private _receiveReplyReceiver<T extends threema.Receiver>(
         message: threema.WireMessage,
         receiverType: threema.ReceiverType,
-    ): threema.PromiseRequestResult<T> {
-        this.$log.debug('Received ' + receiverType + ' response');
+        future: Future<any>,
+    ): void {
+        this.$log.debug(`Received ${receiverType} ${message.subType}`);
 
-        // Unpack and validate data
+        // Handle error (if any)
+        if (message.ack !== undefined && !message.ack.success) {
+            return future.reject(message.ack.error);
+        }
+
+        // Unpack and validate args
         const args = message.args;
         const data = message.data;
         if (args === undefined) {
-            this.$log.error('Invalid ' + receiverType + ' response, args or data missing');
-            return this.promiseRequestError('invalidResponse');
+            this.$log.error(`Invalid ${receiverType} response, args or data missing`);
+            return future.reject('invalidResponse');
         }
 
-        switch (args[WebClientService.ARGUMENT_SUCCESS]) {
-            case true:
-                if (data === undefined) {
-                    this.$log.error('Invalid ' + receiverType + ' response, args or data missing');
-                    return this.promiseRequestError('invalidResponse');
-                }
-
-                // Get receiver instance
-                const receiver = data[WebClientService.SUB_TYPE_RECEIVER] as T;
-
-                // Update receiver type if not set
-                if (receiver.type === undefined) {
-                    receiver.type = receiverType;
-                }
-
-                // Extend models
-                if (isContactReceiver(receiver)) {
-                    this.receivers.extendContact(receiver);
-                } else if (isGroupReceiver(receiver)) {
-                    this.receivers.extendGroup(receiver);
-                } else if (isDistributionListReceiver(receiver)) {
-                    this.receivers.extendDistributionList(receiver);
-                }
-
-                return {
-                    success: true,
-                    data: receiver,
-                };
-            case false:
-                return this.promiseRequestError(args[WebClientService.ARGUMENT_ERROR]);
-            default:
-                this.$log.error('Invalid ' + receiverType + ' response, success field is not a boolean');
-                return this.promiseRequestError('invalidResponse');
+        // Validate data
+        if (data === undefined) {
+            this.$log.error(`Invalid ${receiverType} response, 'data' is missing`);
+            return future.reject('invalidResponse');
         }
+
+        // Get receiver instance
+        const receiver = data[WebClientService.SUB_TYPE_RECEIVER] as T;
+
+        // Update receiver type if not set
+        if (receiver.type === undefined) {
+            receiver.type = receiverType;
+        }
+
+        // Extend models
+        if (isContactReceiver(receiver)) {
+            this.receivers.extendContact(receiver);
+        } else if (isGroupReceiver(receiver)) {
+            this.receivers.extendGroup(receiver);
+        } else if (isDistributionListReceiver(receiver)) {
+            this.receivers.extendDistributionList(receiver);
+        }
+        future.resolve(receiver);
     }
 
-    /**
-     * Handle new or modified contacts.
-     */
-    private _receiveUpdateContact(message: threema.WireMessage):
-                                    threema.PromiseRequestResult<threema.ContactReceiver> {
-        return this._receiveResponseReceiver(message, 'contact');
+    private _receiveCreateContact(message: threema.WireMessage): void {
+        const future = this.popWireMessageFuture(message);
+        this._receiveReplyReceiver(message, 'contact', future);
     }
 
-    /**
-     * Handle new or modified groups.
-     */
-    private _receiveResponseGroup(message: threema.WireMessage):
-                                  threema.PromiseRequestResult<threema.GroupReceiver> {
-        return this._receiveResponseReceiver(message, 'group');
+    private _receiveCreateGroup(message: threema.WireMessage): void {
+        const future = this.popWireMessageFuture(message);
+        this._receiveReplyReceiver(message, 'group', future);
     }
 
-    /**
-     * Handle new or modified distribution lists.
-     */
-    private _receiveResponseDistributionList(message: threema.WireMessage):
-                                             threema.PromiseRequestResult<threema.DistributionListReceiver> {
-        return this._receiveResponseReceiver(message, 'distributionList');
+    private _receiveCreateDistributionList(message: threema.WireMessage): void {
+        const future = this.popWireMessageFuture(message);
+        this._receiveReplyReceiver(message, 'distributionList', future);
     }
 
-    private _receiveResponseCreateMessage(message: threema.WireMessage): threema.PromiseRequestResult<string> {
+    private _receiveCreateMessage(message: threema.WireMessage): void {
         this.$log.debug('Received create message response');
+        const future = this.popWireMessageFuture(message);
+
+        // Handle error (if any)
+        if (!message.ack.success) {
+            return future.reject(message.ack.error);
+        }
 
         // Unpack data and arguments
         const args = message.args;
         const data = message.data;
-
         if (args === undefined || data === undefined) {
             this.$log.warn('Invalid create message received, arguments or data missing');
-            return this.promiseRequestError('invalidResponse');
+            return future.reject('invalidResponse');
         }
 
-        switch (args[WebClientService.ARGUMENT_SUCCESS]) {
-            case true:
-                const receiverType: threema.ReceiverType = args[WebClientService.ARGUMENT_RECEIVER_TYPE];
-                const receiverId: string = args[WebClientService.ARGUMENT_RECEIVER_ID];
-                const temporaryId: string = args[WebClientService.ARGUMENT_TEMPORARY_ID];
-
-                const messageId: string = data[WebClientService.ARGUMENT_MESSAGE_ID];
-                if (receiverType === undefined || receiverId === undefined ||
-                    temporaryId === undefined || messageId === undefined) {
-                    this.$log.warn('Invalid create received [type, id, temporaryId arg ' +
-                        'or messageId in data missing]');
-                    return this.promiseRequestError('invalidResponse');
-                }
-
-                this.messages.bindTemporaryToMessageId(
-                    {
-                        type: receiverType,
-                        id: receiverId,
-                    } as threema.Receiver,
-                    temporaryId,
-                    messageId,
-                );
-
-                return { success: true, data: messageId };
-            case false:
-                return this.promiseRequestError(args[WebClientService.ARGUMENT_ERROR]);
-            default:
-                this.$log.error('Invalid create message response, success field is not a boolean');
-                return this.promiseRequestError('invalidResponse');
+        const receiverType: threema.ReceiverType = args[WebClientService.ARGUMENT_RECEIVER_TYPE];
+        const receiverId: string = args[WebClientService.ARGUMENT_RECEIVER_ID];
+        const messageId: string = data[WebClientService.ARGUMENT_MESSAGE_ID];
+        if (receiverType === undefined || receiverId === undefined || messageId === undefined) {
+            this.$log.warn("Invalid create received: 'type', 'id' or 'messageId' missing");
+            return future.reject('invalidResponse');
         }
+
+        // Map the previously used temporary id to the one chosen by the app
+        const receiver = {
+            type: receiverType,
+            id: receiverId,
+        } as threema.Receiver;
+        this.messages.bindTemporaryToMessageId(
+            receiver,
+            message.ack.id,
+            messageId,
+        );
+        future.resolve(messageId);
     }
 
     private _receiveResponseConversations(message: threema.WireMessage) {
         this.$log.debug('Received conversations response');
+        const future = this.popWireMessageFuture(message, this.requiresTemporaryIdBackwardsCompatibility);
+
+        // Handle error (if any)
+        if ((!this.requiresTemporaryIdBackwardsCompatibility && message.ack !== undefined) && !message.ack.success) {
+            future.reject(message.ack.error);
+        }
+
         const data = message.data as threema.Conversation[];
         if (data === undefined) {
             this.$log.warn('Invalid conversation response, data missing');
+            future.reject('invalidResponse');
         } else {
             // If a avatar was set on a conversation, convert and copy to the receiver
             for (const conversation of data) {
@@ -2397,20 +2436,28 @@ export class WebClientService {
                 }
             }
             this.conversations.set(data);
+            future.resolve();
         }
+
         this.updateUnreadCount();
         this.registerInitializationStep(InitializationStep.Conversations);
     }
 
     private _receiveResponseMessages(message: threema.WireMessage): void {
         this.$log.debug('Received messages response');
+        const future = this.popWireMessageFuture(message, this.requiresTemporaryIdBackwardsCompatibility);
+
+        // Handle error (if any)
+        if ((!this.requiresTemporaryIdBackwardsCompatibility && message.ack !== undefined) && !message.ack.success) {
+            future.reject(message.ack.error);
+        }
 
         // Unpack data and arguments
         const args = message.args;
         const data = message.data as threema.Message[];
         if (args === undefined || data === undefined) {
             this.$log.warn('Invalid messages response, data or arguments missing');
-            return;
+            return future.reject('invalidResponse');
         }
 
         // Unpack required argument fields
@@ -2419,11 +2466,11 @@ export class WebClientService {
         let more: boolean = args[WebClientService.ARGUMENT_HAS_MORE];
         if (type === undefined || id === undefined || more === undefined) {
             this.$log.warn('Invalid messages response, argument field missing');
-            return;
+            return future.reject('invalidResponse');
         }
         if (!isValidReceiverType(type)) {
             this.$log.warn('Invalid messages response, unknown receiver type (' + type + ')');
-            return;
+            return future.reject('invalidResponse');
         }
         const receiver: threema.BaseReceiver = {type: type, id: id};
 
@@ -2435,38 +2482,51 @@ export class WebClientService {
         // Set as loaded
         this.loadingMessages.delete(receiver.type + receiver.id);
 
-        if (this.messages.isRequested(receiver)) {
-            // Add messages
-            this.messages.addOlder(receiver, data);
-
-            // Clear pending request
-            this.messages.clearRequested(receiver);
-
-            // Set "more" flag to indicate that more (older) messages are available.
-            this.messages.setMore(receiver, more);
-
-            // Notify listeners
-            this.messages.notify(receiver, this.$rootScope);
-        } else {
+        // Check if the messages have been requested
+        // TODO: Isn't this a bogus check since we know that we have made the
+        //       request at this point?
+        if (!this.messages.isRequested(receiver)) {
             this.$log.warn("Ignoring message response that hasn't been requested");
-            return;
+            return future.reject('invalidResponse');
         }
+
+        // Add messages
+        this.messages.addOlder(receiver, data);
+
+        // Clear pending request
+        this.messages.clearRequested(receiver);
+
+        // Set "more" flag to indicate that more (older) messages are available.
+        this.messages.setMore(receiver, more);
+
+        // Notify listeners
+        this.messages.notify(receiver, this.$rootScope);
+
+        // Done
+        future.resolve();
     }
 
-    private _receiveResponseAvatar(message: threema.WireMessage): threema.PromiseRequestResult<any> {
+    private _receiveResponseAvatar(message: threema.WireMessage): void {
         this.$log.debug('Received avatar response');
+        const future = this.popWireMessageFuture(message);
+
+        // Handle error (if any)
+        if (!message.ack.success) {
+            future.reject(message.ack.error);
+        }
 
         // Unpack data and arguments
         const args = message.args;
         if (args === undefined) {
             this.$log.warn('Invalid message response: arguments missing');
-            return this.promiseRequestError('invalidResponse');
+            return future.reject('invalidResponse');
         }
 
+        // Check for avatar data
         const avatar = message.data;
         if (avatar === undefined) {
-            // It's ok, a receiver without a avatar
-            return { success: true, data: null };
+            // A receiver without an avatar - fine!
+            return future.resolve(null);
         }
 
         // Unpack required argument fields
@@ -2475,7 +2535,7 @@ export class WebClientService {
         const highResolution = args[WebClientService.ARGUMENT_AVATAR_HIGH_RESOLUTION];
         if (type === undefined || id === undefined || highResolution === undefined) {
             this.$log.warn('Invalid avatar response, argument field missing');
-            return this.promiseRequestError('invalidResponse');
+            return future.reject('invalidResponse');
         }
 
         // Set avatar for receiver according to resolution
@@ -2484,81 +2544,71 @@ export class WebClientService {
         if (receiverData.avatar === null || receiverData.avatar === undefined) {
             receiverData.avatar = {};
         }
-
         receiverData.avatar[field] = avatar;
-
-        return { success: true, data: avatar };
+        future.resolve(avatar);
     }
 
-    private _receiveResponseThumbnail(message: threema.WireMessage): threema.PromiseRequestResult<any> {
+    private _receiveResponseThumbnail(message: threema.WireMessage): void {
         this.$log.debug('Received thumbnail response');
+        const future = this.popWireMessageFuture(message);
+
+        // Handle error (if any)
+        if (!message.ack.success) {
+            future.reject(message.ack.error);
+        }
 
         // Unpack data and arguments
         const args = message.args;
         if (args === undefined) {
             this.$log.warn('Invalid message response: arguments missing');
-            return {
-                success: false,
-                data: 'invalidResponse',
-            };
+            return future.reject('invalidResponse');
         }
 
-        const data = message.data;
-        if ( data === undefined) {
-            // It's ok, a message without a thumbnail
-            return {
-                success: true,
-                data: null,
-            };
+        // Check for thumbnail data
+        const thumbnail = message.data;
+        if (thumbnail === undefined) {
+            // A message without a thumbnail - fine!
+            return future.resolve(null);
         }
 
         // Unpack required argument fields
         const type = args[WebClientService.ARGUMENT_RECEIVER_TYPE];
         const id = args[WebClientService.ARGUMENT_RECEIVER_ID];
         const messageId: string = args[WebClientService.ARGUMENT_MESSAGE_ID];
-
         if (type === undefined || id === undefined || messageId === undefined ) {
             this.$log.warn('Invalid thumbnail response, argument field missing');
-            return {
-                success: false,
-                data: 'invalidResponse',
-            };
+            return future.reject('invalidResponse');
         }
 
-        this.messages.setThumbnail( this.receivers.getData(args), messageId, data);
-
-        return {
-            success: true,
-            data: data,
-        };
+        // Set thumbnail
+        this.messages.setThumbnail( this.receivers.getData(args), messageId, thumbnail);
+        future.resolve(thumbnail);
     }
 
-    private _receiveResponseBlob(message: threema.WireMessage): threema.PromiseRequestResult<threema.BlobInfo> {
+    private _receiveResponseBlob(message: threema.WireMessage): void {
         this.$log.debug('Received blob response');
+        const future = this.popWireMessageFuture(message);
+
+        // Handle error (if any)
+        if (!message.ack.success) {
+            return future.reject(message.ack.error);
+        }
 
         // Unpack data and arguments
         const args = message.args;
         const data = message.data;
-        if (args === undefined ) {
-            this.$log.warn('Invalid message response, arguments missing');
-            return this.promiseRequestError('invalidResponse');
+        if (args === undefined) {
+            this.$log.warn('Invalid message response, args missing');
+            return future.reject('invalidResponse');
         }
 
         // Unpack required argument fields
         const receiverType = args[WebClientService.ARGUMENT_RECEIVER_TYPE];
         const receiverId = args[WebClientService.ARGUMENT_RECEIVER_ID];
         const msgId: string = args[WebClientService.ARGUMENT_MESSAGE_ID];
-        const temporaryId: string = args[WebClientService.ARGUMENT_TEMPORARY_ID];
-        const success: boolean = args[WebClientService.ARGUMENT_SUCCESS];
-        if (receiverType === undefined || receiverId === undefined
-            || msgId === undefined || temporaryId === undefined || success === undefined) {
+        if (receiverType === undefined || receiverId === undefined || msgId === undefined) {
             this.$log.warn('Invalid blob response, argument field missing');
-            return this.promiseRequestError('invalidResponse');
-        }
-
-        // Check success flag
-        if (success === false) {
-            return this.promiseRequestError(args[WebClientService.ARGUMENT_ERROR]);
+            return future.reject('invalidResponse');
         }
 
         // Unpack data
@@ -2569,27 +2619,39 @@ export class WebClientService {
         };
         if (blobInfo.buffer === undefined || blobInfo.mimetype === undefined || blobInfo.filename === undefined) {
             this.$log.warn('Invalid blob response, data field missing');
-            return this.promiseRequestError('invalidResponse');
+            return future.reject('invalidResponse');
         }
 
+        // Store blob
         this.blobCache.set(msgId + receiverType, blobInfo);
+        future.resolve(blobInfo);
+    }
 
-        // Download to browser
-        return {
-            success: true,
-            data: blobInfo,
-        };
+    private _receiveUpdateConfirm(message: threema.WireMessage): void {
+        this.$log.debug('Received wire message acknowledgement');
+        const future = this.popWireMessageFuture(message);
+        if (!message.ack.success) {
+            future.reject(message.ack.error);
+        } else {
+            future.resolve();
+        }
     }
 
     private _receiveUpdateMessages(message: threema.WireMessage): void {
         this.$log.debug('Received messages update');
+        const future = this.popWireMessageFuture(message, true);
+
+        // Handle error (if any)
+        if (message.ack !== undefined && !message.ack.success) {
+            return future.reject(message.ack.error);
+        }
 
         // Unpack data and arguments
         const args = message.args;
         const data: threema.Message[] = message.data;
         if (args === undefined || data === undefined) {
             this.$log.warn('Invalid message update, data or arguments missing');
-            return;
+            return future.reject('invalidResponse');
         }
 
         // Unpack required argument fields
@@ -2598,11 +2660,11 @@ export class WebClientService {
         const mode: string = args[WebClientService.ARGUMENT_MODE];
         if (type === undefined || id === undefined || mode === undefined) {
             this.$log.warn('Invalid message update, argument field missing');
-            return;
+            return future.reject('invalidResponse');
         }
         if (!isValidReceiverType(type)) {
             this.$log.warn(this.logTag, 'Invalid messages update, unknown receiver type (' + type + ')');
-            return;
+            return future.reject('invalidResponse');
         }
         const receiver: threema.BaseReceiver = {type: type, id: id};
 
@@ -2632,10 +2694,11 @@ export class WebClientService {
         if (notify) {
             this.messages.notify(receiver, this.$rootScope);
         }
+        future.resolve();
     }
 
     private _receiveUpdateReceiver(message: threema.WireMessage): void {
-        this.$log.debug('Received receiver update or delete');
+        this.$log.debug('Received receiver update');
 
         // Unpack data and arguments
         const args = message.args;
@@ -2748,6 +2811,8 @@ export class WebClientService {
 
     private _receiveUpdateConversation(message: threema.WireMessage) {
         this.$log.debug('Received conversation update');
+
+        // Validate data
         const args = message.args;
         const data = message.data as threema.ConversationWithPosition;
         if (args === undefined || data === undefined) {
@@ -2807,7 +2872,7 @@ export class WebClientService {
                 break;
             default:
                 this.$log.warn(this.logTag, 'Received conversation without a mode');
-                return;
+                break;
         }
 
         this.updateUnreadCount();
@@ -2837,18 +2902,39 @@ export class WebClientService {
      */
     private _receiveUpdateBatteryStatus(message: threema.WireMessage): void {
         this.$log.debug('Received battery status');
+        const future = this.popWireMessageFuture(message, true);
+
+        // Handle error (if any)
+        if (message.ack !== undefined && !message.ack.success) {
+            return future.reject(message.ack.error);
+        }
 
         // Unpack data and arguments
         const data = message.data as threema.BatteryStatus;
         if (data === undefined) {
             this.$log.warn('Invalid battery status message, data missing');
-            return;
+            return future.reject('invalidResponse');
         }
 
         // Set battery status
         this.batteryStatusService.setStatus(data);
-
         this.$log.debug('[BatteryStatusService]', this.batteryStatusService.toString());
+        future.resolve();
+    }
+
+    private _receiveUpdateContact(message: threema.WireMessage): void {
+        const future = this.popWireMessageFuture(message, true);
+        this._receiveReplyReceiver(message, 'contact', future);
+    }
+
+    private _receiveUpdateGroup(message: threema.WireMessage): void {
+        const future = this.popWireMessageFuture(message, true);
+        this._receiveReplyReceiver(message, 'group', future);
+    }
+
+    private _receiveUpdateDistributionList(message: threema.WireMessage): void {
+        const future = this.popWireMessageFuture(message, true);
+        this._receiveReplyReceiver(message, 'distributionList', future);
     }
 
     /**
@@ -2879,6 +2965,7 @@ export class WebClientService {
             }
 
             // Request new low-res avatar
+            // noinspection JSIgnoredPromiseFromCall
             this.requestAvatar(this.me, false);
         }
     }
@@ -2888,11 +2975,19 @@ export class WebClientService {
      * identify the active session.
      */
     private _receiveResponseClientInfo(message: threema.WireMessage): void {
-        this.$log.debug('Received client info');
+        this.$log.debug('Received client info response');
+        const future = this.popWireMessageFuture(message, this.requiresTemporaryIdBackwardsCompatibility);
+
+        // Handle error (if any)
+        if ((!this.requiresTemporaryIdBackwardsCompatibility && message.ack !== undefined) && !message.ack.success) {
+            future.reject(message.ack.error);
+        }
+
+        // Validate data
         const data = message.data;
         if (data === undefined) {
             this.$log.warn('Invalid client info, data field missing');
-            return;
+            return future.reject('invalidResponse');
         }
 
         /**
@@ -2948,17 +3043,26 @@ export class WebClientService {
         }
 
         this.registerInitializationStep(InitializationStep.ClientInfo);
+        future.resolve();
     }
 
     /**
      * The peer sends information about the current user profile.
      */
     private _receiveResponseProfile(message: threema.WireMessage): void {
-        this.$log.debug('Received profile');
+        this.$log.debug('Received profile response');
+        const future = this.popWireMessageFuture(message, this.requiresTemporaryIdBackwardsCompatibility);
+
+        // Handle error (if any)
+        if ((!this.requiresTemporaryIdBackwardsCompatibility && message.ack !== undefined) && !message.ack.success) {
+            future.reject(message.ack.error);
+        }
+
+        // Validate data
         const data = message.data as threema.Profile;
         if (data === undefined) {
             this.$log.warn('Invalid client info, data field missing');
-            return;
+            return future.reject('invalidResponse');
         }
 
         // Create 'me' receiver with profile + dummy data
@@ -2985,6 +3089,7 @@ export class WebClientService {
         });
 
         this.registerInitializationStep(InitializationStep.Profile);
+        future.resolve();
     }
 
     public setPassword(password: string) {
@@ -3188,160 +3293,229 @@ export class WebClientService {
         this.pushTokenType = tokenType;
     }
 
-    private _sendRequest(type, retransmit: boolean, args?: object, data?: object): void {
-        const message: threema.WireMessage = {
-            type: WebClientService.TYPE_REQUEST,
-            subType: type,
-        };
-        if (args !== undefined) {
-            message.args = args;
-        }
-        if (data !== undefined) {
-            message.data = data;
-        }
-        this.send(message, retransmit);
-    }
-
-    private _sendUpdate(type, retransmit: boolean, args?: object, data?: object): void {
-        const message: threema.WireMessage = {
-            type: WebClientService.TYPE_UPDATE,
-            subType: type,
-        };
-        if (args !== undefined) {
-            message.args = args;
-        }
-        if (data !== undefined) {
-            message.data = data;
-        }
-        this.send(message, retransmit);
-    }
-
-    private _sendPromiseMessage(
-        message: threema.WireMessage,
+    private sendRequestWireMessage(
+        subType: string,
         retransmit: boolean,
+        args?: object,
+        data?: any,
+        id?: string,
     ): Promise<any> {
-        // Create arguments on wired message
-        if (message.args === undefined || message.args === null) {
-            message.args = {};
-        }
-        let promiseId = message.args[WebClientService.ARGUMENT_TEMPORARY_ID];
-        if (promiseId === undefined) {
-            // Create a random id to identity the promise
-            promiseId = 'p' + Math.random().toString(36).substring(7);
-            message.args[WebClientService.ARGUMENT_TEMPORARY_ID] = promiseId;
+        return this.sendWireMessage(WebClientService.TYPE_REQUEST, subType, retransmit, args, data, id);
+    }
+
+    private sendUpdateWireMessage(
+        subType: string,
+        retransmit: boolean,
+        args?: object,
+        data?: any,
+        id?: string,
+    ): Promise<any> {
+        return this.sendWireMessage(WebClientService.TYPE_UPDATE, subType, retransmit, args, data, id);
+    }
+
+    private sendCreateWireMessage(
+        subType: string,
+        retransmit: boolean,
+        args?: object,
+        data?: any,
+        id?: string,
+    ): Promise<any> {
+        return this.sendWireMessage(WebClientService.TYPE_CREATE, subType, retransmit, args, data, id);
+    }
+
+    private sendDeleteWireMessage(
+        subType: string,
+        retransmit: boolean,
+        args?: object,
+        data?: any,
+        id?: string,
+    ): Promise<any> {
+        return this.sendWireMessage(WebClientService.TYPE_DELETE, subType, retransmit, args, data, id);
+    }
+
+    private createRandomWireMessageId() {
+        let id;
+        do {
+            id = randomString(6);
+        } while (this.wireMessageFutures.has(id));
+        return id;
+    }
+
+    private sendWireMessage(
+        type: string,
+        subType: string,
+        retransmit: boolean,
+        args?: object,
+        data?: any,
+        id?: string,
+    ): Promise<any> {
+        const message: threema.WireMessage = {
+            type: type,
+            subType: subType,
+        };
+
+        // Create a promise with a random ID (if retransmitting)
+        // Note: We do this in order to keep track of which messages the app
+        //       has processed (NOT only received). A message that has not been
+        //       processed yet is an indicator to wake the app up again after a
+        //       connection loss.
+        let promise: Promise<any>;
+        if (retransmit) {
+            // Ensure ID uniqueness (if supplied) or create random ID
+            if (id === undefined) {
+                id = this.createRandomWireMessageId();
+            } else if (this.wireMessageFutures.has(id))  {
+                throw new Error('Duplicate id for wire message detected');
+            }
+            message.id = id;
+
+            // TODO: Remove when removing temporaryId backwards compatibility
+            // Set temporary ID
+            if (args === undefined) {
+                args = {};
+            }
+            args[WebClientService.ARGUMENT_TEMPORARY_ID] = message.id;
+
+            // Create & store future
+            const future: Future<any> = new Future();
+            if (this.config.MSG_DEBUGGING) {
+                this.$log.debug(this.logTag, `Added wire message future: ${id} -> ${type}/${subType}`);
+            }
+            this.wireMessageFutures.set(message.id, future);
+            promise = future;
+        } else {
+            promise = Promise.resolve({
+                id: '',
+                success: true,
+            });
         }
 
-        // Store promise
-        const promise = new Future();
-        this.requestPromises.set(promiseId, promise);
+        // Set args and data (if any)
+        if (args !== undefined) {
+            message.args = args;
+        }
+        if (data !== undefined) {
+            message.data = data;
+        }
 
-        // Send request & return promise
+        // Send message & return promise (or undefined)
         this.send(message, retransmit);
         return promise;
     }
 
+    private static validateWireMessageAcknowledgement(ack: threema.WireMessageAcknowledgement): void {
+        if (!hasValue(ack.id)) {
+            throw new Error("Invalid wire message acknowledgement: 'id' is missing");
+        }
+        if (!hasValue(ack.success)) {
+            throw new Error("Invalid wire message acknowledgement: 'success' is missing");
+        }
+        switch (ack.success) {
+            case true:
+                break;
+            case false:
+                if (!hasValue(ack.error)) {
+                    throw new Error("Invalid wire message acknowledgement: 'error' is missing");
+                }
+                break;
+            default:
+                throw new Error("Invalid wire message acknowledgement: 'success' is not a boolean");
+        }
+    }
+
     /**
-     * Send a request and return a promise.
+     * Find and return the wire message future corresponding to the message.
      *
-     * The promise will be resolved if a response arrives with the same temporary ID.
+     * This will automatically validate that the 'ack' field of the message is
+     * correct. Also, note that the future will be removed from the map of
+     * pending wire message futures.
+     *
+     * @param message The message that (may) contain an acknowledgement.
+     * @param optional If set to `true`, no error will be thrown if the message
+     *   did not contain an acknowledgement.
+     *
+     * Throws an exception in case the acknowledgement field is invalid.
+     * Throws an exception in case the wire message does not contain an
+     *   acknowledgement and the acknowledgement is not optional.
+     * Throws an exception if no future could be found.
+     *
+     * In any exception case, if the associated future could be found, it will
+     *   be rejected with 'invalidResponse' before the exception is being
+     *   thrown. The case of 'ack.success == false' does NOT count as an
+     *   exception case.
      */
-    private _sendRequestPromise(
-        type: string,
-        retransmit: boolean,
-        args = null,
-    ): Promise<any> {
-        const message: threema.WireMessage = {
-            type: WebClientService.TYPE_REQUEST,
-            subType: type,
-            args: args,
-        };
-        return this._sendPromiseMessage(message, retransmit);
+    private popWireMessageFuture(message: threema.WireMessage, optional = false): Future<any> {
+        // Transfer old temporaryId-related fields into new 'ack' field.
+        // TODO: Remove when removing temporaryId backwards compatibility
+        if (message.ack === undefined &&
+            message.args !== undefined &&
+            message.args[WebClientService.ARGUMENT_TEMPORARY_ID] !== undefined
+        ) {
+            // Not all messages with 'temporaryId' had a 'success' field, so
+            // we need to patch it.
+            if (message.args[WebClientService.ARGUMENT_SUCCESS] === undefined) {
+                message.args[WebClientService.ARGUMENT_SUCCESS] = true;
+            }
+            message.ack = {
+                id: message.args[WebClientService.ARGUMENT_TEMPORARY_ID],
+                success: message.args[WebClientService.ARGUMENT_SUCCESS],
+                error: message.args[WebClientService.ARGUMENT_ERROR],
+            };
+        }
+
+        // Validate message
+        let error: Error;
+        if (hasValue(message.ack)) {
+            try {
+                WebClientService.validateWireMessageAcknowledgement(message.ack);
+            } catch (e) {
+                error = e;
+            }
+        } else if (!optional) {
+            throw new Error('Wire message did not contain an acknowledgement');
+        } else {
+            // Nit: We could use a fake future here for performance
+            return new Future();
+        }
+        const id = message.ack.id;
+
+        // Get associated future
+        const future = this.wireMessageFutures.get(id);
+        if (future === undefined && error === undefined) {
+            error = new Error(`Wire message future not found for id: ${id}`);
+        }
+
+        // Remove the future from the map
+        this.wireMessageFutures.delete(id);
+        if (this.config.MSG_DEBUGGING) {
+            this.$log.debug(this.logTag, `Removed wire message future: ${id} -> ${message.type}/${message.subType}`);
+        }
+
+        // Handle error (reject future and throw)
+        if (error !== undefined) {
+            future.reject('invalidResponse');
+            throw error;
+        }
+
+        // Done
+        return future;
     }
 
-    private _sendCreatePromise(
-        type: string,
-        retransmit: boolean,
-        args = null,
-        data: any = null,
-    ): Promise<any> {
-        const message: threema.WireMessage = {
-            type: WebClientService.TYPE_CREATE,
-            subType: type,
-            args: args,
-            data: data,
-        };
-        return this._sendPromiseMessage(message, retransmit);
-    }
-
-    private _sendUpdatePromise(
-        type: string,
-        retransmit: boolean,
-        args = null,
-        data: any = null,
-    ): Promise<any> {
-        const message: threema.WireMessage = {
-            type: WebClientService.TYPE_UPDATE,
-            subType: type,
-            data: data,
-            args: args,
-        };
-        return this._sendPromiseMessage(message, retransmit);
-    }
-
-    private _sendDeletePromise(
-        type: string,
-        retransmit: boolean,
-        args = null,
-        data: any = null,
-    ): Promise<any> {
-        const message: threema.WireMessage = {
-            type: WebClientService.TYPE_DELETE,
-            subType: type,
-            data: data,
-            args: args,
-        };
-        return this._sendPromiseMessage(message, retransmit);
-    }
-
-    private _receiveRequest(type, message): void {
+    private _receiveRequest(type: string, message: threema.WireMessage): void {
         switch (type) {
             case WebClientService.SUB_TYPE_CONNECTION_ACK:
                 this._receiveRequestConnectionAck(message);
                 break;
             default:
-                this.$log.warn('Ignored update with type:', type);
+                this.$log.warn(`Ignored request/${type}`);
                 break;
         }
     }
 
-    private _receivePromise(message: any, receiveResult: threema.PromiseRequestResult<any>) {
-        if (
-            message !== undefined
-            && message.args !== undefined
-            && message.args[WebClientService.ARGUMENT_TEMPORARY_ID] !== undefined) {
-            // find pending promise
-            const promiseId = message.args[WebClientService.ARGUMENT_TEMPORARY_ID];
-
-            if (this.requestPromises.has(promiseId)) {
-                const promise = this.requestPromises.get(promiseId);
-                if (receiveResult === null || receiveResult === undefined) {
-                    promise.reject('unknown');
-                } else if (receiveResult.success) {
-                    promise.resolve(receiveResult.data);
-                } else {
-                    promise.reject(receiveResult.error);
-                }
-                // remove from map
-                this.requestPromises.delete(promiseId);
-            }
-        }
-    }
-
-    private _receiveResponse(type, message): void {
-        let receiveResult: threema.PromiseRequestResult<any>;
+    private _receiveResponse(type: string, message: threema.WireMessage): void {
         switch (type) {
             case WebClientService.SUB_TYPE_CONFIRM_ACTION:
-                receiveResult = this._receiveResponseConfirmAction(message);
+                this._receiveResponseConfirmAction(message);
                 break;
             case WebClientService.SUB_TYPE_RECEIVERS:
                 this._receiveResponseReceivers(message);
@@ -3357,13 +3531,13 @@ export class WebClientService {
                 this._receiveResponseMessages(message);
                 break;
             case WebClientService.SUB_TYPE_AVATAR:
-                receiveResult = this._receiveResponseAvatar(message);
+                this._receiveResponseAvatar(message);
                 break;
             case WebClientService.SUB_TYPE_THUMBNAIL:
-                receiveResult = this._receiveResponseThumbnail(message);
+                this._receiveResponseThumbnail(message);
                 break;
             case WebClientService.SUB_TYPE_BLOB:
-                receiveResult = this._receiveResponseBlob(message);
+                this._receiveResponseBlob(message);
                 break;
             case WebClientService.SUB_TYPE_CLIENT_INFO:
                 this._receiveResponseClientInfo(message);
@@ -3372,19 +3546,19 @@ export class WebClientService {
                 this._receiveResponseProfile(message);
                 break;
             case WebClientService.SUB_TYPE_CONTACT_DETAIL:
-                receiveResult = this._receiveResponseContactDetail(message);
+                this._receiveResponseContactDetail(message);
                 break;
             default:
-                this.$log.warn('Ignored response with type:', type);
-                return;
+                this.$log.warn(`Ignored response/${type}`);
+                break;
         }
-
-        this._receivePromise(message, receiveResult);
     }
 
-    private _receiveUpdate(type, message): void {
-        let receiveResult;
+    private _receiveUpdate(type: string, message: threema.WireMessage): void {
         switch (type) {
+            case WebClientService.SUB_TYPE_CONFIRM:
+                this._receiveUpdateConfirm(message);
+                break;
             case WebClientService.SUB_TYPE_RECEIVER:
                 this._receiveUpdateReceiver(message);
                 break;
@@ -3407,56 +3581,51 @@ export class WebClientService {
                 this._receiveUpdateBatteryStatus(message);
                 break;
             case WebClientService.SUB_TYPE_CONTACT:
-                receiveResult = this._receiveUpdateContact(message);
+                this._receiveUpdateContact(message);
                 break;
             case WebClientService.SUB_TYPE_GROUP:
-                receiveResult = this._receiveResponseGroup(message);
+                this._receiveUpdateGroup(message);
                 break;
             case WebClientService.SUB_TYPE_DISTRIBUTION_LIST:
-                receiveResult = this._receiveResponseDistributionList(message);
+                this._receiveUpdateDistributionList(message);
                 break;
             case WebClientService.SUB_TYPE_PROFILE:
                 this._receiveUpdateProfile(message);
                 break;
             case WebClientService.SUB_TYPE_ALERT:
-                this._receiveAlert(message);
+                this._receiveUpdateAlert(message);
                 break;
             case WebClientService.SUB_TYPE_CONNECTION_ACK:
                 this._receiveUpdateConnectionAck(message);
                 break;
             case WebClientService.SUB_TYPE_CONNECTION_DISCONNECT:
-                this._receiveConnectionDisconnect(message);
+                this._receiveUpdateConnectionDisconnect(message);
                 break;
             default:
-                this.$log.warn('Ignored update with type:', type);
-                return;
+                this.$log.warn(`Ignored update/${type}`);
+                break;
         }
-
-        this._receivePromise(message, receiveResult);
     }
 
-    private _receiveCreate(type, message): void {
-        let receiveResult: threema.PromiseRequestResult<any>;
+    private _receiveCreate(type: string, message: threema.WireMessage): void {
         switch (type) {
             case WebClientService.SUB_TYPE_CONTACT:
-                receiveResult = this._receiveUpdateContact(message);
+                this._receiveCreateContact(message);
                 break;
             case WebClientService.SUB_TYPE_GROUP:
-                receiveResult = this._receiveResponseGroup(message);
+                this._receiveCreateGroup(message);
                 break;
             case WebClientService.SUB_TYPE_DISTRIBUTION_LIST:
-                receiveResult = this._receiveResponseDistributionList(message);
+                this._receiveCreateDistributionList(message);
                 break;
-            case WebClientService.SUB_TYPE_TEXT_MESSAGE:
+            case WebClientService.SUB_TYPE_TEXT_MESSAGE: // fallthrough
             case WebClientService.SUB_TYPE_FILE_MESSAGE:
-                receiveResult = this._receiveResponseCreateMessage(message);
+                this._receiveCreateMessage(message);
                 break;
             default:
-                this.$log.warn('Ignored response with type:', type);
-                return;
+                this.$log.warn(`Ignored response/${type}`);
+                break;
         }
-
-        this._receivePromise(message, receiveResult);
     }
 
     /**
@@ -3674,25 +3843,48 @@ export class WebClientService {
             return;
         }
 
-        // Dispatch message
+        // Determine message handler
+        let messageHandler: (type, message) => void;
         switch (message.type) {
             case WebClientService.TYPE_REQUEST:
-                this._receiveRequest(message.subType, message);
+                messageHandler = this._receiveRequest;
                 break;
             case WebClientService.TYPE_RESPONSE:
-                this._receiveResponse(message.subType, message);
+                messageHandler = this._receiveResponse;
                 break;
             case WebClientService.TYPE_CREATE:
-                this._receiveCreate(message.subType, message);
+                messageHandler = this._receiveCreate;
                 break;
             case WebClientService.TYPE_UPDATE:
-                this._receiveUpdate(message.subType, message);
-                break;
-            case WebClientService.TYPE_DELETE:
-                this._receiveDelete(message.subType, message);
+                messageHandler = this._receiveUpdate;
                 break;
             default:
-                this.$log.warn('Ignored message with type:', message.type);
+                this.$log.warn(this.logTag, `Ignored message ${message.type}/${message.subType}`);
+                break;
+        }
+
+        // Dispatch message
+        if (messageHandler !== undefined) {
+            try {
+                messageHandler.apply(this, [message.subType, message]);
+            } catch (error) {
+                this.$log.error(this.logTag, `Unable to handle incoming wire message: ${error}`);
+                return;
+            }
+        }
+
+        // Catch unhandled wire message acknowledgements
+        // Nit: We could cache that we have already scraped the message for a
+        //      wire message acknowledgement instead of double-parsing.
+        let future: Future<any>;
+        try {
+            future = this.popWireMessageFuture(message);
+        } catch {
+            // Yes, I really know what I'm doing, thanks eslint...
+        }
+        if (future !== undefined) {
+            this.$log.warn(`Unhandled message acknowledgement for type ${message.type}: ${message.ack}`);
+            future.reject('unhandled');
         }
     }
 

--- a/src/threema.d.ts
+++ b/src/threema.d.ts
@@ -26,12 +26,20 @@ declare namespace threema {
         high?: ArrayBuffer;
     }
 
+    interface WireMessageAcknowledgement {
+        id: string,
+        success: boolean,
+        error?: string,
+    }
+
     /**
      * Messages that are sent through the secure data channel as encrypted msgpack bytes.
      */
     interface WireMessage {
         type: string;
         subType: string;
+        id?: string;
+        ack?: WireMessageAcknowledgement;
         args?: any;
         data?: any;
     }

--- a/src/threema.d.ts
+++ b/src/threema.d.ts
@@ -507,21 +507,6 @@ declare namespace threema {
         Safari = 'safari',
     }
 
-    interface BrowserInfo {
-        chrome: boolean;
-        chromeIos: boolean;
-        firefox: boolean;
-        firefoxIos: boolean;
-        ie: boolean;
-        edge: boolean;
-        opera: boolean;
-        safari: boolean;
-        name?: BrowserName;
-        mobile?: boolean;
-        version?: number;
-        textInfo?: string;
-    }
-
     interface PromiseRequestResult<T> {
         success: boolean;
         error?: string;


### PR DESCRIPTION
Refactor message acknowledgements and many other connectivity improvements for the relayed data task:

- Replace `temporaryId` and its friends with the upper layer fields `ack` and `id`
- Replace `response/confirmAction` with `update/confirm`
- Add backwards compatibility for `temporaryId` (and friends) and `response/confirmAction`
- Remove handling of `delete/contactDetail` which doesn't exist
- Remove unused interface `BrowserInfo`
- Cleanup of message send and receive methods
- Make SaltyRTC less noisy