### PR TITLE
Handle signaling connection state changes before handover

### DIFF
--- a/src/services/state.ts
+++ b/src/services/state.ts
@@ -83,11 +83,12 @@ export class StateService {
     /**
      * Signaling connection state.
      */
-    public updateSignalingConnectionState(state: saltyrtc.SignalingState, chosenTask: ChosenTask): void {
+    public updateSignalingConnectionState(
+        state: saltyrtc.SignalingState, chosenTask: ChosenTask, handoverDone: boolean,
+    ): void {
         const prevState = this.signalingConnectionState;
         this.signalingConnectionState = state;
-        if (this.stage === Stage.Signaling
-        || (this.stage === Stage.Task && chosenTask === ChosenTask.RelayedData)) {
+        if (!handoverDone) {
             this.$log.debug(this.logTag, 'Signaling connection state:', prevState, '=>', state);
             switch (state) {
                 case 'new':
@@ -109,7 +110,7 @@ export class StateService {
                     this.state = GlobalConnectionState.Error;
                     break;
                 default:
-                    this.$log.warn(this.logTag, 'Ignored signaling connection state change to', state);
+                    this.$log.warn(this.logTag, `Unknown signaling connection state: ${state}`);
             }
         } else {
             this.$log.debug(this.logTag, 'Ignored signaling connection state to "' + state + '"');

--- a/src/services/webclient.ts
+++ b/src/services/webclient.ts
@@ -187,6 +187,7 @@ export class WebClientService {
     // State handling
     private startupPromise: ng.IDeferred<{}> = null; // TODO: deferred type
     public startupDone: boolean = false;
+    private handoverDone: boolean = false;
     private pendingInitializationStepRoutines: Set<threema.InitializationStepRoutine> = new Set();
     private initialized: Set<threema.InitializationStep> = new Set();
     private stateService: StateService;
@@ -542,7 +543,7 @@ export class WebClientService {
                             this.$log.warn(this.logTag, 'Unknown signaling state:', state);
                     }
                 }
-                this.stateService.updateSignalingConnectionState(state, this.chosenTask);
+                this.stateService.updateSignalingConnectionState(state, this.chosenTask, this.handoverDone);
             }, 0);
         });
 
@@ -1042,6 +1043,11 @@ export class WebClientService {
             this.secureDataChannel.onclose = (ev: Event) => {
                 this.$log.warn('Secure data channel: Closed');
             };
+
+            // Mark as handed over
+            // Note: Even though this method is also "misused" for the relayed
+            //       data task, only WebRTC really hands over.
+            this.handoverDone = true;
         } else if (this.chosenTask === threema.ChosenTask.RelayedData) {
             // Handle messages directly
             this.relayedDataTask.on('data', (ev: saltyrtc.SaltyRTCEvent) => {
@@ -1170,6 +1176,7 @@ export class WebClientService {
             this.startupPromise = this.$q.defer();
         }
         this.startupDone = false;
+        this.handoverDone = false;
 
         // Connect
         this.salty.connect();


### PR DESCRIPTION
This should fix UI issues that occurred when the SaltyRTC task kicked in but the connection died during handover.

Resolves (partially) #799 