### PR TITLE
Upgrade autolinker.js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1880,9 +1880,9 @@
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
     },
     "autolinker": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/autolinker/-/autolinker-2.2.2.tgz",
-      "integrity": "sha512-BMKcu6Zey3fqlYj/+DqnbVTLjYZz9jhFq87F8SaD4ebuPM+2nABQUfVYe7aoks5ltWkuYEE61Or63I8KSGZzOw==",
+      "version": "3.11.1",
+      "resolved": "https://registry.npmjs.org/autolinker/-/autolinker-3.11.1.tgz",
+      "integrity": "sha512-6sAmetStorjXvwmV8MBxI5DGICHKD1B5EjdkIrq34X6YBDN6jj54EUHnoHgNqmNCclcf8c409zuVMNy449u80g==",
       "requires": {
         "tslib": "^1.9.3"
       }

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "angular-sanitize": "^1.7.8",
     "angular-translate": "~2.18",
     "angularjs-scroll-glue": "=2.1.0",
-    "autolinker": "^2.2.2",
+    "autolinker": "^3.11.1",
     "babel-loader": "^8.0.6",
     "core-js": "^3.1.4",
     "croppie": "^2.6.4",

--- a/tests/filters.js
+++ b/tests/filters.js
@@ -210,18 +210,21 @@ describe('Filters', function() {
     });
 
     describe('linkify', function() {
+        const autolinker_attributes_url = 'class="autolinked autolinked-url" target="_blank" rel="noopener noreferrer"';
+        const autolinker_attributes_email = 'class="autolinked autolinked-email" target="_blank" rel="noopener noreferrer"';
+
         let process = (text) => {
             return $filter('linkify')(text)
         };
 
         it('links http urls', () => {
             expect(process('hello https://threema.ch/!'))
-                .toEqual('hello <a href="https://threema.ch/" class="autolinked autolinked-url" target="_blank" rel="noopener noreferrer">https://threema.ch/</a>!');
+                .toEqual(`hello <a href="https://threema.ch/" ${autolinker_attributes_url}>https://threema.ch/</a>!`);
         });
 
         it('links e-mails', () => {
             expect(process('hello info@threema.ch!'))
-                .toEqual('hello <a href="mailto:info@threema.ch" class="autolinked autolinked-email" target="_blank" rel="noopener noreferrer">info@threema.ch</a>!');
+                .toEqual(`hello <a href="mailto:info@threema.ch" ${autolinker_attributes_email}>info@threema.ch</a>!`);
         });
 
         it('does not link phone numbers', () => {
@@ -237,6 +240,20 @@ describe('Filters', function() {
         it('does not link hashtags', () => {
             const input = 'hello #threema';
             expect(process(input)).toEqual(input);
+        });
+
+        it('handles square brackets properly', () => {
+            const url = 'https://threema.ch?query=a';
+            expect(process(`[${url}]`))
+                .toEqual(`[<a href="${url}" ${autolinker_attributes_url}>${url}</a>]`);
+        });
+
+        it('handles round parentheses properly', () => {
+            const url = 'https://de.wikipedia.org/wiki/Bundeshaus_(Bern)';
+            expect(process(`${url}`))
+                .toEqual(`<a href="${url}" ${autolinker_attributes_url}>${url}</a>`);
+            expect(process(`(${url})`))
+                .toEqual(`(<a href="${url}" ${autolinker_attributes_url}>${url}</a>)`);
         });
     });
 


### PR DESCRIPTION
The new autolinker version is really nice, it even handled URLs ending with round parentheses, placed inside a pair of parentheses.

GitHub does it correctly too: (https://de.wikipedia.org/wiki/Bundeshaus_(Bern))

Fixes #807.