### PR TITLE
Use translate-cloak directive on main and footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,14 +77,14 @@
         <!-- The overlay box that shows up if media is previewed -->
         <mediabox></mediabox>
 
-        <div id="main">
+        <div id="main" translate-cloak>
             <div id="status-bar">
                 <status-bar active="ctrl.expandStatusBar"></status-bar>
             </div>
             <div id="main-content" ui-view></div>
         </div>
         <footer ng-controller="FooterController as ctrl">
-            <ul>
+            <ul translate-cloak>
                 <li><a ng-click="ctrl.showVersionInfo('[[VERSION]]')" ng-keypress="ctrl.showVersionInfo('[[VERSION]]', $event)" tabindex="0">Version [[VERSION]] {{ ctrl.config.VERSION_MOUNTAIN }}</a></li>
                 <li><a href="https://threema.ch/threema-web" target="_blank" rel="noopener noreferrer" tabindex="0" translate>welcome.MORE_ABOUT_WEB</a>
                 </li>

--- a/src/sass/app.scss
+++ b/src/sass/app.scss
@@ -9,6 +9,7 @@
 @import "base/reset";
 @import "base/typography";
 @import "base/colors";
+@import "base/cloak";
 
 // Helpers: Tools, helper files, variables, config files.
 @import "helpers/colors";

--- a/src/sass/base/_cloak.scss
+++ b/src/sass/base/_cloak.scss
@@ -1,0 +1,5 @@
+// Like ng-cloak, for angular-translate.
+
+.translate-cloak {
+    display: none;
+}


### PR DESCRIPTION
This finally avoids the flash of untranslated text.

The `ng-cloak` directive does not suffice for this, because translations are loaded after AngularJS is loaded.