### PR TITLE
Disable Grammarly on compose area

### DIFF
--- a/src/directives/compose_area.ts
+++ b/src/directives/compose_area.ts
@@ -724,6 +724,7 @@ export default [
                             id="composeDiv"
                             contenteditable
                             autofocus
+                            data-gramm="false"
                             translate
                             translate-attr-data-placeholder="messenger.COMPOSE_MESSAGE"
                             translate-attr-aria-label="messenger.COMPOSE_MESSAGE"


### PR DESCRIPTION
Generally 3rd party extensions are in the responsibility of the user and
we should not embed vendor-specific attributes into our markup, but
Grammarly has repeatedly been causing problems with Threema Web,
resulting in incomplete/garbled text being sent to contacts.

Furthermore, let's not forget that Grammarly sends your personal Threema
conversations to the cloud for processing, it's thus not much different
from a keylogger. The terms of service even grant Grammarly a full,
perpetual, transferrable and irrevocable license to all your user
content. This clearly contradicts our values regarding user privacy.