### PR TITLE
StateService: Allow more time for loading initial data

### DIFF
--- a/src/services/state.ts
+++ b/src/services/state.ts
@@ -206,7 +206,7 @@ export class StateService {
                 this.progress = 60;
                 this.progressInterval = this.$interval(() => {
                     if (this.progress < 80) {
-                        this.progress += 5;
+                        this.progress += 4;
                     } else if (this.progress < 90) {
                         this.progress += 2;
                     } else if (this.progress < 99) {
@@ -214,7 +214,7 @@ export class StateService {
                     } else {
                         this.slowConnect = true;
                     }
-                }, 500);
+                }, 600);
                 break;
             case 'done':
                 this.progress = 100;


### PR DESCRIPTION
Now it takes 10.8s instead of 8.5s for the loading progress between 60% and 99% until the "slowConnect" flag is set.

This is because some people report that often the "slow connect" warning is shown for 1s before the data is finally loaded.