### PR TITLE
Fix largeSingleEmoji setting

### DIFF
--- a/src/directives/message_text.ts
+++ b/src/directives/message_text.ts
@@ -74,7 +74,7 @@ export default [
                  * Apply filters to text.
                  */
                 function processText(text: string, largeSingleEmoji: boolean, multiLine: boolean, linkifyText: boolean): string {
-                    const nonLinkified = mentionify(enlargeSingleEmoji(emojify(markify(escapeHtml(text))), enlargeSingleEmoji));
+                    const nonLinkified = mentionify(enlargeSingleEmoji(emojify(markify(escapeHtml(text))), largeSingleEmoji));
                     const maybeLinkified = linkifyText ? linkify(nonLinkified) : nonLinkified;
                     return nlToBr(maybeLinkified, multiLine);
                 }
@@ -97,7 +97,7 @@ export default [
                     );
                 };
 
-                this.enlargeSingleEmoji = webClientService.appConfig.largeSingleEmoji;
+                this.largeSingleEmoji = webClientService.appConfig.largeSingleEmoji;
 
                 this.$onInit = function() {
                     // Process initial text


### PR DESCRIPTION
It wasn't applied properly due to typos. TypeScript classes would have prevented that :slightly_smiling_face:  Unfortunately they don't work well as AngularJS directive controllers :slightly_frowning_face: 

Based on #601, merge that first. If you already want to review, only look at the last commit.