### PR TITLE
Compose area: Properly insert newlines in Safari

### DIFF
--- a/src/directives/compose_area.ts
+++ b/src/directives/compose_area.ts
@@ -159,9 +159,9 @@ export default [
                         //
                         // - Firefox and chrome insert a <br> between two text nodes
                         // - Safari creates two <div>s without any line break in between
+                        //   (except for the first line, which stays plain text)
                         //
-                        // Thus, for Safari, we need to detect adjacent <div>s and insert a newline.
-                        let lastNodeType = null;
+                        // Thus, for Safari, we need to detect <div>s and insert a newline.
 
                         // tslint:disable-next-line: prefer-for-of (see #98)
                         for (let i = 0; i < parentNode.childNodes.length; i++) {
@@ -170,28 +170,21 @@ export default [
                                 case Node.TEXT_NODE:
                                     // Append text, but strip leading and trailing newlines
                                     text += node.nodeValue.replace(/(^[\r\n]*|[\r\n]*$)/g, '');
-                                    lastNodeType = 'text';
                                     break;
                                 case Node.ELEMENT_NODE:
                                     const tag = node.tagName.toLowerCase();
                                     if (tag === 'div') {
-                                        if (lastNodeType === 'div') {
-                                            text += '\n';
-                                        }
+                                        text += '\n';
                                         visitChildNodes(node);
-                                        lastNodeType = 'div';
                                         break;
                                     } else if (tag === 'img') {
                                         text += (node as HTMLImageElement).alt;
-                                        lastNodeType = 'img';
                                         break;
                                     } else if (tag === 'br') {
                                         text += '\n';
-                                        lastNodeType = 'br';
                                         break;
                                     } else if (tag === 'span' && node.hasAttribute('text')) {
                                         text += node.getAttributeNode('text').value;
-                                        lastNodeType = 'span';
                                         break;
                                     }
                                 default:


### PR DESCRIPTION
Fixes #541.