### PR TITLE
Ignore case when translating shortcodes

### DIFF
--- a/src/helpers/emoji.ts
+++ b/src/helpers/emoji.ts
@@ -3160,9 +3160,14 @@ export function parseEmoji(text: string): Array<threema.EmojiInfo | string> {
 
 /**
  * Translate a shortname to UTF8.
+ *
+ * If the shortname is unknown, `null` will be returned.
+ *
+ * Case will be ignored (the input will be converted to lowercase) until
+ * `ignoreCase` is set to `false`.
  */
-export function shortnameToUtf8(shortname: string): string | null {
-    return SHORTNAMES[shortname] || null;
+export function shortnameToUtf8(shortname: string, ignoreCase: boolean = true): string | null {
+    return SHORTNAMES[ignoreCase ? shortname.toLowerCase() : shortname] || null;
 }
 
 /**

--- a/src/helpers/emoji.ts
+++ b/src/helpers/emoji.ts
@@ -3163,11 +3163,10 @@ export function parseEmoji(text: string): Array<threema.EmojiInfo | string> {
  *
  * If the shortname is unknown, `null` will be returned.
  *
- * Case will be ignored (the input will be converted to lowercase) until
- * `ignoreCase` is set to `false`.
+ * Case will be ignored (the input will be converted to lowercase).
  */
-export function shortnameToUtf8(shortname: string, ignoreCase: boolean = true): string | null {
-    return SHORTNAMES[ignoreCase ? shortname.toLowerCase() : shortname] || null;
+export function shortnameToUtf8(shortname: string): string | null {
+    return SHORTNAMES[shortname.toLowerCase()] || null;
 }
 
 /**

--- a/tests/ts/emoji_helpers.ts
+++ b/tests/ts/emoji_helpers.ts
@@ -133,6 +133,12 @@ describe('Emoji Helpers', () => {
         it('handles multi-codepoint emoji', function() {
             expect(shortnameToUtf8('flag_ch')).toEqual('\ud83c\udde8\ud83c\udded');
         });
+
+        it('ignores case', function() {
+            expect(shortnameToUtf8('Flag_CH')).toEqual('\ud83c\udde8\ud83c\udded');
+            expect(shortnameToUtf8('Flag_CH', true)).toEqual('\ud83c\udde8\ud83c\udded');
+            expect(shortnameToUtf8('Flag_CH', false)).toEqual(null);
+        });
     });
 
     describe('enlargeSingleEmoji', function() {

--- a/tests/ts/emoji_helpers.ts
+++ b/tests/ts/emoji_helpers.ts
@@ -136,8 +136,6 @@ describe('Emoji Helpers', () => {
 
         it('ignores case', function() {
             expect(shortnameToUtf8('Flag_CH')).toEqual('\ud83c\udde8\ud83c\udded');
-            expect(shortnameToUtf8('Flag_CH', true)).toEqual('\ud83c\udde8\ud83c\udded');
-            expect(shortnameToUtf8('Flag_CH', false)).toEqual(null);
         });
     });
 


### PR DESCRIPTION
Low hanging :cherries:, for people who get stuck on the shift key after entering `:`.