### PR TITLE
Own nickname to me

### DIFF
--- a/public/i18n/de.json
+++ b/public/i18n/de.json
@@ -189,7 +189,8 @@
         "PINNED_CONVERSATION_OK": "Unterhaltung angepinnt",
         "PINNED_CONVERSATION_ERROR": "Unterhaltung konnte nicht angepinnt werden",
         "UNPINNED_CONVERSATION_OK": "Unterhaltung entpinnt",
-        "UNPINNED_CONVERSATION_ERROR": "Unterhaltung konnte nicht entpinnt werden"
+        "UNPINNED_CONVERSATION_ERROR": "Unterhaltung konnte nicht entpinnt werden",
+        "ME": "Ich"
     },
     "messageStates": {
         "WE_ACK": "Sie haben ein Daumen-Hoch gesendet",

--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -189,7 +189,8 @@
         "PINNED_CONVERSATION_OK": "Conversation pinned",
         "PINNED_CONVERSATION_ERROR": "Conversation could not be pinned",
         "UNPINNED_CONVERSATION_OK": "Conversation unpinned",
-        "UNPINNED_CONVERSATION_ERROR": "Conversation could not be unpinned"
+        "UNPINNED_CONVERSATION_ERROR": "Conversation could not be unpinned",
+        "ME": "Me"
     },
     "messageStates": {
         "WE_ACK": "You sent thumbs-up",

--- a/public/i18n/fr.json
+++ b/public/i18n/fr.json
@@ -189,7 +189,8 @@
         "PINNED_CONVERSATION_OK": "Les conversations épinglées",
         "PINNED_CONVERSATION_ERROR": "Les conversations n'ont pas pu être épinglées",
         "UNPINNED_CONVERSATION_OK": "Les conversations non épinglées",
-        "UNPINNED_CONVERSATION_ERROR": "La conversation n'a pas pu être désépinglé"
+        "UNPINNED_CONVERSATION_ERROR": "La conversation n'a pas pu être désépinglé",
+        "ME": "Moi"
     },
     "messageStates": {
         "WE_ACK": "Vous avez envoyé un pouce levé",

--- a/src/directives/contact_badge.ts
+++ b/src/directives/contact_badge.ts
@@ -90,7 +90,7 @@ export default [
                         <eee-avatar eee-receiver="ctrl.contactReceiver"
                                     eee-resolution="'low'"></eee-avatar>
                     </section>
-                    <div class="receiver-badge-name" ng-bind-html="ctrl.contactReceiver.displayName | escapeHtml | emojify"></div>
+                    <div class="receiver-badge-name" ng-bind-html="ctrl.contactReceiver | displayName | escapeHtml | emojify"></div>
                     <div class="contact-badge-identity">{{ ctrl.contactReceiver.id }}</div>
                     <div class="contact-badge-actions" ng-if="ctrl.showActions">
                         <md-button aria-label="Remove" class="md-icon-button" ng-click="ctrl.onRemove(ctrl.contactReceiver)">

--- a/src/directives/message_contact.ts
+++ b/src/directives/message_contact.ts
@@ -26,7 +26,7 @@ export default [
             template: `
                 <span class="message-name"
                     ng-style="colored && {'color': contact.color}"
-                       ng-bind-html="contact.displayName | escapeHtml | emojify">
+                       ng-bind-html="contact.displayName | meNickname | escapeHtml | emojify">
                 </span>
             `,
         };

--- a/src/directives/message_contact.ts
+++ b/src/directives/message_contact.ts
@@ -26,7 +26,7 @@ export default [
             template: `
                 <span class="message-name"
                     ng-style="colored && {'color': contact.color}"
-                       ng-bind-html="contact.displayName | meNickname | escapeHtml | emojify">
+                       ng-bind-html="contact.displayName | ownIdToNickname | escapeHtml | emojify">
                 </span>
             `,
         };

--- a/src/directives/message_contact.ts
+++ b/src/directives/message_contact.ts
@@ -26,7 +26,7 @@ export default [
             template: `
                 <span class="message-name"
                     ng-style="colored && {'color': contact.color}"
-                       ng-bind-html="contact.displayName | ownIdToNickname | escapeHtml | emojify">
+                       ng-bind-html="contact | displayName | escapeHtml | emojify">
                 </span>
             `,
         };

--- a/src/filters.ts
+++ b/src/filters.ts
@@ -439,7 +439,9 @@ angular.module('3ema.filters', [])
         return function(contact: threema.Receiver) {
             if (contact.id === webClientService.me.id) {
                 return $translate.instant('messenger.ME');
-            } else { return contact.displayName; }
+            } else {
+                return contact.displayName;
+            }
         };
 }])
 

--- a/src/filters.ts
+++ b/src/filters.ts
@@ -431,10 +431,10 @@ angular.module('3ema.filters', [])
     return $sce.trustAsResourceUrl;
 }])
 
