### PR TITLE
Add double asterisk markup parser test

### DIFF
--- a/tests/ts/markup_parser.ts
+++ b/tests/ts/markup_parser.ts
@@ -257,6 +257,7 @@ describe('Markup Parser', () => {
                 ['random *asterisk', 'random *asterisk'],
                 ['***three asterisks', '***three asterisks'],
                 ['***three asterisks*', '**<span class="text-bold">three asterisks</span>'],
+                ['**double asterisks*', '**double asterisks*'],
             ]);
         });
 


### PR DESCRIPTION
Another edge case to ensure that the current behavior stays the same.