### PR TITLE
Don't rely on sortKey to be unique when marking msg as read

### DIFF
--- a/src/partials/messenger.ts
+++ b/src/partials/messenger.ts
@@ -805,7 +805,7 @@ class ConversationController {
         }
 
         // Update lastReadMsg
-        if (this.lastReadMsg === null || message.sortKey > this.lastReadMsg.sortKey) {
+        if (this.lastReadMsg === null || message.sortKey >= this.lastReadMsg.sortKey) {
             this.lastReadMsg = message;
         }
 


### PR DESCRIPTION
While the sortKey should be unique, adjust the code slightly so it can even deal with duplicate sortKey values.