-.filter('meNickname', ['WebClientService', function(webClientService: WebClientService) {
+.filter('meNickname', ['WebClientService', '$translate', function(webClientService: WebClientService, $translate: ng.translate.ITranslateService) {
     return function(displayName: string) {
         if (displayName === webClientService.me.displayName) {
-            return 'Ich';
+            return $translate.instant('messenger.ME');
         } else { return displayName; }
     };
 }])

--- a/src/filters.ts
+++ b/src/filters.ts
@@ -431,12 +431,15 @@ angular.module('3ema.filters', [])
     return $sce.trustAsResourceUrl;
 }])
 
-.filter('ownIdToNickname', ['WebClientService', '$translate',
+/**
+ * Show 'Me' for own contact, for all other contacts show displayName
+ */
+.filter('displayName', ['WebClientService', '$translate',
     function(webClientService: WebClientService, $translate: ng.translate.ITranslateService) {
-        return function(displayName: string) {
-            if (displayName === webClientService.me.displayName) {
+        return function(contact: threema.Receiver) {
+            if (contact.id === webClientService.me.id) {
                 return $translate.instant('messenger.ME');
-            } else { return displayName; }
+            } else { return contact.displayName; }
         };
 }])
 

--- a/src/filters.ts
+++ b/src/filters.ts
@@ -431,4 +431,12 @@ angular.module('3ema.filters', [])
     return $sce.trustAsResourceUrl;
 }])
 
+.filter('meNickname', ['WebClientService', function(webClientService: WebClientService) {
+    return function(displayName: string) {
+        if (displayName === webClientService.me.displayName) {
+            return 'Ich';
+        } else { return displayName; }
+    };
+}])
+
 ;

--- a/src/filters.ts
+++ b/src/filters.ts
@@ -339,15 +339,15 @@ angular.module('3ema.filters', [])
 }])
 
 /**
- * Convert ID-Array to (Display-)Name-String, separated by ','
+ * Convert ID-Array to (Display-)Name-String, separated by ','. Invokes the displayName filter.
  */
-.filter('idsToNames', ['WebClientService', function(webClientService: WebClientService) {
+.filter('idsToNames', ['WebClientService', '$filter', function(webClientService: WebClientService, $filter) {
     return(ids: string[]) => {
         const names: string[] = [];
         for (const id of ids) {
             const contactReceiver = webClientService.contacts.get(id);
             if (hasValue(contactReceiver)) {
-                names.push(contactReceiver.displayName);
+                names.push($filter('displayName')(contactReceiver));
             } else {
                 names.push('Unknown');
             }

--- a/src/filters.ts
+++ b/src/filters.ts
@@ -431,12 +431,13 @@ angular.module('3ema.filters', [])
     return $sce.trustAsResourceUrl;
 }])
 
-.filter('meNickname', ['WebClientService', '$translate', function(webClientService: WebClientService, $translate: ng.translate.ITranslateService) {
-    return function(displayName: string) {
-        if (displayName === webClientService.me.displayName) {
-            return $translate.instant('messenger.ME');
-        } else { return displayName; }
-    };
+.filter('ownIdToNickname', ['WebClientService', '$translate',
+    function(webClientService: WebClientService, $translate: ng.translate.ITranslateService) {
+        return function(displayName: string) {
+            if (displayName === webClientService.me.displayName) {
+                return $translate.instant('messenger.ME');
+            } else { return displayName; }
+        };
 }])
 
 ;

--- a/tests/filters.js
+++ b/tests/filters.js
@@ -17,21 +17,25 @@ describe('Filters', function() {
             get: function(id) {
                 if (id === 'AAAAAAAA') {
                     return {
+                        id: 'AAAAAAAA',
                         displayName: 'ContactA'
                     }
                 }
                 else if (id === 'XXXXXXXX') {
                     return {
+                        id: 'XXXXXXXX',
                         displayName: 'ContactX'
                     }
                 }
                 else if (id === '*AAAAAAA') {
                     return {
+                        id: '*AAAAAAA',
                         displayName: 'GWContactA'
                     }
                 }
                 else if (id === 'BAD0BAD1') {
                     return {
+                        id: 'BAD0BAD1',
                         displayName: '<b>< script >foo&ndash;</b>< script>',
                     }
                 }
@@ -238,6 +242,24 @@ describe('Filters', function() {
             const input = 'hello #threema';
             expect(process(input)).toEqual(input);
         });
+    });
+
+    describe('displayName', function() {
+
+        let process = (id) => {
+            return $filter('displayName')(id)
+        };
+
+        it('own contact/nickname to me', () => {
+            expect(process(webClientServiceMock.me)).toEqual('messenger.ME');
+        });
+
+        it('other contacts to displayName', () => {
+            expect(process(webClientServiceMock.contacts.get('AAAAAAAA'))).toEqual('ContactA');
+            expect(process(webClientServiceMock.contacts.get('XXXXXXXX'))).toEqual('ContactX');
+            expect(process(webClientServiceMock.contacts.get('*AAAAAAA'))).toEqual('GWContactA');
+        });
+
     });
 
 });


### PR DESCRIPTION
**The problem:**
Instead of showing 'Me' in the message overview (if group message) the own nickname was shown. This was different than in the app.

**The solution**
A new displayName filter, which returns the displayName (Nickname) for non-me contacts and 'Me' for the own contact

Todo:
- [ ] Translations for 'Me' 

Idk how the translation process for new strings is handled - but you can tell me :)