### PR TITLE
Unbreak source bundle on Firefox 52

### DIFF
--- a/dist/babelify-config.js
+++ b/dist/babelify-config.js
@@ -1,9 +1,15 @@
+// Target a version without class support due to this issue:
+// https://stackoverflow.com/q/43307607
+// This does not mean that we support Firefox <60ESR!
+// We will increase the target again once FF52 has died out.
+const minFirefoxTarget = 44;
+
 const babelifyConfig = {
     presets: [
         ['@babel/preset-env', {
             useBuiltIns: 'entry',
             targets: {
-                firefox: 60,
+                firefox: minFirefoxTarget,
                 chrome: 65,
                 opera: 52,
                 safari: 11,


### PR DESCRIPTION
Firefox <55 has a bug that prevents the app bundle from loading:

https://stackoverflow.com/q/43307607

Unfortunately this means that only the background image is visible, and
that the version support message is not being shown at all.

The simplest workaround for now is to target a Firefox version without
native class support, to cause ES5 to be generated. Once Firefox 52 has
died out, we can remove support. This will probably (hopefully) be the
case by the end of 2019.

Note that this does not mean that we officially support Firefox 52.