### PR TITLE
Show message ID in history dialog

### DIFF
--- a/src/directives/message.ts
+++ b/src/directives/message.ts
@@ -169,11 +169,13 @@ export default [
                     };
 
                     this.showHistory = (ev) => {
-                        const getEvents = () => this.message.events;
+                        const getEvents = () => (this.message as threema.Message).events;
+                        const getMessageId = () => (this.message as threema.Message).id;
                         $mdDialog.show({
                             controllerAs: 'ctrl',
                             controller: function() {
                                 this.getEvents = getEvents;
+                                this.getMessageId = getMessageId;
                                 this.close = () => {
                                     $mdDialog.hide();
                                 };
@@ -187,6 +189,7 @@ export default [
                                             </div>
                                         </md-toolbar>
                                         <md-dialog-content>
+                                            <p><span class="message-id">Message ID:</span> {{ ctrl.getMessageId() }}</p>
                                             <p ng-repeat="event in ctrl.getEvents()">
                                                 <span class="event-type" ng-if="event.type === 'created'" translate>messenger.MSG_HISTORY_CREATED</span>
                                                 <span class="event-type" ng-if="event.type === 'sent'" translate>messenger.MSG_HISTORY_SENT</span>

--- a/src/sass/components/_dialogs.scss
+++ b/src/sass/components/_dialogs.scss
@@ -68,6 +68,10 @@ md-dialog.message-history-dialog {
         padding: 24px;
     }
 
+    .message-id {
+        font-weight: bold;
+    }
+
     .event-type {
         font-weight: bold;
 


### PR DESCRIPTION
Similar to the message IDs in iOS.

Useful mainly for debugging.

![2020-01-30-150959_556x289_scrot](https://user-images.githubusercontent.com/105168/73457335-cbef9e80-4373-11ea-9585-bb7764bb5f71.png)
