### PR TITLE
Force reloading when signalling connection is lost

### DIFF
--- a/src/partials/dialog.device-unreachable.html
+++ b/src/partials/dialog.device-unreachable.html
@@ -32,7 +32,7 @@
             <md-button role="button" class="md-primary reload-btn" ng-click="ctrl.reload()" aria-labelledby="aria-label-reload">
                 <span translate id="aria-label-reload">welcome.RELOAD</span>
             </md-button>
-            <md-button role="button" class="md-primary reload-btn circular-progress-button" ng-click="ctrl.retry()" ng-disabled="ctrl.retrying" aria-labelledby="aria-label-retry">
+            <md-button ng-if="ctrl.canRetry" role="button" class="md-primary reload-btn circular-progress-button" ng-click="ctrl.retry()" ng-disabled="ctrl.retrying" aria-labelledby="aria-label-retry">
                 <md-progress-circular ng-if="ctrl.retrying" md-mode="determinate" md-diameter="20" value="{{ctrl.progress}}"></md-progress-circular>
                 <i ng-if="!ctrl.retrying" class="material-icons">refresh</i>
                 <span translate id="aria-label-retry">welcome.RETRY</span>

--- a/src/partials/messenger.ts
+++ b/src/partials/messenger.ts
@@ -154,6 +154,23 @@ export class DeviceUnreachableController extends DialogController {
     }
 
     /**
+     * We can only retry as long as the signaling connection has not been
+     * closed.
+     *
+     * TODO: This is a hack and should be removed as soon as the transport code
+     *       has been rewritten.
+     */
+    public get canRetry(): boolean {
+        switch (this.webClientService.salty.state) {
+            case 'closing':
+            case 'closed':
+                return false;
+            default:
+                return true;
+        }
+    }
+
+    /**
      * Retry wakeup of the device via a push session.
      */
     public async retry(): Promise<void> {


### PR DESCRIPTION
Unfortunately the SaltyRTC/WebSocket instance is hard to replace on-the-fly, so, as a workaround, we force to reload the page when the device is unreachable and a connection to the SaltyRTC server cannot be established.