### PR TITLE
Reconnect overhaul

### DIFF
--- a/public/i18n/de.json
+++ b/public/i18n/de.json
@@ -8,6 +8,7 @@
         "PLEASE_SCAN": "Scannen Sie den QR-Code mit Ihrer Threema-App",
         "PLEASE_UNLOCK": "Verbindung wiederaufbauen",
         "WAITING": "Auf Verbindung warten",
+        "RETRY": "Erneut versuchen",
         "PLEASE_RELOAD": "Bitte laden Sie die Seite neu.",
         "RELOAD": "Seite neu laden",
         "PASSWORD": "Passwort",
@@ -59,6 +60,8 @@
         "APP_STARTED": "Ist die Threema-App gestartet?",
         "SESSION_DELETED": "Wurde diese Sitzung in der Threema-App gelöscht?",
         "PHONE_ONLINE": "Ist Ihr Mobilgerät mit dem Internet verbunden?",
+        "UNLOCK_OR_CHARGE": "Es kann helfen, Ihr Mobilgerät zu entsperren oder an ein Ladegerät anzuschliessen.",
+        "PUSH_FAQ": "Möglicherweise liegt ein Problem bei der Verarbeitung von Push-Benachrichtigungen vor. Die FAQ-Artikel für <a target=\"_blank\" href=\"https://threema.ch/faq/push_andr\">Android</a> und <a target=\"_blank\" href=\"https://threema.ch/faq/push_ios\">iOS</a> helfen bei der Fehlersuche.",
         "WEBCLIENT_ENABLED": "Ist Threema Web in der Threema-App aktiviert?",
         "PLUGIN": "Ist in Ihrem Browser ein Plugin zum Blockieren von WebRTC installiert?",
         "ADBLOCKER": "Ist in Ihrem Browser ein Ad-Blocker installiert?",
@@ -289,6 +292,10 @@
             "SHOW_PREVIEW": "Nachrichteninhalt in Benachrichtigungen anzeigen",
             "PLAY_SOUND": "Ton abspielen"
         }
+    },
+    "deviceUnreachable": {
+        "DEVICE_UNREACHABLE": "Mobilgerät nicht erreichbar",
+        "UNABLE_TO_CONNECT": "Eine Verbindung mit Ihrem Mobilgerät konnte nicht hergestellt werden …"
     },
     "version": {
         "NEW_VERSION": "Neue Version Verfügbar",

--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -8,6 +8,7 @@
         "PLEASE_SCAN": "Scan this QR code with your Threema app",
         "PLEASE_UNLOCK": "Reconnecting session",
         "WAITING": "Waiting for connection",
+        "RETRY": "Retry",
         "PLEASE_RELOAD": "Please reload the page to try again.",
         "RELOAD": "Reload page",
         "PASSWORD": "Password",
@@ -59,6 +60,8 @@
         "APP_STARTED": "Is the Threema app started?",
         "SESSION_DELETED": "Did you delete this session on your phone?",
         "PHONE_ONLINE": "Is your phone connected to the internet?",
+        "UNLOCK_OR_CHARGE": "It may help to unlock your device or connect it to a charger.",
+        "PUSH_FAQ": "Your device may be affected by Push Notification issues. See the FAQ articles for <a target=\"_blank\" href=\"https://threema.ch/faq/push_andr\">Android</a> and <a target=\"_blank\" href=\"https://threema.ch/faq/push_ios\">iOS</a> for troubleshooting.",
         "WEBCLIENT_ENABLED": "Is Threema Web enabled in the Threema app?",
         "PLUGIN": "Is a privacy plugin installed in your browser which blocks WebRTC communication?",
         "ADBLOCKER": "Do you use an ad blocker which also blocks WebRTC communication?",
@@ -289,6 +292,10 @@
             "SHOW_PREVIEW": "Show message contents in notifications",
             "PLAY_SOUND": "Play sound"
         }
