### PR TITLE
Warn when receiving message update with unknown id

### DIFF
--- a/src/services/webclient.ts
+++ b/src/services/webclient.ts
@@ -2751,10 +2751,19 @@ export class WebClientService {
                     notify = true;
                     break;
                 case WebClientService.ARGUMENT_MODE_MODIFIED:
-                    this.messages.update(receiver, msg);
+                    if (!this.messages.update(receiver, msg)) {
+                        const log = `Received message update for unknown message (id ${msg.id})`;
+                        this.$log.error(this.logTag, log);
+                        if (this.config.DEBUG) {
+                            this.messages.addStatusMessage(receiver, 'Warning: ' + log);
+                            notify = true;
+                        }
+                    }
                     break;
                 case WebClientService.ARGUMENT_MODE_REMOVED:
-                    this.messages.remove(receiver, msg.id);
+                    if (!this.messages.remove(receiver, msg.id)) {
+                        this.$log.error(this.logTag, `Received message deletion for unknown message (id ${msg.id})`);
+                    }
                     notify = true;
                     break;
                 default:

--- a/src/threema.d.ts
+++ b/src/threema.d.ts
@@ -820,6 +820,7 @@ declare namespace threema {
             clearRequested(receiver: BaseReceiver): void;
             addNewer(receiver: BaseReceiver, messages: Message[]): void;
             addOlder(receiver: BaseReceiver, messages: Message[]): void;
+            addStatusMessage(receiver: BaseReceiver, text: string): void;
             update(receiver: BaseReceiver, message: Message): boolean;
             setThumbnail(receiver: BaseReceiver, messageId: string, thumbnailImage: string): boolean;
             remove(receiver: BaseReceiver, messageId: string): boolean;

--- a/src/threema/container.ts
+++ b/src/threema/container.ts
@@ -15,7 +15,7 @@
  * along with Threema Web. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import {copyShallow} from '../helpers';
+import {copyShallow, randomString} from '../helpers';
 import {isFirstUnreadStatusMessage} from '../message_helpers';
 import {ReceiverService} from '../services/receiver';
 
@@ -601,6 +601,34 @@ class Messages implements threema.Container.Messages {
         // Add the oldest message as ref
         receiverMessages.referenceMsgId = messages[0].id;
         receiverMessages.list.unshift.apply(receiverMessages.list, messages);
+    }
+
+    /**
+     * Insert a new fake status message.
+     *
+     * Note: This should probably only be used for debugging.
+     */
+    public addStatusMessage(receiver: threema.BaseReceiver, text: string): void {
+        // Get reference to message list for the specified receiver
+        const receiverMessages = this.getReceiverMessages(receiver);
+
+        // Determine sort key
+        const sortKey = receiverMessages.list.length > 0
+            ? receiverMessages.list[receiverMessages.list.length - 1].sortKey
+            : 0;
+
+        // Create fake status message
+        receiverMessages.list.push({
+            type: 'status',
+            id: randomString(6),
+            body: '',
+            caption: text,
+            sortKey: sortKey,
+            partnerId: receiver.id,
+            isOutbox: false,
+            isStatus: true,
+            statusType: 'text',
+        });
     }
 
     /**


### PR DESCRIPTION
If an `update/messages` message is received with messages that have unknown ids, log an error and - if in DEBUG mode - show a warning status message.

Screenshot:

![img](https://tmp.dbrgn.ch/screenshots/20190508170615-gse7a9ci.png)