### PR TITLE
Conversations: Handle clearing of latest message

### DIFF
--- a/src/threema.d.ts
+++ b/src/threema.d.ts
@@ -340,7 +340,7 @@ declare namespace threema {
         position?: number;
         messageCount: number;
         unreadCount: number;
-        latestMessage: Message | null;
+        latestMessage?: Message;
         receiver?: Receiver;
         avatar?: ArrayBuffer;
         notifications?: NotificationSettings;

--- a/src/threema/container.ts
+++ b/src/threema/container.ts
@@ -339,6 +339,12 @@ export class Conversations implements threema.Container.Conversations {
                 // Copy properties from new conversation to old conversation
                 Object.assign(this.conversations[i], conversation);
 
+                // The latest message can be cleared.
+                if (conversation.latestMessage === undefined
+                        && this.conversations[i].latestMessage !== undefined) {
+                    delete this.conversations[i].latestMessage;
+                }
+
                 // If the position changed, re-sort.
                 if (this.conversations[i].position !== i) {
                     const tmp = this.conversations.splice(i, 1)[0];

--- a/tests/ts/containers.ts
+++ b/tests/ts/containers.ts
@@ -35,7 +35,6 @@ function makeContactConversation(id: string, position?: number): threema.Convers
         position: position,
         messageCount: 5,
         unreadCount: 0,
-        latestMessage: null,
         isStarred: false,
     };
 }
@@ -148,6 +147,42 @@ describe('Container', () => {
 
                 conversations.updateOrAdd(makeContactConversation('1', 7));
                 expect(conversations.get().map(getId)).toEqual(['2', '0', '1']);
+            });
+
+            it('handles conversations that clear the latest message', function() {
+                // Regression test for #693
+                const conversations = getConversations();
+                conversations.set([
+                    {
+                        type: 'contact',
+                        id: '0',
+                        position: 0,
+                        messageCount: 1,
+                        unreadCount: 0,
+                        latestMessage: {
+                            type: 'text',
+                            id: 'xyz',
+                            body: 'a',
+                            sortKey: 0,
+                            partnerId: 'z',
+                            isOutbox: true,
+                            isStatus: false,
+                        },
+                        isStarred: false,
+                    },
+                ]);
+
+                conversations.updateOrAdd({
+                    type: 'contact',
+                    id: '0',
+                    position: 0,
+                    messageCount: 0,
+                    unreadCount: 0,
+                    isStarred: false,
+                });
+                const updated = conversations.get()[0];
+                expect(updated.messageCount).toEqual(0);
+                expect(updated.latestMessage).toBeUndefined();
             });
         });
     });


### PR DESCRIPTION
Fixes #693.

The problem was that since protocol v2, an absent latestMessage would result in the key being omitted, instead of setting it to null. (Null is now disallowed.)