### PR TITLE
Require at least Safari 11

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -77,7 +77,7 @@ angular.module('3ema', [
     FF: 50,
     CHROME: 45,
     OPERA: 32,
-    SAFARI: 10,
+    SAFARI: 11,
 })
 
 // Set default route


### PR DESCRIPTION
Unfortunately Safari 10 support was broken in commit 72cb6af released with v2.0.0-beta.8, when we switched to using the `window.crypto.subtle` API (used for the `sha256` function that we use when sending a push message). Safari 10 does not support it, meaning that we never properly supported Safari 10 in the first place.

Safari 11 is shipped with macOS High Sierra. Safari 10 usage is minimal on our live servers, so it's not worth it to add a library just for Safari 10. People that cannot or don't want to upgrade from macOS Sierra can still use Threema Web with Firefox, Chrome, Opera or another WebKit based browser.