### PR TITLE
Fix collapsing of consecutive whitespace in compose area

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ To run unit tests:
 
 To run UI tests:
 
+    npm run build  # Required for CSS to be rebuilt
     npm run test:ui <browser>
 
 For example:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1232,9 +1232,9 @@
       }
     },
     "@threema/compose-area": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@threema/compose-area/-/compose-area-0.3.2.tgz",
-      "integrity": "sha512-EAfu2Sei49xsjTiOJDtIRzNGbG40RsB7+daMd5vVZdc/eN43PSIxofpYZnpm66yiFJF/3SEOYXSnUmXdHemeSg=="
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@threema/compose-area/-/compose-area-0.3.3.tgz",
+      "integrity": "sha512-Kg6ueaUyqGMO7Lqz4JUavG/K/aUwMjke8xoKQkDeUaVvs37F+II8CI4baZvqntmRZhx+Ev2A/fhwUpCzsZDByw=="
     },
     "@types/angular": {
       "version": "1.6.54",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@saltyrtc/client": "^0.14.4",
     "@saltyrtc/task-relayed-data": "^0.3.1",
     "@saltyrtc/task-webrtc": "^0.13.0",
-    "@threema/compose-area": "^0.3.2",
+    "@threema/compose-area": "^0.3.3",
     "@types/angular": "^1.6.54",
     "@types/angular-material": "^1.1.68",
     "@types/angular-sanitize": "^1.3.7",

--- a/src/sass/sections/_compose_area.scss
+++ b/src/sass/sections/_compose_area.scss
@@ -34,6 +34,7 @@ compose-area {
                         min-height: 22px;
                         max-height: calc(1.3em * 5);
                         line-height: 20px;
+                        white-space: pre-wrap;
 
                         // show placeholder if field is on focus
                         &:empty {


### PR DESCRIPTION
This was reverted previously because of bugs related to the old compose area. Now that we've merged the new one, the CSS change should work.

See #703.