### PR TITLE
Fix scroll glue behavior

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -220,32 +220,6 @@ export function isString(val: any): boolean {
 }
 
 /**
- * Throttle function.
- *
- * Taken from https://remysharp.com/2010/07/21/throttling-function-calls
- */
-export function throttle(fn, threshold: number = 250, scope) {
-    let last;
-    let deferTimer;
-    return function() {
-        const context = scope || this;
-        const now = +(new Date());
-        const args = arguments;
-        if (last && now < last + threshold) {
-            // hold on to it
-            clearTimeout(deferTimer);
-            deferTimer = setTimeout(function() {
-                last = now;
-                fn.apply(context, args);
-            }, threshold);
-        } else {
-            last = now;
-            fn.apply(context, args);
-        }
-    };
-}
-
-/**
  * Detect whether browser supports passive event listeners.
  *
  * Taken from https://github.com/WICG/EventListenerOptions/blob/gh-pages/explainer.md

--- a/src/partials/messenger.ts
+++ b/src/partials/messenger.ts
@@ -410,7 +410,7 @@ class ConversationController {
                 $rootScope.$apply(() => {
                     this.updateScrollJump();
                 });
-            }, 100, this), supportsPassive() ? {passive: true} : false);
+            }, 0, this), supportsPassive() ? {passive: true} : false);
         }
 
         // Set receiver, conversation and type
@@ -915,12 +915,12 @@ class ConversationController {
     }
 
     /**
-     * Only show the scroll to bottom button if user scrolled more than 10px
+     * Only show the scroll to bottom button if user scrolled more than 1px
      * away from bottom.
      */
     private updateScrollJump(): void {
         const chat = this.domChatElement;
-        this.showScrollJump = chat.scrollHeight - (chat.scrollTop + chat.offsetHeight) > 10;
+        this.showScrollJump = chat.scrollHeight - (chat.scrollTop + chat.offsetHeight) > 1;
     }
 
     /**

--- a/src/partials/messenger.ts
+++ b/src/partials/messenger.ts
@@ -406,11 +406,11 @@ class ConversationController {
             this.domChatElement = document.querySelector('#conversation-chat') as HTMLElement;
 
             // Add custom event handlers
-            this.domChatElement.addEventListener('scroll', throttle(() => {
+            this.domChatElement.addEventListener('scroll', () => {
                 $rootScope.$apply(() => {
                     this.updateScrollJump();
                 });
-            }, 0, this), supportsPassive() ? {passive: true} : false);
+            }, supportsPassive() ? {passive: true} : false);
         }
 
         // Set receiver, conversation and type

--- a/src/partials/messenger.ts
+++ b/src/partials/messenger.ts
@@ -27,7 +27,7 @@ import {Logger} from 'ts-log';
 import {ContactControllerModel} from '../controller_model/contact';
 import {DialogController} from '../controllers/dialog';
 import {TroubleshootingController} from '../controllers/troubleshooting';
-import {bufferToUrl, hasValue, supportsPassive, throttle, u8aToHex} from '../helpers';
+import {bufferToUrl, hasValue, supportsPassive, u8aToHex} from '../helpers';
 import {emojify} from '../helpers/emoji';
 import {ContactService} from '../services/contact';
 import {ControllerService} from '../services/controller';


### PR DESCRIPTION
The throttleling of the scroll event causes the behavior in issue https://github.com/threema-ch/threema-web/issues/18.
But to be able to detach from bottom-glue without throtteling, updateScrollJump() must already have set showScrollJump to true when there is scrolled more than one pixel.

I guess this solution is not optimal for performance, but I have no problems in my browser. 
It's much better than living with the scroll-glue bug, though.