### PR TITLE
Fix welcome page displaying an empty page on unlock/waiting state

### DIFF
--- a/src/services/webclient.ts
+++ b/src/services/webclient.ts
@@ -503,17 +503,6 @@ export class WebClientService {
             this.$log.debug('Auth token:', this.salty.authTokenHex);
         }
 
-        // We want to know about new responders.
-        this.salty.on('new-responder', () => {
-            if (!this.startupDone) {
-                // Pushing complete
-                this.resetPushSession(true);
-
-                // Peer handshake
-                this.stateService.updateConnectionBuildupState('peer_handshake');
-            }
-        });
-
         // We want to know about state changes
         this.salty.on('state-change', (ev: saltyrtc.SaltyRTCEvent) => {
             const state: saltyrtc.SignalingState = ev.data;
@@ -535,7 +524,6 @@ export class WebClientService {
                         }
                         break;
                     case 'task':
-                        // Do nothing, state will be updated once SecureDataChannel is open
                         break;
                     case 'closing':
                     case 'closed':
@@ -551,6 +539,12 @@ export class WebClientService {
         // Once the connection is established, if this is a WebRTC connection,
         // initiate the peer connection and start the handover.
         this.salty.once('state-change:task', () => {
+            // Pushing complete
+            this.resetPushSession(true);
+
+            // Peer handshake
+            this.stateService.updateConnectionBuildupState('peer_handshake');
+
             // Determine chosen task
             const task = this.salty.getTask();
             if (task.getName().indexOf('webrtc.tasks.saltyrtc.org') !== -1) {


### PR DESCRIPTION
Before this fix, we have interpreted a 'new-responder' event as an indication that the connection is about to be established. However, that is not the case since a dead responder connection can linger on the WebSocket path for a while.

It would be better if the SaltyRTC library would signal end and start state events which would indicate that e.g. a server or peer handshake is in progress (has started) or has been completed (has ended). Until we have that, we will have to live with this workaround.