### PR TITLE
Fix flaky connection bar

### DIFF
--- a/src/controllers/status.ts
+++ b/src/controllers/status.ts
@@ -81,7 +81,9 @@ export class StatusController {
         // Register event handlers
         this.stateService.evtGlobalConnectionStateChange.attach(
             (stateChange: threema.GlobalConnectionStateChange) => {
-                this.onStateChange(stateChange.state, stateChange.prevState);
+                $scope.$apply(() => {
+                    this.onStateChange(stateChange.state, stateChange.prevState);
+                });
             },
         );
         this.stateService.evtUnreadCountChange.attach(


### PR DESCRIPTION
This also resolves a race condition that happened on iOS where the state had been dispatched too soon (or too late, depending on ones perspective).

Follow-up to #815/#812. Resolves #580.