### PR TITLE
Make pin toggle button more accessible

### DIFF
--- a/src/components/toggle_button.ts
+++ b/src/components/toggle_button.ts
@@ -32,20 +32,20 @@ export default {
         iconEnabled: '@',
         iconDisabled: '@',
     },
+    controller: function() {
+        this.getLabel = () => this.flag ? this.labelEnabled : this.labelDisabled;
+        this.getIcon = () => this.flag ? this.iconEnabled : this.iconDisabled;
+        this.action = () => this.flag ? this.onDisable() : this.onEnable();
+    },
     template: `
         <md-button
             class="md-icon-button"
-            translate-attr="{'aria-label': $ctrl.labelEnabled, 'title': $ctrl.labelEnabled}"
-            ng-if="$ctrl.flag"
-            ng-click="$ctrl.onDisable()">
-            <md-icon><img ng-src="{{ $ctrl.iconEnabled }}"></md-icon>
-        </md-button>
-        <md-button
-            class="md-icon-button"
-            translate-attr="{'aria-label': $ctrl.labelDisabled, 'title': $ctrl.labelDisabled}"
-            ng-if="!$ctrl.flag"
-            ng-click="$ctrl.onEnable()">
-            <md-icon><img ng-src="{{ $ctrl.iconDisabled }}"></md-icon>
+            translate-attr="{'aria-label': $ctrl.getLabel(), 'title': $ctrl.getLabel()}"
+            role="button"
+            tabindex="0"
+            ng-click="$ctrl.action()"
+            aria-pressed="$ctrl.flag">
+            <md-icon><img ng-src="{{ $ctrl.getIcon() }}"></md-icon>
         </md-button>
     `,
 };


### PR DESCRIPTION
- Replace two-element button with single-element button
- Add `aria-pressed` attribute

It appears that by using `role="button"` and the `aria-pressed` attribute, browsers (at least Firefox and Safari) automatically bind the enter key event to the same handler as the click event. @MarcoZehe can we rely on that or would you always add an explicit keypress event handler?