### PR TITLE
Downgrade angularjs-scroll-glue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1672,9 +1672,9 @@
       }
     },
     "angularjs-scroll-glue": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/angularjs-scroll-glue/-/angularjs-scroll-glue-2.2.0.tgz",
-      "integrity": "sha1-B9M5msFsqHTGO2te4u4wVYs35dE="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/angularjs-scroll-glue/-/angularjs-scroll-glue-2.1.0.tgz",
+      "integrity": "sha1-2aXo5QG7XkDL6yXzr2awxhM1wiY="
     },
     "ansi-colors": {
       "version": "3.2.4",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "angular-route": "^1.7.8",
     "angular-sanitize": "^1.7.8",
     "angular-translate": "~2.18",
-    "angularjs-scroll-glue": "~2.2.0",
+    "angularjs-scroll-glue": "=2.1.0",
     "autolinker": "^2.2.2",
     "babel-loader": "^8.0.6",
     "core-js": "^3.1.4",


### PR DESCRIPTION
This was already done in 06f1d5c1e158a50cd41f69cc3ed01e27206fad1b, but I accidentally re-upgraded. Version 2.2.0 causes laggy UI behavior when switching chats.

This time the exact version is pinned, then it should be obvious that there's a reason for that. Unfortunately comments cannot be added to JSON files...

Fixes #870.