### PR TITLE
Reintroduce dual stack TURN servers

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -26,9 +26,9 @@ export default {
     // ICE
     ICE_SERVERS: [{
         urls: [
-            'turn:turn-{prefix}.threema.ch:443?transport=udp',
-            'turn:turn-{prefix}.threema.ch:443?transport=tcp',
-            'turns:turn-{prefix}.threema.ch:443',
+            'turn:ds-turn-{prefix}.threema.ch:443?transport=udp',
+            'turn:ds-turn-{prefix}.threema.ch:443?transport=tcp',
+            'turns:ds-turn-{prefix}.threema.ch:443',
         ],
         username: 'threema-angular',
         credential: 'Uv0LcCq3kyx6EiRwQW5jVigkhzbp70CjN2CJqzmRxG3UGIdJHSJV6tpo7Gj7YnGB',

--- a/troubleshoot/troubleshoot.js
+++ b/troubleshoot/troubleshoot.js
@@ -9,9 +9,9 @@ function createPeerConnection(role) {
 
     // Determine ICE servers
     const iceServers = [
-        'turn:turn-ff.threema.ch:443?transport=udp',
-        'turn:turn-ff.threema.ch:443?transport=tcp',
-        'turns:turn-ff.threema.ch:443',
+        'turn:ds-turn-ff.threema.ch:443?transport=udp',
+        'turn:ds-turn-ff.threema.ch:443?transport=tcp',
+        'turns:ds-turn-ff.threema.ch:443',
     ];
     console.debug('Using ICE servers: ' + iceServers);
     const configuration = {iceServers: [{


### PR DESCRIPTION
Hoping that this will resolve #946. Note that the prefixes are still active and therefore the amount of ICE candidates should still be significantly less than in 2.2.x.