+    },
+    "deviceUnreachable": {
+        "DEVICE_UNREACHABLE": "Device Unreachable",
+        "UNABLE_TO_CONNECT": "Unable to connect to your device …"
     },
     "version": {
         "NEW_VERSION": "New Version Available",

--- a/src/controllers/status.ts
+++ b/src/controllers/status.ts
@@ -161,7 +161,7 @@ export class StatusController {
      * Attempt to reconnect an Android device after a connection loss.
      */
     private reconnectAndroid(): void {
-        this.$log.warn(this.logTag, `Connection lost (Android). Reconnect attempt #${this.stateService.attempt + 1}`);
+        this.$log.info(this.logTag, `Connection lost (Android). Reconnect attempt #${this.stateService.attempt + 1}`);
 
         // Show expanded status bar (if on 'messenger')
         if (this.$state.includes('messenger')) {

--- a/src/controllers/status.ts
+++ b/src/controllers/status.ts
@@ -305,7 +305,8 @@ export class StatusController {
             };
         })();
 
-        this.$timeout(() => {
+        this.$timeout.cancel(this.reconnectTimeout);
+        this.reconnectTimeout = this.$timeout(() => {
             if (push.send) {
                 this.$log.debug(`Starting new connection with push, reason: ${push.reason}`);
             } else {

--- a/src/controllers/status.ts
+++ b/src/controllers/status.ts
@@ -183,18 +183,22 @@ export class StatusController {
             peerTrustedKey: originalPeerPermanentKeyBytes,
             resume: true,
         });
-        this.webClientService.start().then(
-            () => {
+        this.webClientService.start()
+            .then(
+                () => { /* ignored */ },
+                (error) => {
+                    this.$log.error(this.logTag, 'Error state:', error);
+                    // Note: The web client service has already been stopped at
+                    // this point.
+                },
+                (progress: threema.ConnectionBuildupStateChange) => {
+                    this.$log.debug(this.logTag, 'Connection buildup advanced:', progress);
+                },
+            )
+            .finally(() => {
                 // Hide expanded status bar
                 this.collapseStatusBar();
-            },
-            (error) => {
-                this.$log.error(this.logTag, 'Error state:', error);
-            },
-            (progress: threema.ConnectionBuildupStateChange) => {
-                this.$log.debug(this.logTag, 'Connection buildup advanced:', progress);
-            },
-        );
+            });
     }
 
     /**
@@ -257,16 +261,11 @@ export class StatusController {
             });
 
             this.webClientService.start(!push.send).then(
-                () => { /* ok */ },
+                () => { /* ignored */ },
                 (error) => {
                     this.$log.error(this.logTag, 'Error state:', error);
-                    this.webClientService.stop({
-                        reason: DisconnectReason.SessionError,
-                        send: false,
-                        // TODO: Use welcome.error once we have it
-                        close: 'welcome',
-                        connectionBuildupState: 'reconnect_failed',
-                    });
+                    // Note: The web client service has already been stopped at
+                    // this point.
                 },
                 (progress: threema.ConnectionBuildupStateChange) => {
                     this.$log.debug(this.logTag, 'Connection buildup advanced:', progress);

--- a/src/exceptions.ts
+++ b/src/exceptions.ts
@@ -1,0 +1,18 @@
+/**
+ * This file is part of Threema Web.
+ *
+ * Threema Web is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Threema Web. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export class TimeoutError extends Error {}

--- a/src/partials/dialog.device-unreachable.html
+++ b/src/partials/dialog.device-unreachable.html
@@ -1,0 +1,43 @@
+<md-dialog aria-label="Device Unreachable">
+    <form ng-cloak>
+        <md-toolbar>
+            <div class="md-toolbar-tools">
+                <h2 translate>deviceUnreachable.DEVICE_UNREACHABLE</h2>
+            </div>
+        </md-toolbar>
+        <md-dialog-content>
+            <div class="md-dialog-content">
+                <h3 translate>deviceUnreachable.UNABLE_TO_CONNECT</h3>
+                <ul class="material-icons-list">
+                    <li class="help">
+                        <span translate>troubleshooting.PHONE_ONLINE</span>
+                    </li>
+                    <li class="help">
+                        <span translate>troubleshooting.APP_STARTED</span>
+                    </li>
+                    <li class="help">
+                        <span translate>troubleshooting.WEBCLIENT_ENABLED</span>
+                    </li>
+                    <li class="info">
+                        <span translate>troubleshooting.UNLOCK_OR_CHARGE</span>
+                    </li>
+                    <li class="info">
+                        <span translate>troubleshooting.PUSH_FAQ</span>
+                    </li>
+                </ul>
+            </div>
+        </md-dialog-content>
+        <md-dialog-actions layout="row">
+            <span flex></span>
+            <md-button role="button" class="md-primary reload-btn" ng-click="ctrl.reload()" aria-labelledby="aria-label-reload">
+                <span translate id="aria-label-reload">welcome.RELOAD</span>
+            </md-button>
+            <md-button role="button" class="md-primary reload-btn circular-progress-button" ng-click="ctrl.retry()" ng-disabled="ctrl.retrying" aria-labelledby="aria-label-retry">
+                <md-progress-circular ng-if="ctrl.retrying" md-mode="determinate" md-diameter="20" value="{{ctrl.progress}}"></md-progress-circular>
+                <i ng-if="!ctrl.retrying" class="material-icons">refresh</i>
+                <span translate id="aria-label-retry">welcome.RETRY</span>
+            </md-button>
+        </md-dialog-actions>
+    </form>
+</md-dialog>
+

--- a/src/partials/messenger.ts
+++ b/src/partials/messenger.ts
@@ -131,27 +131,35 @@ class SendFileController extends DialogController {
  * Handle device unreachable
  */
 export class DeviceUnreachableController extends DialogController {
-    public static readonly $inject = ['$rootScope', '$window', '$mdDialog', 'CONFIG', 'WebClientService'];
+    public static readonly $inject = [
+        '$rootScope', '$window', '$mdDialog',
+        'CONFIG', 'StateService', 'WebClientService',
+    ];
     private readonly $rootScope: any;
     private readonly $window: ng.IWindowService;
+    private readonly stateService: StateService;
     private readonly webClientService: WebClientService;
     public retrying: boolean = false;
     public progress: number = 0;
 
     constructor(
         $rootScope: any, $window: ng.IWindowService, $mdDialog: ng.material.IDialogService,
-        CONFIG: threema.Config, webClientService: WebClientService,
+        CONFIG: threema.Config, stateService: StateService, webClientService: WebClientService,
     ) {
         super($mdDialog, CONFIG);
         this.$rootScope = $rootScope;
         this.$window = $window;
+        this.stateService = stateService;
         this.webClientService = webClientService;
     }
 
     /**
      * Retry wakeup of the device via a push session.
      */
-    public async retry(): Promise<any> {
+    public async retry(): Promise<void> {
+        // Reset attempt counter
+        this.stateService.attempt = 0;
+
         // Schedule sending a push
         const [expectedPeriodMaxMs, pushSessionPromise] = this.webClientService.sendPush();
 

--- a/src/partials/messenger.ts
+++ b/src/partials/messenger.ts
@@ -24,7 +24,7 @@ import {
 } from '@uirouter/angularjs';
 
 import {ContactControllerModel} from '../controller_model/contact';
-import {bufferToUrl, filter, hasValue, logAdapter, supportsPassive, throttle, u8aToHex} from '../helpers';
+import {bufferToUrl, hasValue, logAdapter, supportsPassive, throttle, u8aToHex} from '../helpers';
 import {emojify} from '../helpers/emoji';
 import {ContactService} from '../services/contact';
 import {ControllerService} from '../services/controller';
@@ -61,7 +61,7 @@ class DialogController {
         this.done();
     }
 
-    protected hide(data: any): void {
+    protected hide(data?: any): void {
         this.$mdDialog.hide(data);
         this.done();
     }
@@ -128,10 +128,59 @@ class SendFileController extends DialogController {
 }
 
 /**
+ * Handle device unreachable
+ */
+export class DeviceUnreachableController extends DialogController {
+    public static readonly $inject = ['$rootScope', '$window', '$mdDialog', 'CONFIG', 'WebClientService'];
+    private readonly $rootScope: any;
+    private readonly $window: ng.IWindowService;
+    private readonly webClientService: WebClientService;
+    public retrying: boolean = false;
+    public progress: number = 0;
+
+    constructor(
+        $rootScope: any, $window: ng.IWindowService, $mdDialog: ng.material.IDialogService,
+        CONFIG: threema.Config, webClientService: WebClientService,
+    ) {
+        super($mdDialog, CONFIG);
+        this.$rootScope = $rootScope;
+        this.$window = $window;
+        this.webClientService = webClientService;
+    }
+
+    /**
+     * Retry wakeup of the device via a push session.
+     */
+    public async retry(): Promise<any> {
+        // Schedule sending a push
+        const [expectedPeriodMaxMs, pushSessionPromise] = this.webClientService.sendPush();
+
+        // Initialise progress circle
+        this.retrying = true;
+        this.progress = 0;
+        const interval = setInterval(() => this.$rootScope.$apply(() => ++this.progress), expectedPeriodMaxMs / 100);
+
+        // Wait for push to succeed/reject and reset the progress circle
+        try {
+            await pushSessionPromise;
+        } finally {
+            clearInterval(interval);
+            this.$rootScope.$apply(() => this.retrying = false);
+        }
+    }
+
+    /**
+     * Reload the page.
+     */
+    public reload(): void {
+        this.$window.location.reload();
+    }
+}
+
+/**
  * Handle settings
  */
 class SettingsController {
-
     public static $inject = ['$mdDialog', '$window', 'SettingsService', 'NotificationService'];
 
     public $mdDialog: ng.material.IDialogService;
@@ -190,7 +239,6 @@ class SettingsController {
     public setWantsSound(notificationSound: boolean) {
         this.notificationService.setWantsSound(notificationSound);
     }
-
 }
 
 interface ConversationStateParams extends UiStateParams {

--- a/src/partials/welcome.html
+++ b/src/partials/welcome.html
@@ -66,29 +66,29 @@
                     <p ng-if="ctrl.state === 'loading' || ctrl.state === 'done'" translate>welcome.LOADING_INITIAL_DATA</p>
                     <div class="troubleshoot" ng-if="ctrl.slowConnect">
                         <h3 translate>troubleshooting.SLOW_CONNECT</h3>
-                        <ul>
-                            <li>
-                                <i class="material-icons md-dark md-14">help</i>
+                        <ul class="material-icons-list">
+                            <li class="help">
                                 <span translate>troubleshooting.PHONE_ONLINE</span>
                             </li>
-                            <li ng-if="ctrl.state === 'push'">
-                                <i class="material-icons md-dark md-14">help</i>
+                            <li ng-if="ctrl.state === 'push'" class="help">
                                 <span translate>troubleshooting.APP_STARTED</span>
                             </li>
-                            <li ng-if="ctrl.state === 'push'">
-                                <i class="material-icons md-dark md-14">help</i>
+                            <li ng-if="ctrl.state === 'push'" class="help">
                                 <span translate>troubleshooting.WEBCLIENT_ENABLED</span>
                             </li>
-                            <li ng-if="ctrl.state === 'push'">
-                                <i class="material-icons md-dark md-14">help</i>
+                            <li ng-if="ctrl.state === 'push'" class="help">
                                 <span translate>troubleshooting.SESSION_DELETED</span>
                             </li>
-                            <li ng-if="ctrl.state === 'peer_handshake' && ctrl.showWebrtcTroubleshooting">
-                                <i class="material-icons md-dark md-14">help</i>
+                            <li ng-if="ctrl.state === 'push'" class="info">
+                                <span translate>troubleshooting.UNLOCK_OR_CHARGE</span>
+                            </li>
+                            <li ng-if="ctrl.state === 'push'" class="info">
+                                <span translate>troubleshooting.PUSH_FAQ</span>
+                            </li>
+                            <li ng-if="ctrl.state === 'peer_handshake' && ctrl.showWebrtcTroubleshooting" class="help">
                                 <span translate>troubleshooting.PLUGIN</span>
                             </li>
-                            <li ng-if="ctrl.state === 'peer_handshake' && ctrl.showWebrtcTroubleshooting">
-                                <i class="material-icons md-dark md-14">help</i>
+                            <li ng-if="ctrl.state === 'peer_handshake' && ctrl.showWebrtcTroubleshooting" class="help">
                                 <span translate>troubleshooting.ADBLOCKER</span>
                             </li>
                         </ul>

--- a/src/partials/welcome.ts
+++ b/src/partials/welcome.ts
@@ -582,19 +582,12 @@ class WelcomeController {
             // If an error occurs...
             (error) => {
                 this.$log.error(this.logTag, 'Error state:', error);
-                // TODO: should probably show an error message instead
-                this.timeoutService.register(
-                    () => this.$state.reload(),
-                    WelcomeController.REDIRECT_DELAY,
-                    true,
-                    'reloadStateError',
-                );
+                // Note: On rejection, the web client service will already
+                //       redirect to 'welcome' and show a protocol error.
             },
 
             // State updates
-            (progress: threema.ConnectionBuildupStateChange) => {
-                // Do nothing
-            },
+            (progress: threema.ConnectionBuildupStateChange) => { /* ignored */ },
         );
     }
 

--- a/src/sass/layout/_main.scss
+++ b/src/sass/layout/_main.scss
@@ -250,12 +250,44 @@
             opacity: 1;
         }
     }
+}
 
+ul.material-icons-list {
+    list-style-type: none;
+
+    li {
+        $list-style-width: 1.3em;
+        margin-left: $list-style-width;
+        text-indent: -$list-style-width;
+
+        &::before {
+            font-family: 'Material Icons';
+        }
+
+        &.help {
+            &::before {
+                content: 'help';
+            }
+        }
+
+        &.info {
+            &::before {
+                content: 'info';
+            }
+        }
+    }
 }
 
 .md-dialog-content {
     &.center {
         text-align: center;
+    }
+}
+
+.circular-progress-button {
+    md-progress-circular {
+        float: left;
+        margin: 8px 4px;
     }
 }
 

--- a/src/sass/sections/_welcome.scss
+++ b/src/sass/sections/_welcome.scss
@@ -112,10 +112,13 @@
     }
 
     .loading {
+        $progress-height: 250px;
+        $progress-overlap: 70px;
         margin-top: 48px;
 
         md-progress-circular {
-            margin: 0 auto;
+            margin: 0 auto calc(-#{$progress-height} + #{$progress-overlap});
+            height: $progress-height;
 
             svg path {
                 stroke-width: 12px !important;
@@ -123,13 +126,6 @@
         }
 
         .info {
-            display: flex;
-            position: relative;
-            top: -250px;
-            flex-direction: column;
-            justify-content: center;
-            height: 250px;
-
             .percentage {
                 margin-bottom: 8px;
                 vertical-align: center;
@@ -140,11 +136,7 @@
         }
 
         .troubleshoot {
-            $troubleshoot-height: 190px;
-            position: absolute;
-            bottom: -$troubleshoot-height - 32px;
-            width: 100%;
-            height: $troubleshoot-height;
+            margin-top: calc(#{$progress-overlap} + 40px);
 
             h3 {
                 margin-bottom: 8px;
@@ -152,13 +144,13 @@
             }
 
             ul {
+                text-align: left;
                 font-size: .9em;
-                list-style-type: none;
-            }
 
-            li {
-                padding-bottom: .3em;
-                line-height: 1.2em;
+                li {
+                    padding: 0 1em .3em;
+                    line-height: 1.2em;
+                }
             }
 
             .forget {
@@ -170,21 +162,6 @@
                 padding: 0 10px;
                 height: 35px;
             }
-        }
-    }
-
-    .notification {
-        flex-direction: horizontal;
-        margin-bottom: 16px;
-        background-color: #ff9800;
-        padding: 8px;
-
-        p {
-            width: 100%;
-            text-align: center;
-            line-height: 1.4em;
-            font-size: .8em;
-            font-weight: bold;
         }
     }
 }

--- a/src/services/push.ts
+++ b/src/services/push.ts
@@ -48,7 +48,6 @@ export class PushSession {
     private readonly service: PushService;
     private readonly session: Uint8Array;
     private readonly config: threema.PushSessionConfig;
-    private readonly collapseKey: string = randomString(6);
     private readonly doneFuture: Future<any> = new Future();
     private logTag: string = '[Push]';
     private running: boolean = false;
@@ -150,7 +149,7 @@ export class PushSession {
     private async run(): Promise<void> {
         // Calculate session hash
         const sessionHash = await sha256(this.session.buffer);
-        this.logTag = `[Push.${sessionHash}.${this.collapseKey}]`;
+        this.logTag = `[Push.${sessionHash}]`;
 
         // Prepare data
         const data = new URLSearchParams();
@@ -184,7 +183,7 @@ export class PushSession {
             if (timeToLive === 0) {
                 data.delete(PushService.ARG_COLLAPSE_KEY);
             } else {
-                data.set(PushService.ARG_COLLAPSE_KEY, this.collapseKey);
+                data.set(PushService.ARG_COLLAPSE_KEY, sessionHash.slice(0, 6));
             }
 
             // Modify data

--- a/src/services/push.ts
+++ b/src/services/push.ts
@@ -49,6 +49,7 @@ export class PushSession {
     private readonly session: Uint8Array;
     private readonly config: threema.PushSessionConfig;
     private readonly doneFuture: Future<any> = new Future();
+    private readonly affiliation: string = randomString(6);
     private logTag: string = '[Push]';
     private running: boolean = false;
     private retryTimeoutMs: number;
@@ -156,6 +157,7 @@ export class PushSession {
         data.set(PushService.ARG_TYPE, this.service.pushType);
         data.set(PushService.ARG_SESSION, sessionHash);
         data.set(PushService.ARG_VERSION, `${this.service.version}`);
+        data.set(PushService.ARG_AFFILIATION, this.affiliation);
         if (this.service.pushType === threema.PushTokenType.Apns) {
             // APNS token format: "<hex-deviceid>;<endpoint>;<bundle-id>"
             const parts = this.service.pushToken.split(';');
@@ -244,6 +246,7 @@ export class PushService {
     public static readonly ARG_TOKEN = 'token';
     public static readonly ARG_SESSION = 'session';
     public static readonly ARG_VERSION = 'version';
+    public static readonly ARG_AFFILIATION = 'affiliation';
     public static readonly ARG_ENDPOINT = 'endpoint';
     public static readonly ARG_BUNDLE_ID = 'bundleid';
     public static readonly ARG_TIME_TO_LIVE = 'ttl';

--- a/src/services/push.ts
+++ b/src/services/push.ts
@@ -228,7 +228,7 @@ export class PushSession {
             this.retryTimeoutMs = Math.min(this.retryTimeoutMs * 2, this.config.retryTimeoutMaxMs);
 
             // Maximum tries reached?
-            if (this.tries === this.config.triesMax) {
+            if (!this.doneFuture.done && this.tries === this.config.triesMax) {
                 const error = `Push session timeout after ${this.tries} tries`;
                 this.$log.warn(this.logTag, error);
                 this.doneFuture.reject(new TimeoutError(error));

--- a/src/services/state.ts
+++ b/src/services/state.ts
@@ -52,7 +52,7 @@ export class StateService {
     // Global connection state
     private stage: Stage;
     private _state: threema.GlobalConnectionState;
-    public wasConnected: boolean;
+    public attempt: number = 0;
 
     // Unread messages
     private _unreadCount: number = 0;
@@ -132,7 +132,7 @@ export class StateService {
                     break;
                 case TaskConnectionState.Connected:
                     this.state = GlobalConnectionState.Ok;
-                    this.wasConnected = true;
+                    this.attempt = 0;
                     break;
                 case TaskConnectionState.Disconnected:
                     this.state = GlobalConnectionState.Error;
@@ -271,7 +271,6 @@ export class StateService {
         this.taskConnectionState = TaskConnectionState.New;
         this.stage = Stage.Signaling;
         this.state = GlobalConnectionState.Error;
-        this.wasConnected = false;
         this.connectionBuildupState = connectionBuildupState;
         this.progress = 0;
         this.unreadCount = 0;

--- a/src/services/webclient.ts
+++ b/src/services/webclient.ts
@@ -1257,6 +1257,12 @@ export class WebClientService {
 
         // Done, redirect now if session closed
         if (close) {
+            // Reject startup promise (if any)
+            if (this.startupPromise !== null) {
+                this.startupPromise.reject();
+                this.startupPromise = null;
+            }
+
             // Translate close flag
             const state = args.close !== false ? args.close : 'welcome';
             this.$state.go(state);

--- a/src/services/webclient.ts
+++ b/src/services/webclient.ts
@@ -1280,6 +1280,7 @@ export class WebClientService {
             if (this.startupPromise !== null) {
                 this.startupPromise.reject();
                 this.startupPromise = null;
+                this._resetInitializationSteps();
             }
 
             // Translate close flag

--- a/src/services/webclient.ts
+++ b/src/services/webclient.ts
@@ -3954,7 +3954,8 @@ export class WebClientService {
             try {
                 messageHandler.apply(this, [message.subType, message]);
             } catch (error) {
-                this.$log.error(this.logTag, `Unable to handle incoming wire message: ${error}`, error.stack);
+                this.$log.error(this.logTag, 'Unable to handle incoming wire message:', error);
+                console.trace(error); // tslint:disable-line:no-console
                 return;
             }
         }

--- a/src/services/webclient.ts
+++ b/src/services/webclient.ts
@@ -1215,6 +1215,11 @@ export class WebClientService {
             this.previousIncomingChunkSequenceNumber = null;
             this.previousChunkCache = null;
 
+            // Remove chosen task
+            // Note: This implicitly prevents automatic connection attempts
+            //       from the status controller.
+            this.chosenTask = threema.ChosenTask.None;
+
             // Reset general client information
             this.clientInfo = null;
 

--- a/src/threema.d.ts
+++ b/src/threema.d.ts
@@ -487,6 +487,13 @@ declare namespace threema {
         text: string;
     }
 
+    interface PushSessionConfig {
+        retryTimeoutInitMs: number;
+        retryTimeoutMaxMs: number;
+        triesMax: number;
+        timeToLiveRange: number[];
+    }
+
     const enum PushTokenType {
         Gcm = 'gcm',
         Apns = 'apns',


### PR DESCRIPTION
## Push Session (aka Continuous Pushes)

Add a push session instance will send pushes continuously until an undefined goal has been achieved which needs to call the `.done` method to stop pushes.

The push session will stop and reject the returned promise in case the push relay determined a client error (e.g. an invalid push token). In any other case, it will continue sending pushes. Thus, it is crucial to call `.done` eventually!

With default settings, the push session will send a push in the following intervals: 0s, 2s, 4s, 8s, 16s, 30s (maximum), 30s, ...
The first push will use a TTL of 0, the second push a TTL of 15s, and all subsequent pushes will use a TTL of 90s.

The default settings intend to wake up the app immediately by the first push which uses a TTL of 0, indicating the push server to deliver *now or never*. The mid TTL tries to work around potential issues with FCM clients misinterpreting the TTL as *don't need to dispatch until expired*. And the TTL of 90s acts as a last resort mechanism to wake up the app eventually.

## *Device Unreachable* Dialog

Instead of redirecting to the *welcome* page (Android) or doing nothing and letting the web client remain in a limbo state (iOS), the push session will retry waking the device three times. If that is unsuccessful, it will show a new dialog that allows to either *retry* or *reload page*. This dialog will disappear automatically once a connection to the device has been established.

## Fast Session Recovery

When the connection to the app is already lost but there was no explicit closure, we previously had to wait until the SaltyRTC server or the underlying transport recognised that the connection has been lost.

With this change, we request a connectionAck and send a push after 3 seconds of silence (no incoming chunks). This has a cooldown phase of 10 seconds.

Note: This only affects iOS at the moment.

## To Do

- [x] Investigate if there are other timers messing with the connection (e.g. iOS)
- [x] Optionally reject after N retries
- [x] On welcome, stop after N retries but don't show a dialog or fail the session
- [x] On messenger, stop after N retries and show an alert dialog which allows to retry. The dialog should automatically close if the connection resumes in the background.
  - [x] Link to Push FAQ should automatically redirect to the appropriate language (@sillych)

Resolves #354