### PR TITLE
Don't add null quote objects to outgoing messages

### DIFF
--- a/src/partials/messenger.ts
+++ b/src/partials/messenger.ts
@@ -590,7 +590,7 @@ class ConversationController {
 
     public cancelQuoting(): void {
         // Clear current quote
-        this.webClientService.setQuote(this.receiver);
+        this.webClientService.setQuote(this.receiver, null);
     }
 
     public showError(errorMessage?: string, hideDelayMs = 3000) {
@@ -733,9 +733,12 @@ class ConversationController {
                 case 'text':
                     // do not show confirmation, send directly
                     contents.forEach((msg: threema.MessageData, index: number) => {
-                        msg.quote = this.webClientService.getQuote(this.receiver);
-                        // remove quote
-                        this.webClientService.setQuote(this.receiver);
+                        const quote = this.webClientService.getQuote(this.receiver);
+                        if (hasValue(quote)) {
+                            msg.quote = quote;
+                        }
+                        // Remove quote
+                        this.webClientService.setQuote(this.receiver, null);
                         // send message
                         // TODO: This should probably be moved into the
                         //       WebClientService as a specific method for the

--- a/src/services/webclient.ts
+++ b/src/services/webclient.ts
@@ -2288,14 +2288,14 @@ export class WebClientService {
     /**
      * Return the curring quoted message model
      */
-    public getQuote(receiver: threema.Receiver): threema.Quote {
+    public getQuote(receiver: threema.Receiver): threema.Quote | undefined {
         return this.drafts.getQuote(receiver);
     }
 
     /**
      * Set or remove (if message is null) a quoted message model.
      */
-    public setQuote(receiver: threema.Receiver, message: threema.Message = null): void {
+    public setQuote(receiver: threema.Receiver, message: threema.Message): void {
         // Remove current quote
         this.drafts.removeQuote(receiver);
 

--- a/src/threema/container.ts
+++ b/src/threema/container.ts
@@ -874,7 +874,7 @@ class Drafts implements threema.Container.Drafts {
         this.quotes.delete(this.getReceiverUid(receiver));
     }
 
-    public getQuote(receiver: threema.Receiver): threema.Quote {
+    public getQuote(receiver: threema.Receiver): threema.Quote | undefined {
         return this.quotes.get(this.getReceiverUid(receiver));
     }
 
@@ -886,7 +886,7 @@ class Drafts implements threema.Container.Drafts {
         this.texts.delete(this.getReceiverUid(receiver));
     }
 
-    public getText(receiver: threema.Receiver): string {
+    public getText(receiver: threema.Receiver): string | undefined {
         return this.texts.get(this.getReceiverUid(receiver));
     }
 }


### PR DESCRIPTION
If there is no quote, the `Message` type may not have a `quote` field set to `null`. The field is optional, but not nullable.

https://threema-ch.github.io/app-remote-protocol/model-message.html

This gets rid of the (caught, logged and ignored) exceptions in the Threema for Android app log.