### PR TITLE
Handle rejected pushes gracefully

### DIFF
--- a/public/i18n/de.json
+++ b/public/i18n/de.json
@@ -354,6 +354,8 @@
         "WEBCLIENT_DISABLED": "Threema Web wurde auf Ihrem Gerät deaktiviert.",
         "SESSION_REPLACED": "Die Sitzung wurde beendet, weil Sie eine andere Sitzung gestartet haben.",
         "OUT_OF_MEMORY": "Die Sitzung musste beendet werden, da auf dem Gerät nicht genügend Arbeitsspeicher zur Verfügung steht.",
-        "SESSION_ERROR": "Die Sitzung wurde aufgrund eines Protokollfehlers beendet."
+        "SESSION_ERROR": "Die Sitzung wurde aufgrund eines Protokollfehlers beendet.",
+        "PUSH_ERROR_INFO": "Threema Web konnte Ihr Gerät nicht mit einer Push-Benachrichtigung aufwecken. Dies passiert oft beim Wechsel auf ein neues Gerät.",
+        "PUSH_ERROR_ACTION": "Falls der Fehler weiterhin besteht, klicken Sie bitte auf \"Sitzung vergessen\" und erstellen Sie eine neue Sitzung."
     }
 }

--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -355,6 +355,8 @@
         "WEBCLIENT_DISABLED": "Threema Web was disabled on your device.",
         "SESSION_REPLACED": "This session was stopped because you started a Threema Web session in another browser window.",
         "OUT_OF_MEMORY": "The session had to be stopped because your device ran out of memory.",
-        "SESSION_ERROR": "The session was stopped due to a protocol error."
+        "SESSION_ERROR": "The session was stopped due to a protocol error.",
+        "PUSH_ERROR_INFO": "Could not wake up your device with a push notification. This happens for example if you recently switched to a new mobile device.",
+        "PUSH_ERROR_ACTION": "If this error persists, you should click \"Forget Session\" and create a new session."
     }
 }

--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -356,7 +356,7 @@
         "SESSION_REPLACED": "This session was stopped because you started a Threema Web session in another browser window.",
         "OUT_OF_MEMORY": "The session had to be stopped because your device ran out of memory.",
         "SESSION_ERROR": "The session was stopped due to a protocol error.",
-        "PUSH_ERROR_INFO": "Could not wake up your device with a push notification. This happens for example if you recently switched to a new mobile device.",
-        "PUSH_ERROR_ACTION": "If this error persists, you should click \"Forget Session\" and create a new session."
+        "PUSH_ERROR_INFO": "Attempts to wake up your device using push notifications have failed. This can happen, for example, if you have switched to a new mobile device recently.",
+        "PUSH_ERROR_ACTION": "Should this error persist, please click \"Forget Session\" and initiate a new Threema Web session."
     }
 }

