### PR TITLE
Add length limits to text input fields

### DIFF
--- a/public/i18n/de.json
+++ b/public/i18n/de.json
@@ -248,7 +248,8 @@
             "disabledByPolicy": "Funktion wurde durch den Administrator deaktiviert",
             "syncFailed": "Gruppen-Synchronisation fehlgeschlagen",
             "noMembers": "Keine Mitglieder definiert",
-            "alreadyLeft": "Sie haben diese Gruppe bereits verlassen"
+            "alreadyLeft": "Sie haben diese Gruppe bereits verlassen",
+            "valueTooLong": "Ein eingegebener Wert ist zu lang"
         }
     },
     "error": {

--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -249,7 +249,8 @@
             "disabledByPolicy": "Feature disabled by administrator",
             "syncFailed": "Group synchronization failed",
             "noMembers": "No members defined",
-            "alreadyLeft": "You have already left this group"
+            "alreadyLeft": "You have already left this group",
+            "valueTooLong": "A value you entered is too long"
         }
     },
     "error": {

--- a/src/partials/messenger.receiver/contact.edit.html
+++ b/src/partials/messenger.receiver/contact.edit.html
@@ -15,12 +15,12 @@
 	<md-card-content>
 		<md-input-container class="md-block" ng-if="ctrl.controllerModel.access.canChangeFirstName">
 			<label>{{ctrl.controllerModel.firstNameLabel}}</label>
-			<input ng-disabled="ctrl.isSaving()" ng-model="ctrl.controllerModel.firstName" ng-keypress="ctrl.keypress($event)">
+			<input ng-disabled="ctrl.isSaving()" ng-model="ctrl.controllerModel.firstName" ng-keypress="ctrl.keypress($event)" maxlength="256">
 		</md-input-container>
 
 		<md-input-container class="md-block" ng-if="ctrl.controllerModel.access.canChangeLastName">
 			<label translate>messenger.LAST_NAME</label>
-			<input ng-disabled="ctrl.isSaving()" ng-model="ctrl.controllerModel.lastName" ng-keypress="ctrl.keypress($event)">
+			<input ng-disabled="ctrl.isSaving()" ng-model="ctrl.controllerModel.lastName" ng-keypress="ctrl.keypress($event)" maxlength="256">
 		</md-input-container>
 	</md-card-content>
 </md-card>

--- a/src/partials/messenger.receiver/distributionList.create.html
+++ b/src/partials/messenger.receiver/distributionList.create.html
@@ -12,6 +12,7 @@
                     ng-model="ctrl.controllerModel.name"
                     ng-disabled="ctrl.isSaving()"
                     ng-keypress="ctrl.keypress($event)"
+                    maxlength="256"
                     autofocus>
         </md-input-container>
     </md-card-content>

--- a/src/partials/messenger.receiver/distributionList.edit.html
+++ b/src/partials/messenger.receiver/distributionList.edit.html
@@ -11,7 +11,8 @@
                 translate-attr="{'aria-label': 'messenger.DISTRIBUTION_LIST_NAME'}"
                 ng-model="ctrl.controllerModel.name"
                 ng-disabled="ctrl.isSaving()"
-                ng-keypress="ctrl.keypress($event)">
+                ng-keypress="ctrl.keypress($event)"
+                maxlength="256">
         </md-input-container>
     </md-card-content>
 </md-card>

--- a/src/partials/messenger.receiver/group.create.html
+++ b/src/partials/messenger.receiver/group.create.html
@@ -19,6 +19,7 @@
                     ng-model="ctrl.controllerModel.name"
                     ng-disabled="ctrl.isSaving()"
                     ng-keypress="ctrl.keypress($event)"
+                    maxlength="256"
                     autofocus>
         </md-input-container>
     </md-card-content>

--- a/src/partials/messenger.receiver/group.edit.html
+++ b/src/partials/messenger.receiver/group.edit.html
@@ -21,7 +21,8 @@
                 translate-attr="{'aria-label': 'messenger.GROUP_NAME'}"
                 ng-model="ctrl.controllerModel.name"
                 ng-disabled="ctrl.isSaving()"
-                ng-keypress="ctrl.keypress($event)">
+                ng-keypress="ctrl.keypress($event)"
+                maxlength="256">
         </md-input-container>
     </md-card-content>
 </md-card>

--- a/src/partials/messenger.receiver/me.edit.html
+++ b/src/partials/messenger.receiver/me.edit.html
@@ -12,7 +12,7 @@
     <md-card-content>
         <md-input-container class="md-block">
             <label translate>messenger.MY_PUBLIC_NICKNAME</label>
-            <input ng-disabled="ctrl.isSaving()" ng-model="ctrl.controllerModel.nickname" ng-keypress="ctrl.keypress($event)">
+            <input ng-disabled="ctrl.isSaving()" ng-model="ctrl.controllerModel.nickname" ng-keypress="ctrl.keypress($event)" maxlength="32">
         </md-input-container>
     </md-card-content>
 </md-card>


### PR DESCRIPTION
- Limit nickname to 32 characters
- Limit first name, last name, group name, distribution list name to
  256 characters

In case multi-byte characters are used, the values will be rejected by
the apps with the error `valueTooLong`. I don't think we need to add
special handling / validation for these rare cases.