### PR TITLE
Fix shortnameToUnicode for multi-codepoint emoji

### DIFF
--- a/src/helpers/emoji.ts
+++ b/src/helpers/emoji.ts
@@ -3778,11 +3778,10 @@ export function shortnameToUnicode(shortname: string): string | null {
     if (codepoints === undefined) {
         return null;
     }
-    const parts = [];
-    for (const codepoint of codepoints.split('-')) {
-        parts.push(twemoji.convert.fromCodePoint(codepoint));
-    }
-    return parts.join('');
+    return codepoints
+        .split('-')
+        .map(twemoji.convert.fromCodePoint)
+        .join('');
 }
 
 /**

--- a/src/helpers/emoji.ts
+++ b/src/helpers/emoji.ts
@@ -3774,11 +3774,15 @@ export function emojify(text: string): string {
  * Translate a shortname to UTF8.
  */
 export function shortnameToUnicode(shortname: string): string | null {
-    const codepoint = shortnames[shortname];
-    if (codepoint === undefined) {
+    const codepoints = shortnames[shortname];
+    if (codepoints === undefined) {
         return null;
     }
-    return twemoji.convert.fromCodePoint(codepoint);
+    const parts = [];
+    for (const codepoint of codepoints.split('-')) {
+        parts.push(twemoji.convert.fromCodePoint(codepoint));
+    }
+    return parts.join('');
 }
 
 /**

--- a/tests/ts/emoji_helpers.ts
+++ b/tests/ts/emoji_helpers.ts
@@ -44,6 +44,10 @@ describe('Emoji Helpers', () => {
         it('returns null for unknown shortcodes', function() {
             expect(shortnameToUnicode('sömbsöp')).toBeNull();
         });
+
+        it('handles multi-codepoint emoji', function() {
+            expect(shortnameToUnicode('ch')).toEqual('\ud83c\udde8\ud83c\udded');
+        });
     });
 
     describe('enlargeSingleEmoji', function() {


### PR DESCRIPTION
The `convert.fromCodePoint` function only converts the first codepoint in a list of dash-separated codepoints.

For multi-codepoint emoji, the codepoints need to be converted separately.