### PR TITLE
Opt out of translation suggestion

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,6 +24,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="referrer" content="no-referrer">
+    <meta name="google" content="notranslate">
 
     <title>Threema Web</title>
     <meta name="description" translate translate-attr-content="meta.DESCRIPTION"


### PR DESCRIPTION
Ask Google to not analyse the contents of the page for translation purposes

We already have i18n. Furthermore, Google may analyse sensitive content for
the purpose of recognising whether the page needs to be translated, see
https://support.google.com/webmasters/answer/79812?hl=en

---

Hello dear user. Consider switching to Firefox. We can only ask Google's browser to not do it. We cannot prevent it...