### PR TITLE
Stop using local fonts for material icons

### DIFF
--- a/public/fonts/material.css
+++ b/public/fonts/material.css
@@ -1,8 +1,6 @@
 @font-face {
     font-family: 'Material Icons';
-    src: local('Material Icons'),
-         local('MaterialIcons-Regular'),
-         url('MaterialIcons-Regular.woff2?v=1') format('woff2'),
+    src: url('MaterialIcons-Regular.woff2?v=1') format('woff2'),
          url('MaterialIcons-Regular.woff?v=1') format('woff');
     font-style: normal;
     font-weight: 400;


### PR DESCRIPTION
While local fonts can reduce the number of resource downloads, there
have been repeated problems with icons not showing due to a conflict
with other locally installed fonts.

Fixes #714.