### PR TITLE
When reloading receivers, show appropriate msg

### DIFF
--- a/public/i18n/de.json
+++ b/public/i18n/de.json
@@ -101,6 +101,7 @@
         "CONVERSATIONS": "Chats",
         "CONTACTS": "Kontakte",
         "NO_CONVERSATIONS_FOUND": "Keine Chats gefunden.",
+        "LOADING_CONVERSATIONS": "Chats werden geladen...",
         "ABOUT": "\u00dcber",
         "SETTINGS": "Einstellungen",
         "HELP": "Hilfe",

--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -101,6 +101,7 @@
         "CONVERSATIONS": "Conversations",
         "CONTACTS": "Contacts",
         "NO_CONVERSATIONS_FOUND": "No conversations found.",
+        "LOADING_CONVERSATIONS": "Loading conversations...",
         "ABOUT": "About",
         "SETTINGS": "Settings",
         "HELP": "Help",

--- a/src/partials/messenger.navigation.html
+++ b/src/partials/messenger.navigation.html
@@ -64,7 +64,8 @@
 
 <!-- Conversations -->
 <div id="navigation-conversations" class="tab-content" ng-if="ctrl.activeTab == 'conversations'" in-view-container>
-    <p class="empty" ng-if="ctrl.conversations().length === 0" translate>messenger.NO_CONVERSATIONS_FOUND</p>
+    <p class="empty" ng-if="ctrl.conversations().length === 0 && !ctrl.startupDone()" translate>messenger.LOADING_CONVERSATIONS</p>
+    <p class="empty" ng-if="ctrl.conversations().length === 0 && ctrl.startupDone()" translate>messenger.NO_CONVERSATIONS_FOUND</p>
     <ul>
         <li ng-repeat="conversation in ctrl.conversations() | filter:ctrl.searchConversation"
             ng-init="dndModeSimplified = ctrl.dndModeSimplified(conversation)"

--- a/src/partials/messenger.ts
+++ b/src/partials/messenger.ts
@@ -988,6 +988,10 @@ class NavigationController {
         return this.receiverService.isConversationActive(value);
     }
 
+    public startupDone(): boolean {
+        return this.webClientService.startupDone;
+    }
+
     /**
      * Return true if the app wants to hide inactive contacts.
      */

--- a/src/sass/sections/_navigation.scss
+++ b/src/sass/sections/_navigation.scss
@@ -98,7 +98,7 @@
     .empty {
         color: $material-grey;
         margin-top: 1em;
-        margin-left: 4px;
+        margin-left: 16px;
         font-size: 1.2em;
         font-weight: 300;
     }

--- a/src/services/webclient.ts
+++ b/src/services/webclient.ts
@@ -177,7 +177,7 @@ export class WebClientService {
 
     // State handling
     private startupPromise: ng.IDeferred<{}> = null; // TODO: deferred type
-    private startupDone: boolean = false;
+    public startupDone: boolean = false;
     private pendingInitializationStepRoutines: Set<threema.InitializationStepRoutine> = new Set();
     private initialized: Set<threema.InitializationStep> = new Set();
     private stateService: StateService;


### PR DESCRIPTION
Show "Loading conversations..." instead of "No conversations found", leading to better UX.

No conversations available:

![screenshot](https://tmp.dbrgn.ch/screenshots/20181016132415-w7e9z7eu.png)

Conversations reloading (after reset):

![screenshot](https://tmp.dbrgn.ch/screenshots/20181016132536-bjrrvlh6.png)