### PR TITLE
Fix the Future to be marked as done when using the inner executor

### DIFF
--- a/public/libs/future.js
+++ b/public/libs/future.js
@@ -6,18 +6,26 @@
  */
 class Future extends Promise {
     constructor(executor) {
-        let resolve, reject;
-        super((resolve_, reject_) => {
-            resolve = resolve_;
-            reject = reject_;
+        const resolve = (...args) => {
+            this.resolve(...args);
+        };
+        const reject = (...args) => {
+            this.reject(...args);
+        };
+        let innerResolve, innerReject;
+
+        super((resolveFunc, rejectFunc) => {
+            innerResolve = resolveFunc;
+            innerReject = rejectFunc;
             if (executor) {
-                return executor(resolve_, reject_);
+                return executor(resolve, reject);
             }
         });
 
         this._done = false;
-        this._resolve = resolve;
-        this._reject = reject;
+        console.assert(innerResolve !== undefined && innerReject !== undefined, 'THERE IS NO HOPE!');
+        this._resolve = innerResolve;
+        this._reject = innerReject;
     }
 
     /**


### PR DESCRIPTION
Holy cow, this is ugly... before you ask: We cannot use `this` before
calling `super` but wrapping it in an arrow function expression is
apparently okay.

Resolves #820