### PR TITLE
Fix out-of-sync bug on Android reconnect

### DIFF
--- a/src/partials/messenger.ts
+++ b/src/partials/messenger.ts
@@ -521,7 +521,10 @@ class ConversationController {
     public submit = (type: threema.MessageContentType, contents: threema.MessageData[]): Promise<any> => {
         // Validate whether a connection is available
         return new Promise((resolve, reject) => {
-            if (!this.stateService.readyToSubmit(this.webClientService.chosenTask)) {
+            if (!this.stateService.readyToSubmit(
+                this.webClientService.chosenTask,
+                this.webClientService.startupDone,
+            )) {
                 // Invalid connection, show toast and abort
                 this.showError(this.$translate.instant('error.NO_CONNECTION'));
                 return reject();

--- a/src/services/state.ts
+++ b/src/services/state.ts
@@ -225,13 +225,19 @@ export class StateService {
         }
     }
 
-    public readyToSubmit(chosenTask: ChosenTask): boolean {
+    /**
+     * Return whether messages can be submitted to the outgoing queue.
+     *
+     * The `startupDone` flag indicates, whether the initial data in the
+     * webclient service has been loaded or not.
+     */
+    public readyToSubmit(chosenTask: ChosenTask, startupDone: boolean): boolean {
         switch (chosenTask) {
             case ChosenTask.RelayedData:
                 return true;
             case ChosenTask.WebRTC:
             default:
-                return this.state === GlobalConnectionState.Ok;
+                return this.state === GlobalConnectionState.Ok && startupDone;
         }
     }
 

--- a/src/services/webclient.ts
+++ b/src/services/webclient.ts
@@ -895,6 +895,12 @@ export class WebClientService {
                 this.startupPromise = null;
                 this.startupDone = true;
                 this._resetInitializationSteps();
+
+                // Hack for #712
+                // TODO: Remove once we have the ack protocol for Android too
+                if (this.$state.includes('messenger')) {
+                    this.$state.reload();
+                }
             });
         }
 


### PR DESCRIPTION
This is work in progress. It's a bit tricky.

When Android reconnects, the messages and the conversations are reloaded. If a user submits a message after the receivers are already loaded but before the conversations are loaded, the unsent message gets put into a new(?) conversation which is then overwritten by the real conversations, or something like that.