### PR TITLE
Do not apply the receiver's color as background color

### DIFF
--- a/src/directives/avatar.ts
+++ b/src/directives/avatar.ts
@@ -118,7 +118,6 @@ export default [
                     // Set initial values
                     this.highResolution = this.resolution === 'high';
                     this.isLoading = this.highResolution;
-                    this.backgroundColor = receiver.color;
                     this.receiverName = receiver.displayName;
                 };
 
@@ -140,8 +139,6 @@ export default [
                             return false;
                         }
                         this.isLoading = false;
-                        // Reset background color
-                        this.backgroundColor = null;
                         return true;
                     };
 
@@ -279,7 +276,6 @@ export default [
                     </div>
                     <img
                          ng-class="ctrl.avatarClass()"
-                         ng-style="{ 'background-color': ctrl.backgroundColor }"
                          ng-src="{{ ctrl.getAvatarUri() }}"
                          in-view="ctrl.requestAvatar($inview)"
                          aria-label="avatar {{ ctrl.receiverName }}">


### PR DESCRIPTION
We may want to revert this once the apps do not send avatar images for every contact (even those who do not have an profile image) any more.

Fixes #851

Note: Low resolution is an unrelated problem. This needs to be fixed in the Android app.