### PR TITLE
Sort issue template sections more logically

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,21 +1,21 @@
-## Expected Behavior
-<!--- If you're describing a bug, tell us what should happen -->
-<!--- If you're suggesting a change/improvement, tell us how it should work -->
-
-## Current Behavior
-<!--- If describing a bug, tell us what happens instead of the expected behavior -->
-<!--- If suggesting a change/improvement, explain the difference from current behavior -->
-
-## Possible Solution
-<!--- Not obligatory, but suggest a fix/reason for the bug, -->
-<!--- or ideas how to implement the addition or change -->
-
 ## Steps to Reproduce (for bugs)
 <!--- Provide a screenshot and/or an unambiguous set of steps to reproduce this bug. -->
 1.
 2.
 3.
 4.
+
+## Current Behavior
+<!--- If describing a bug, tell us what happens instead of the expected behavior -->
+<!--- If suggesting a change/improvement, explain the difference from current behavior -->
+
+## Expected Behavior
+<!--- If you're describing a bug, tell us what should happen -->
+<!--- If you're suggesting a change/improvement, tell us how it should work -->
+
+## Possible Solution
+<!--- Not obligatory, but suggest a fix/reason for the bug, -->
+<!--- or ideas how to implement the addition or change -->
 
 ## Your Environment
 <!--- Include as many relevant details about the environment you experienced the bug in. -->


### PR DESCRIPTION
This has annoyed me some times already: If I want to report an issue, I e.g. certainly won't list "potential solutions" before even describing the steps to reproduce the issue…
Similarly, I e.g. often cannot describe a "current behaviour" when I did not even describe what happened before.

IMHO this new order is much more logical.

---

BTW GitHub also notifies one that this file uses the "legacy" version of issue templates (wrong location). You maybe want to change that, too: https://help.github.com/en/articles/about-issue-and-pull-request-templates