### PR TITLE
Increase browser requirements

### DIFF
--- a/dist/babelify-config.js
+++ b/dist/babelify-config.js
@@ -2,6 +2,12 @@ const babelifyConfig = {
     presets: [
         ['@babel/preset-env', {
             'useBuiltIns': 'entry',
+            'targets': {
+                'firefox': 50,
+                'chrome': 45,
+                'opera': 32,
+                'safari': 11,
+            },
         }],
     ],
     extensions: '.ts',

--- a/dist/babelify-config.js
+++ b/dist/babelify-config.js
@@ -3,9 +3,9 @@ const babelifyConfig = {
         ['@babel/preset-env', {
             'useBuiltIns': 'entry',
             'targets': {
-                'firefox': 50,
-                'chrome': 45,
-                'opera': 32,
+                'firefox': 60,
+                'chrome': 65,
+                'opera': 52,
                 'safari': 11,
             },
         }],

--- a/src/app.ts
+++ b/src/app.ts
@@ -76,9 +76,9 @@ angular.module('3ema', [
 
 // Constants to be used by controllers
 .constant('BROWSER_MIN_VERSIONS', {
-    FF: 50,
-    CHROME: 45,
-    OPERA: 32,
+    FF: 60,
+    CHROME: 65,
+    OPERA: 52,
     SAFARI: 11,
 })
 

--- a/src/filters.ts
+++ b/src/filters.ts
@@ -158,7 +158,7 @@ angular.module('3ema.filters', [])
             if (text !== null && text.length > 10) {
                 let result = text.match(/@\[([\*\@a-zA-Z0-9][\@a-zA-Z0-9]{7})\]/g);
                 if (result !== null) {
-                    result = ([...new Set(result)]);
+                    result = new Set(result);
                     // Unique
                     for (const possibleMention of result) {
                         const identity = possibleMention.substr(2, 8);

--- a/src/services/string.ts
+++ b/src/services/string.ts
@@ -17,7 +17,7 @@
 
 export class StringService {
     public byteChunk(str: string, byteLength: number, offset: number = null): string[] {
-        const chars = [...str];
+        const chars = Array.from(str);
         const chunks = [''];
         let currentChunkSize = 0;
         let chunkIndex = 0;
@@ -75,7 +75,7 @@ export class StringService {
             realLength: 0,
         };
         if (input !== null && input.length > 0) {
-            const chars = [...input];
+            const chars = Array.from(input);
             let charFound = false;
             const realPos = Math.min(pos, chars.length) - 1;
 


### PR DESCRIPTION
Use babel-preset-env to build the bundle for the following browser versions:

- Firefox 60 ESR (released 2018-05-09), previously 50
- Chrome 65 (released 2018-03-06), previously 45
- Opera 52 (released 2018-03-14), previously 32
- Safari 11 (released 2017-09-19)

Support for Firefox ESR 52 was dropped on September 5, 2018. Using out-of-date browsers should be discouraged as they pose a security risk.