--- a/src/exceptions.ts
+++ b/src/exceptions.ts
@@ -18,10 +18,11 @@
 export class TimeoutError extends Error {}
 
 export class PushError extends Error {
-    public readonly responseCode: number;
+    // HTTP response status code returned by push relay server.
+    public readonly statusCode: number;
 
-    public constructor(msg: string, responseCode: number) {
+    public constructor(msg: string, statusCode: number) {
         super(msg);
-        this.responseCode = responseCode;
+        this.statusCode = statusCode;
     }
 }

--- a/src/exceptions.ts
+++ b/src/exceptions.ts
@@ -16,3 +16,12 @@
  */
 
 export class TimeoutError extends Error {}
+
+export class PushError extends Error {
+    public readonly responseCode: number;
+
+    public constructor(msg: string, responseCode: number) {
+        super(msg);
+        this.responseCode = responseCode;
+    }
+}

--- a/src/partials/dialog.push-rejected.html
+++ b/src/partials/dialog.push-rejected.html
@@ -1,0 +1,25 @@
+<md-dialog aria-label="Device Unreachable">
+    <form ng-cloak>
+        <md-toolbar>
+            <div class="md-toolbar-tools">
+                <h2 translate>common.ERROR</h2>
+            </div>
+        </md-toolbar>
+        <md-dialog-content>
+            <div class="md-dialog-content">
+                <p translate>connection.PUSH_ERROR_INFO</p>
+                <p translate>connection.PUSH_ERROR_ACTION</p>
+            </div>
+        </md-dialog-content>
+        <md-dialog-actions layout="row">
+            <span flex></span>
+            <md-button role="button" class="md-primary" ng-click="ctrl.forget()" aria-labelledby="aria-label-forget">
+                <span translate id="aria-label-forget">welcome.FORGET_SESSION_BTN</span>
+            </md-button>
+            <md-button role="button" class="md-primary" ng-click="ctrl.cancel()" aria-labelledby="aria-label-cancel">
+                <span translate id="aria-label-cancel">common.CANCEL</span>
+            </md-button>
+        </md-dialog-actions>
+    </form>
+</md-dialog>
+

--- a/src/partials/dialog.push-rejected.html
+++ b/src/partials/dialog.push-rejected.html
@@ -1,4 +1,4 @@
-<md-dialog aria-label="Device Unreachable">
+<md-dialog>
     <form ng-cloak>
         <md-toolbar>
             <div class="md-toolbar-tools">

--- a/src/partials/dialog.push-rejected.html
+++ b/src/partials/dialog.push-rejected.html
@@ -1,8 +1,8 @@
-<md-dialog>
+<md-dialog aria-labelledby="aria-label-error">
     <form ng-cloak>
         <md-toolbar>
             <div class="md-toolbar-tools">
-                <h2 translate>common.ERROR</h2>
+                <h2 translate id="aria-label-error">common.ERROR</h2>
             </div>
         </md-toolbar>
         <md-dialog-content>

--- a/src/partials/dialog.push-rejected.html
+++ b/src/partials/dialog.push-rejected.html
@@ -1,8 +1,8 @@
-<md-dialog aria-labelledby="aria-label-error">
+<md-dialog translate-attr="{'aria-label': 'common.ERROR'}">
     <form ng-cloak>
         <md-toolbar>
             <div class="md-toolbar-tools">
-                <h2 translate id="aria-label-error">common.ERROR</h2>
+                <h2>common.ERROR</h2>
             </div>
         </md-toolbar>
         <md-dialog-content>

--- a/src/partials/messenger.ts
+++ b/src/partials/messenger.ts
@@ -166,6 +166,40 @@ export class DeviceUnreachableController extends DialogController {
 }
 
 /**
+ * Handle device unreachable
+ */
+export class PushRejectedDialogController extends DialogController {
+    private readonly log: Logger;
+
+    private readonly $window: ng.IWindowService;
+
+    private readonly trustedKeyStore: TrustedKeyStoreService;
+
+    public static readonly $inject = ['$mdDialog', '$window', 'TrustedKeyStore' , 'LogService'];
+    constructor(
+        $mdDialog: ng.material.IDialogService,
+        $window: ng.IWindowService,
+        trustedKeyStore: TrustedKeyStoreService,
+        logService: LogService,
+    ) {
+        super($mdDialog);
+        this.$window = $window;
+        this.log = logService.getLogger('PushRejectedDialog-C');
+        this.trustedKeyStore = trustedKeyStore;
+    }
+
+    /**
+     * Remove the stored session.
+     */
+    public forget(): void {
+        this.log.info('Forgetting stored session');
+        this.trustedKeyStore.clearTrustedKey();
+        this.cancel();
+        this.$window.location.reload();
+    }
+}
+
+/**
  * Handle settings
  */
 class SettingsController extends DialogController {

--- a/src/services/push.ts
+++ b/src/services/push.ts
@@ -17,7 +17,7 @@
 
 import {Logger} from 'ts-log';
 
-import {TimeoutError} from '../exceptions';
+import {PushError, TimeoutError} from '../exceptions';
 import {randomString, sleep} from '../helpers';
 import {sha256} from '../helpers/crypto';
 import {LogService} from './log';
@@ -124,6 +124,7 @@ export class PushSession {
      *
      * @throws TimeoutError in case the maximum amount of retries has been
      *   reached.
+     * @throws PushError if the push was rejected by the push relay server.
      * @throws Error in case of an unrecoverable error which prevents further
      *   pushes.
      */
@@ -215,7 +216,7 @@ export class PushSession {
                     // Client error: Don't retry
                     const error = `Push rejected (client error), status: ${response.status}`;
                     this.log.warn(error);
-                    this.doneFuture.reject(new Error(error));
+                    this.doneFuture.reject(new PushError(error, response.status));
                 } else {
                     // Server error: Retry
                     this.log.warn(`Push rejected (server error), status: ${response.status}`);

--- a/src/services/webclient.ts
+++ b/src/services/webclient.ts
@@ -1175,7 +1175,7 @@ export class WebClientService {
                     // Handle errors
                     if (error instanceof TimeoutError) {
                         this.showDeviceUnreachableDialog();
-                    } else if (error instanceof PushError && error.responseCode === 400) {
+                    } else if (error instanceof PushError && error.statusCode === 400) {
                         // Can happen if the push token is invalid
                         this.showPushRejectedDialog();
                     } else {

--- a/src/services/webclient.ts
+++ b/src/services/webclient.ts
@@ -58,10 +58,10 @@ import {TimeoutService} from './timeout';
 import {TitleService} from './title';
 import {VersionService} from './version';
 
-import {TimeoutError} from '../exceptions';
+import {PushError, TimeoutError} from '../exceptions';
 import {ConfidentialWireMessage} from '../helpers/confidential';
 import {UnboundedFlowControlledDataChannel} from '../helpers/data_channel';
-import {DeviceUnreachableController} from '../partials/messenger';
+import {DeviceUnreachableController, PushRejectedDialogController} from '../partials/messenger';
 import {ChunkCache} from '../protocol/cache';
 import {SequenceNumber} from '../protocol/sequence_number';
 
@@ -1172,9 +1172,12 @@ export class WebClientService {
                     // Reset push session
                     this.resetPushSession(false);
 
-                    // Handle error
+                    // Handle errors
                     if (error instanceof TimeoutError) {
                         this.showDeviceUnreachableDialog();
+                    } else if (error instanceof PushError && error.responseCode === 400) {
+                        // Can happen if the push token is invalid
+                        this.showPushRejectedDialog();
                     } else {
                         this.failSession();
                     }
@@ -1227,6 +1230,16 @@ export class WebClientService {
             })
                 .finally(() => this.deviceUnreachableDialog = null);
         }
+    }
+
+    public showPushRejectedDialog(): void {
+        this.$mdDialog.show({
+            controller: PushRejectedDialogController,
+            controllerAs: 'ctrl',
+            templateUrl: 'partials/dialog.push-rejected.html',
+            parent: angular.element(document.body),
+            escapeToClose: false,
+        });
     }
 
     /**


### PR DESCRIPTION
If a push was rejected with a HTTP 400 response (which can indicate an
expired push token), don't show a protocol error. Instead, offer to
forget & recreate the session.

Before this PR, a protocol error was shown.