### PR TITLE
Line clamping when quoting text

### DIFF
--- a/src/sass/sections/_conversation.scss
+++ b/src/sass/sections/_conversation.scss
@@ -65,7 +65,6 @@
             max-width: 85%;
             max-height: 9.4em;
             overflow: hidden;
-            text-overflow: ellipsis;
             line-height: 1.3em;
         }
     }

--- a/src/sass/sections/_conversation.scss
+++ b/src/sass/sections/_conversation.scss
@@ -63,7 +63,7 @@
         .message-quote {
             @include word-wrap;
             max-width: 85%;
-            max-height: 10.4em;
+            max-height: 9.4em;
             overflow: hidden;
             text-overflow: ellipsis;
             line-height: 1.3em;

--- a/src/sass/sections/_conversation.scss
+++ b/src/sass/sections/_conversation.scss
@@ -63,6 +63,9 @@
         .message-quote {
             @include word-wrap;
             max-width: 85%;
+            max-height: 10.4em;
+            overflow: hidden;
+            text-overflow: ellipsis;
             line-height: 1.3em;
         }
     }


### PR DESCRIPTION
Should fix: #751 Too long quoted message destroys layout

It doesn't show an ellipsis (which iOS currently does) at the end which is apparently not easy (https://css-tricks.com/line-clampin/).

Used to look like:
![old](https://user-images.githubusercontent.com/2352766/53622831-6b079580-3bfb-11e9-9ae8-3cb1fd04b393.png)
Now looks like:
![new](https://user-images.githubusercontent.com/2352766/53622833-6cd15900-3bfb-11e9-9403-973c50aa5f87.png)