### PR TITLE
Invert order of messages in notifications

### DIFF
--- a/src/services/notification.ts
+++ b/src/services/notification.ts
@@ -362,9 +362,9 @@ export class NotificationService {
             this.clearCache(tag);
         }
 
-        // If the cache is not empty, append old messages
+        // If the cache is not empty, prepend old messages
         if (this.notificationCache[tag]) {
-            body += '\n' + this.notificationCache[tag].body;
+            body = `${this.notificationCache[tag].body}\n${body}`;
         }
 
         // Show notification


### PR DESCRIPTION
Previously the latest message was on top. But that resulted in
weird situations when multi-line messages are part of the notification.

With this change, all new messages are appended to the notification, so
you can read them from top to bottom.