### PR TITLE
Replace U+00A0 with real spaces before sending text

### DIFF
--- a/src/directives/compose_area.ts
+++ b/src/directives/compose_area.ts
@@ -170,7 +170,16 @@ export default [
                 //
                 // Emoji images are converted to their alt text in this process.
                 function submitText(): Promise<any> {
-                    const text = extractText(composeDiv[0], logAdapter($log.warn, logTag));
+                    const rawText = extractText(composeDiv[0], logAdapter($log.warn, logTag));
+
+                    // Due to #731, and the hack introduced in #706, the
+                    // extracted text may contain non-breaing spaces (U+00A0).
+                    // Replace them with actual whitespace to avoid strange
+                    // behavior when submitting the text.
+                    //
+                    // TODO: Remove this once we have a compose area rewrite and can
+                    // fix the actual bug.
+                    const text = rawText.replace(/\u00A0/g, ' ');
 
                     return new Promise((resolve, reject) => {
                         const submitTexts = (strings: string[]) => {

--- a/src/directives/compose_area.ts
+++ b/src/directives/compose_area.ts
@@ -173,7 +173,7 @@ export default [
                     const rawText = extractText(composeDiv[0], logAdapter($log.warn, logTag));
 
                     // Due to #731, and the hack introduced in #706, the
-                    // extracted text may contain non-breaing spaces (U+00A0).
+                    // extracted text may contain non-breaking spaces (U+00A0).
                     // Replace them with actual whitespace to avoid strange
                     // behavior when submitting the text.
                     //


### PR DESCRIPTION
This is a workaround for the problems introduced in #706. It's not nice, but the hack can be removed once we have the new compose area.

Note that when pasting large texts from the clipboard, it will still look strange in the compose area itself (since non-breaking spaces don't break :wink:) but the submitted text will not contain non-breaking spaces anymore (which caused display issues in the apps themselves).

Fixes #731.