### PR TITLE
Allow dismissing the "device unreachable" dialog

### DIFF
--- a/public/i18n/de.json
+++ b/public/i18n/de.json
@@ -306,7 +306,8 @@
     },
     "deviceUnreachable": {
         "DEVICE_UNREACHABLE": "Gerät nicht erreichbar",
-        "UNABLE_TO_CONNECT": "Verbindung zum Gerät fehlgeschlagen …"
+        "UNABLE_TO_CONNECT": "Verbindung zum Gerät fehlgeschlagen …",
+        "DISMISS_WARNING": "Um die Verbindung wiederherzustellen, laden Sie bitte Ihr Browser-Fenster neu."
     },
     "version": {
         "NEW_VERSION": "Neue Version Verfügbar",

--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -307,7 +307,8 @@
     },
     "deviceUnreachable": {
         "DEVICE_UNREACHABLE": "Device Unreachable",
-        "UNABLE_TO_CONNECT": "Unable to connect to your device …"
+        "UNABLE_TO_CONNECT": "Unable to connect to your device …",
+        "DISMISS_WARNING": "To re-establish the connection, please reload your browser window."
     },
     "version": {
         "NEW_VERSION": "New Version Available",

--- a/src/partials/dialog.device-unreachable.html
+++ b/src/partials/dialog.device-unreachable.html
@@ -3,6 +3,10 @@
         <md-toolbar>
             <div class="md-toolbar-tools">
                 <h2 translate>deviceUnreachable.DEVICE_UNREACHABLE</h2>
+                <span flex></span>
+                <md-button class="button-small" ng-click="ctrl.closeWithWarning()">
+                    <i class="material-icons">close</i>
+                </md-button>
             </div>
         </md-toolbar>
         <md-dialog-content>

--- a/src/sass/components/_buttons.scss
+++ b/src/sass/components/_buttons.scss
@@ -3,4 +3,8 @@ button {
         margin-bottom: 3px;
         vertical-align: middle;
     }
+
+    &.button-small {
+        min-width: initial;
+    }
 }


### PR DESCRIPTION
This allows accessing and saving a message draft when reconnecting fails
repeatedly.

A warning is shown to the user, indicating that a tab reload is
required.