### PR TITLE
ComposeArea: Fix cursor pos when inserting emoji

### DIFF
--- a/tests/ui/run.ts
+++ b/tests/ui/run.ts
@@ -130,12 +130,57 @@ async function regression574(driver: WebDriver) {
     expect(text).to.equal('hello\nthreema\nweb\n😄');
 }
 
+/**
+ * Insert two emoji in the middle of existing text.
+ * Regression test for #671.
+ */
+async function regression671(driver: WebDriver) {
+    // Insert text
+    await driver.findElement(composeArea).click();
+    await driver.findElement(composeArea).sendKeys('helloworld');
+    await driver.findElement(composeArea).sendKeys(Key.LEFT, Key.LEFT, Key.LEFT, Key.LEFT, Key.LEFT);
+
+    // Insert emoji
+    await driver.findElement(emojiTrigger).click();
+    const emoji = await driver.findElement(By.css('.e1[title=":smile:"]'));
+    await emoji.click();
+    await emoji.click();
+
+    const text = await extractText(driver);
+    expect(text).to.equal('hello😄😄world');
+}
+
+/**
+ * Insert two emoji between two lines of text.
+ * Regression test for #672.
+ */
+async function regression672(driver: WebDriver) {
+    // Insert text
+    await driver.findElement(composeArea).click();
+    await driver.findElement(composeArea).sendKeys('hello');
+    await driver.findElement(composeArea).sendKeys(Key.SHIFT, Key.ENTER);
+    await driver.findElement(composeArea).sendKeys(Key.SHIFT, Key.ENTER);
+    await driver.findElement(composeArea).sendKeys('world');
+    await driver.findElement(composeArea).sendKeys(Key.UP);
+
+    // Insert two emoji
+    await driver.findElement(emojiTrigger).click();
+    const emoji = await driver.findElement(By.css('.e1[title=":tired_face:"]'));
+    await emoji.click();
+    await emoji.click();
+
+    const text = await extractText(driver);
+    expect(text).to.equal('hello\n😫😫\nworld');
+}
+
 // Register tests here
 const TESTS: Array<[string, Testfunc]> = [
     ['Show and hide emoji selector', showEmojiSelector],
     ['Insert emoji and text', insertEmoji],
     ['Insert three lines of text', insertNewline],
     ['Regression test #574', regression574],
+    ['Regression test #671', regression671],
+    ['Regression test #672', regression672],
 ];
 
 // Test runner


### PR DESCRIPTION
Fixes #671 and #672.

That one was evil :slightly_smiling_face: Explanation:

When we are inserting into the compose area, we have to track two things: Visible characters and HTML characters. The cursor position depends on the HTML characters, not the visible characters.

To insert an emoji, we convert it to HTML and insert that HTML into the DOM at the specified position. We then increment the position by the length of the HTML snippet.

The HTML snippet we inserted (generated by the emojione library) looked roughly like this:

    <img class="e1" alt="😁" title=":grin:" src="../../public/img/e1/1f601.png"/>

The length of that is 76 bytes, so we advance the cursor position by 76. For some reason, we had an off-by-one error, the cursor would advance too far.

The reason for this is that when inserting the HTML into the DOM, it is normalized and the XML closing slash is stripped:

    <img class="e1" alt="😁" title=":grin:" src="../../public/img/e1/1f601.png">

Thus the HTML gets longer by 75 characters, but we're advancing the cursor by 76 characters.

That explains both #671 and #672.

Two regression UI tests have been added.