### PR TITLE
Fix collapsing of consecutive whitespace in message

### DIFF
--- a/src/sass/sections/_compose_area.scss
+++ b/src/sass/sections/_compose_area.scss
@@ -40,6 +40,7 @@ compose-area {
                     max-height: calc(1.3em * 5);
                     min-height: 22px;
                     cursor: text;
+                    white-space: pre-wrap;
 
                     img.e1 {
                         vertical-align: middle;

--- a/src/sass/sections/_conversation.scss
+++ b/src/sass/sections/_conversation.scss
@@ -351,6 +351,10 @@
                 @include mouse-hand;
             }
 
+            span {
+                white-space: pre-wrap;
+            }
+
             span.e1.large-emoji {
                 transform: scale(1.0);
                 margin: 1px 4px 1px 0px;


### PR DESCRIPTION
This should fix #703.

Unfortunately I didn't find out how to create a Selenium test for this, since white-space collapsing is only display logic and will not be reflected in the DOM.