### PR TITLE
Only show WebRTC troubleshooting tips when appropriate

### DIFF
--- a/src/partials/welcome.html
+++ b/src/partials/welcome.html
@@ -91,11 +91,11 @@
                                 <i class="material-icons md-dark md-14">help</i>
                                 <span translate>troubleshooting.SESSION_DELETED</span>
                             </li>
-                            <li ng-if="ctrl.state === 'peer_handshake'">
+                            <li ng-if="ctrl.state === 'peer_handshake' && ctrl.showWebrtcTroubleshooting">
                                 <i class="material-icons md-dark md-14">help</i>
                                 <span translate>troubleshooting.PLUGIN</span>
                             </li>
-                            <li ng-if="ctrl.state === 'peer_handshake'">
+                            <li ng-if="ctrl.state === 'peer_handshake' && ctrl.showWebrtcTroubleshooting">
                                 <i class="material-icons md-dark md-14">help</i>
                                 <span translate>troubleshooting.ADBLOCKER</span>
                             </li>

--- a/src/partials/welcome.ts
+++ b/src/partials/welcome.ts
@@ -248,6 +248,13 @@ class WelcomeController {
     }
 
     /**
+     * Whether to show troubleshooting hints related to WebRTC.
+     */
+    public get showWebrtcTroubleshooting(): boolean {
+        return this.webClientService.chosenTask === threema.ChosenTask.WebRTC;
+    }
+
+    /**
      * Initiate a new session by scanning a new QR code.
      */
     private scan(stopArguments?: threema.WebClientServiceStopArguments): void {


### PR DESCRIPTION
When the relayed data task is active, these hints don't make sense.