### PR TITLE
Properly report push promise rejections

### DIFF
--- a/src/services/push.ts
+++ b/src/services/push.ts
@@ -72,6 +72,8 @@ export class PushService {
     /**
      * Send a push notification for the specified session (public permanent key
      * of the initiator). The promise is always resolved to a boolean.
+     *
+     * If something goes wrong, the promise is rejected with an `Error` instance.
      */
     public async sendPush(session: Uint8Array): Promise<boolean> {
         if (!this.isAvailable()) {

--- a/src/services/webclient.ts
+++ b/src/services/webclient.ts
@@ -1022,13 +1022,13 @@ export class WebClientService {
 
         // Actually send the push notification
         this.pushService.sendPush(this.salty.permanentKeyBytes)
-            .catch(() => this.$log.warn(this.logTag, 'Could not notify app!'))
             .then(() => {
                 this.$log.debug(this.logTag, 'Requested app wakeup via', this.pushTokenType, 'push');
                 this.$rootScope.$apply(() => {
                     this.stateService.updateConnectionBuildupState('push');
                 });
-            });
+            })
+            .catch((e: Error) => this.$log.error(this.logTag, 'Could not send wakeup push to app: ' + e.message));
     }
 
     /**


### PR DESCRIPTION
Previously the error reason was swallowed by the `catch` block.