### PR TITLE
Do not fail the session when the data channel has been closed

### DIFF
--- a/src/services/webclient.ts
+++ b/src/services/webclient.ts
@@ -1062,7 +1062,8 @@ export class WebClientService {
 
             // Create data channel
             this.arpLog.debug(`Creating data channel ${WebClientService.DC_LABEL}`);
-            const dc = this.pcHelper.pc.createDataChannel(WebClientService.DC_LABEL);
+            const pc = this.pcHelper.pc;
+            const dc = pc.createDataChannel(WebClientService.DC_LABEL);
             dc.binaryType = 'arraybuffer';
 
             // Wrap as unbounded, flow-controlled data channel
@@ -1085,7 +1086,7 @@ export class WebClientService {
 
                 // Determine chunk length
                 this.secureDataChannelChunkLength = Math.min(
-                    WebClientService.DATA_CHANNEL_MAX_CHUNK_SIZE, this.pcHelper.pc.sctp.maxMessageSize);
+                    WebClientService.DATA_CHANNEL_MAX_CHUNK_SIZE, pc.sctp.maxMessageSize);
                 this.arpLog.debug(`Using chunk length: ${this.secureDataChannelChunkLength} for data channel` +
                     dc.label);
 

--- a/src/services/webclient.ts
+++ b/src/services/webclient.ts
@@ -1096,8 +1096,7 @@ export class WebClientService {
                 });
             };
             dc.onclose = () => {
-                this.arpLog.warn(`Data channel ${dc.label} closed`);
-                this.failSession(false);
+                this.arpLog.warn(`Data channel ${dc.label} closed (ICE state: ${pc.iceConnectionState})`);
             };
             dc.onerror = (event) => {
                 this.arpLog.error(`Data channel ${dc.label} error:`, event);


### PR DESCRIPTION
Rationale for this change is that the data channel should not close prematurely any more since we're correctly managing the underlying buffers. It's not trivial to correctly handle multiple failure events that have the same cause. Thus, we'll just ignore this event for now.