### PR TITLE
Improve strings for translation

### DIFF
--- a/public/i18n/cs.json
+++ b/public/i18n/cs.json
@@ -275,12 +275,9 @@
         "SOURCE_CODE": "Zdrojový kód i licenční podmínky naleznete na GitHub webu:",
         "EMOJI_ART": "Sada smajlíků převzata od <a target=\"_blank\" href=\"https://twemoji.twitter.com/\">Twitteru</a>",
         "NOTIFICATION_SOUNDS": "Zvukové soubory &copy; 2012 <a target=\"_blank\" href=\"https://www.soundsnap.com/licence\">soundsnap.com</a> - Licencované dle Soundsnap License",
-        "LICENSE_LINK_BEFORE": "Licenční ujednání na použité open source komponenty najdete",
-        "LICENSE_LINK_TEXT": "ve zdrojovém kódu",
+        "LICENSE_TEXT": "Licenční ujednání na použité open source komponenty najdete <a target=\"_blank\" rel=\"noopener noreferrer\" href=\"{url}\">ve zdrojovém kódu</a>.",
         "CHANGELOG": "Changelog",
-        "CHANGELOG_LINK_BEFORE": "Threema Web changelog naleznete na ",
-        "CHANGELOG_LINK_TEXT": "GitHub",
-        "CHANGELOG_LINK_AFTER": "."
+        "CHANGELOG_TEXT": "Threema Web changelog naleznete na <a target=\"_blank\" rel=\"noopener noreferrer\" href=\"{url}\">GitHub</a>."
     },
     "settings": {
         "SETTINGS": "Nastavení",

--- a/public/i18n/de.json
+++ b/public/i18n/de.json
@@ -277,13 +277,9 @@
         "SOURCE_CODE": "Der Quellcode und die Lizenzbedingungen finden sich auf GitHub:",
         "EMOJI_ART": "Verwendete Emoji stammen von <a target=\"_blank\" href=\"https://twemoji.twitter.com/\">Twitter</a>",
         "NOTIFICATION_SOUNDS": "Benachrichtigunstöne &copy; 2012 <a target=\"_blank\" href=\"https://www.soundsnap.com/licence\">soundsnap.com</a> - Licensed under the Soundsnap License",
-        "LICENSE_LINK_BEFORE": "Lizenzen von verwendeten Open-Source-Komponenten können",
-        "LICENSE_LINK_TEXT": "im Quellcode",
-        "LICENSE_LINK_AFTER": "gefunden werden",
+        "LICENSE_TEXT": "Lizenzen von verwendeten Open-Source-Komponenten können <a target=\"_blank\" rel=\"noopener noreferrer\" href=\"{url}\">im Quellcode</a> gefunden werden.",
         "CHANGELOG": "Änderungsprotokoll",
-        "CHANGELOG_LINK_BEFORE": "Das Änderungsprotokoll von Threema Web findet sich",
-        "CHANGELOG_LINK_TEXT": "auf GitHub",
-        "CHANGELOG_LINK_AFTER": "."
+        "CHANGELOG_TEXT": "Das Änderungsprotokoll von Threema Web findet sich <a target=\"_blank\" rel=\"noopener noreferrer\" href=\"{url}\">auf GitHub</a>."
     },
     "settings": {
         "SETTINGS": "Einstellungen",

--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -277,13 +277,9 @@
         "SOURCE_CODE": "The source code and the licensing terms can be found on GitHub:",
         "EMOJI_ART": "Emoji art supplied by <a target=\"_blank\" href=\"https://twemoji.twitter.com/\">Twitter</a>",
         "NOTIFICATION_SOUNDS": "Sound files &copy; 2012 <a target=\"_blank\" href=\"https://www.soundsnap.com/licence\">soundsnap.com</a> - Licensed under the Soundsnap License",
-        "LICENSE_LINK_BEFORE": "Licenses of used open source components can be found",
-        "LICENSE_LINK_TEXT": "in the source code",
-        "LICENSE_LINK_AFTER": ".",
+        "LICENSE_TEXT": "Licenses of used open source components can be found <a target=\"_blank\" rel=\"noopener noreferrer\" href=\"{url}\">in the source code</a>.",
         "CHANGELOG": "Changelog",
-        "CHANGELOG_LINK_BEFORE": "The Threema Web changelog can be found",
-        "CHANGELOG_LINK_TEXT": "on GitHub",
-        "CHANGELOG_LINK_AFTER": "."
+        "CHANGELOG_TEXT": "The Threema Web changelog can be found <a target=\"_blank\" rel=\"noopener noreferrer\" href=\"{url}\">on GitHub</a>."
     },
     "settings": {
         "SETTINGS": "Settings",

--- a/public/i18n/fr.json
+++ b/public/i18n/fr.json
@@ -275,12 +275,9 @@
         "SOURCE_CODE": "Le code source et les termes de licences peuvent être trouvés sur GitHub:",
         "EMOJI_ART": "Emoji art fourni par <a target=\"_blank\" href=\"https://twemoji.twitter.com/\">Twitter</a>",
         "NOTIFICATION_SOUNDS": "Fichiers audio &copy; 2012 <a target=\"_blank\" href=\"https://www.soundsnap.com/licence\">soundsnap.com</a>- en application des licences Soundsnap",
-        "LICENSE_LINK_BEFORE": "Vous pouvez trouver les licences open source des composants utilisées",
-        "LICENSE_LINK_TEXT": "dans le code source",
+        "LICENSE_TEXT": "Vous pouvez trouver les licences open source des composants utilisées <a target=\"_blank\" rel=\"noopener noreferrer\" href=\"{url}\">dans le code source</a>.",
         "CHANGELOG": "Journal des modifications",
-        "CHANGELOG_LINK_BEFORE": "Le journal des modifications de Threema Web n'a pas été trouvé",
-        "CHANGELOG_LINK_TEXT": "sur GitHub",
-        "CHANGELOG_LINK_AFTER": "."
+        "CHANGELOG_TEXT": "Le journal des modifications de Threema Web n'a pas été trouvé <a target=\"_blank\" rel=\"noopener noreferrer\" href=\"{url}\">sur GitHub</a>."
     },
     "settings": {
         "SETTINGS": "Paramètre",

--- a/public/i18n/zh.json
+++ b/public/i18n/zh.json
@@ -275,12 +275,9 @@
         "SOURCE_CODE": "GitHub",
         "EMOJI_ART": "表情由<a target=\"_blank\" href=\"https://twemoji.twitter.com/\">Twitter</a>提供",
         "NOTIFICATION_SOUNDS": "声音文件和副本; 2012 <a target=\"_blank\" href=\"https://www.soundsnap.com/licence\">soundsnap.com</a> - 根据Soundsnap许可证获得许可",
-        "LICENSE_LINK_BEFORE": "可以找到使用过的开源组件的许可证",
-        "LICENSE_LINK_TEXT": "在源代码里",
+        "LICENSE_TEXT": "可以找到使用过的开源组件的许可证 <a target=\"_blank\" rel=\"noopener noreferrer\" href=\"{url}\">在源代码里</a>。",
         "CHANGELOG": "更新日志",
-        "CHANGELOG_LINK_BEFORE": "找不到更新日志",
-        "CHANGELOG_LINK_TEXT": "在GitHub",
-        "CHANGELOG_LINK_AFTER": "。"
+        "CHANGELOG_TEXT": "找不到更新日志 <a target=\"_blank\" rel=\"noopener noreferrer\" href=\"{url}\">在GitHub/a>。"
     },
     "settings": {
         "SETTINGS": "设置",

--- a/src/partials/dialog.about.html
+++ b/src/partials/dialog.about.html
@@ -27,21 +27,12 @@
                 </p>
 
                 <h2 translate>about.CHANGELOG</h2>
-                <p>
-                    <span translate>about.CHANGELOG_LINK_BEFORE</span>
-                    <a href="https://github.com/threema-ch/threema-web/blob/{{ ctrl.config.GIT_BRANCH }}/CHANGELOG.md"
-                       target="_blank" rel="noopener noreferrer" translate>about.CHANGELOG_LINK_TEXT</a><span translate>about.CHANGELOG_LINK_AFTER</span>
-                </p>
+                <p translate translate-values="{ url: 'https://github.com/threema-ch/threema-web/blob/{{ ctrl.config.GIT_BRANCH }}/CHANGELOG.md' }">about.CHANGELOG_TEXT</p>
 
                 <h2 translate>about.LICENSES</h2>
                 <ul>
                     <li translate>about.EMOJI_ART</li>
-                    <li>
-                        <span translate>about.LICENSE_LINK_BEFORE</span>
-                        <a href="https://github.com/threema-ch/threema-web/blob/{{ ctrl.config.GIT_BRANCH }}/LICENSE-3RD-PARTY.txt"
-                           target="_blank" rel="noopener noreferrer" translate>about.LICENSE_LINK_TEXT</a>
-                        <span translate>about.LICENSE_LINK_AFTER</span>
-                    </li>
+                    <li translate translate-values="{ url: 'https://github.com/threema-ch/threema-web/blob/{{ ctrl.config.GIT_BRANCH }}/LICENSE-3RD-PARTY.txt' }">about.LICENSE_LINK</li>
                     <li translate>about.NOTIFICATION_SOUNDS</li>
                 </ul>
 

--- a/src/partials/dialog.version.html
+++ b/src/partials/dialog.version.html
@@ -18,11 +18,7 @@
                 <p><a ng-href="{{ ctrl.config.VERSION_MOUNTAIN_URL }}" target="_blank" rel="noopener noreferrer">{{ ctrl.config.VERSION_MOUNTAIN }} ({{ ctrl.config.VERSION_MOUNTAIN_HEIGHT }}m)</a> / <a ng-href="{{ ctrl.config.VERSION_MOUNTAIN_IMAGE_URL }}" target="_blank" rel="noopener noreferrer">Source Image</a> ({{ ctrl.config.VERSION_MOUNTAIN_IMAGE_COPYRIGHT }})</p>
 
                 <h2 translate>about.CHANGELOG</h2>
-                <p>
-                    <span translate>about.CHANGELOG_LINK_BEFORE</span>
-                    <a href="https://github.com/threema-ch/threema-web/blob/{{ ctrl.config.GIT_BRANCH }}/CHANGELOG.md"
-                       target="_blank" rel="noopener noreferrer" translate>about.CHANGELOG_LINK_TEXT</a><span translate>about.CHANGELOG_LINK_AFTER</span>
-                </p>
+                <p translate translate-values="{ url: 'https://github.com/threema-ch/threema-web/blob/{{ ctrl.config.GIT_BRANCH }}/CHANGELOG.md' }">about.CHANGELOG_TEXT</p>
             </div>
         </md-dialog-content>
         <md-dialog-actions layout="row">


### PR DESCRIPTION
Split strings make it very hard for translators to see the context.
Joining them with placeholders is a better approach.