### PR TITLE
Use relative emoji paths in emojify function

### DIFF
--- a/src/helpers/emoji.ts
+++ b/src/helpers/emoji.ts
@@ -3759,7 +3759,7 @@ export function emojify(text: string): string {
     if (text !== null) {
         return twemoji.parse(text, {
             callback: (icon, options, variant) => {
-                return '/emoji/png32/' + icon + '.png';
+                return 'emoji/png32/' + icon + '.png';
             },
             attributes: (icon, variant) => {
                 return {'data-c': variant};

--- a/tests/ts/emoji_helpers.ts
+++ b/tests/ts/emoji_helpers.ts
@@ -24,7 +24,7 @@ describe('Emoji Helpers', () => {
         it('emojifies with img tag', function() {
             expect(emojify('hello 🐦'))
                 .toEqual('hello <img class="em" draggable="false" '
-                       + 'alt="🐦" src="/emoji/png32/1f426.png" data-c="1f426"/>');
+                       + 'alt="🐦" src="emoji/png32/1f426.png" data-c="1f426"/>');
         });
 
         it('ignores certain codepoints', function() {
@@ -57,13 +57,13 @@ describe('Emoji Helpers', () => {
 
         const singleEmojiClassName = 'large-emoji';
         const crazy = '<img class="em" draggable="false"'
-            + ' alt="🤪" src="/emoji/png32/1f92a.png" data-c="1f92a">';
+            + ' alt="🤪" src="emoji/png32/1f92a.png" data-c="1f92a">';
         const crazyLarge = '<img class="em ' + singleEmojiClassName
-            + '" draggable="false" alt="🤪" src="/emoji/png64/1f92a.png" data-c="1f92a">';
+            + '" draggable="false" alt="🤪" src="emoji/png64/1f92a.png" data-c="1f92a">';
         const copyright = '<img class="em anotherclass" draggable="false"'
-            + ' alt="©️" src="/emoji/png32/a9.png" data-c="a9">';
+            + ' alt="©️" src="emoji/png32/a9.png" data-c="a9">';
         const copyrightLarge = '<img class="em ' + singleEmojiClassName
-            + ' anotherclass" draggable="false" alt="©️" src="/emoji/png64/a9.png" data-c="a9">';
+            + ' anotherclass" draggable="false" alt="©️" src="emoji/png64/a9.png" data-c="a9">';
 
         it('enlarges 1 emoji', () => {
             expect(process(crazy)).toEqual(crazyLarge);


### PR DESCRIPTION
Refs #742. @lgrahl spotted another case of absolute paths.