### PR TITLE
Fix attribute value of aria-pressed so it reflects the actual state.

### DIFF
--- a/src/components/toggle_button.ts
+++ b/src/components/toggle_button.ts
@@ -44,7 +44,7 @@ export default {
             role="button"
             tabindex="0"
             ng-click="$ctrl.action()"
-            aria-pressed="$ctrl.flag">
+            aria-pressed="{{$ctrl.flag}}">
             <md-icon><img ng-src="{{ $ctrl.getIcon() }}"></md-icon>
         </md-button>
     `,

--- a/src/components/toggle_button.ts
+++ b/src/components/toggle_button.ts
@@ -44,7 +44,7 @@ export default {
             role="button"
             tabindex="0"
             ng-click="$ctrl.action()"
-            aria-pressed="{{$ctrl.flag}}">
+            aria-pressed="{{ $ctrl.flag }}">
             <md-icon><img ng-src="{{ $ctrl.getIcon() }}"></md-icon>
         </md-button>
     `,

--- a/src/threema/container.ts
+++ b/src/threema/container.ts
@@ -286,6 +286,7 @@ export class Conversations implements threema.Container.Conversations {
             if (conversation.position !== undefined) {
                 delete conversation.position;
             }
+            setDefault(conversation, 'isStarred', false);
         }
         this.conversations = data;
     }

--- a/tests/ts/containers.ts
+++ b/tests/ts/containers.ts
@@ -36,6 +36,7 @@ function makeContactConversation(id: string, position?: number): threema.Convers
         messageCount: 5,
         unreadCount: 0,
         latestMessage: null,
+        isStarred: false,
     };
 }
 
@@ -83,6 +84,17 @@ describe('Container', () => {
                 const expected = makeContactConversation('1');
                 delete expected.position;
                 expect((conversations as any).conversations).toEqual([expected]);
+            });
+
+            it('sets defaults', function() {
+                const conversations = getConversations();
+
+                const conversation = makeContactConversation('1', 7);
+                delete conversation.isStarred;
+                conversations.set([conversation]);
+
+                const expected = makeContactConversation('1');
+                expect((conversations as any).conversations[0].isStarred).toEqual(false);
             });
         });
 


### PR DESCRIPTION
Fix by putting double curly braces around the variable. Fixes #639.