### PR TITLE
Work around event handling changes in Chrome

### DIFF
--- a/src/services/peerconnection.ts
+++ b/src/services/peerconnection.ts
@@ -262,7 +262,7 @@ export class PeerConnectionHelper {
             // Rebind close event
             dc.onclose = () => {
                 if (this.closed) {
-                    self.log.debug('Ignoring signalling data channel closed');
+                    this.log.debug('Ignoring signalling data channel closed');
                 } else {
                     this.log.info(`Signalling data channel closed`);
                     link.closed();

--- a/src/services/webclient.ts
+++ b/src/services/webclient.ts
@@ -1099,8 +1099,7 @@ export class WebClientService {
                 this.arpLog.warn(`Data channel ${dc.label} closed (ICE state: ${pc.iceConnectionState})`);
             };
             dc.onerror = (event) => {
-                this.arpLog.error(`Data channel ${dc.label} error:`, event);
-                this.failSession();
+                this.arpLog.warn(`Data channel ${dc.label} error (closed=${dc.onclose === null}):`, event.error);
             };
             dc.onmessage = (event) => {
                 this.arpLogV.debug(`Data channel ${dc.label} incoming chunk of length ${event.data.byteLength}`);


### PR DESCRIPTION
Chrome now doesn't fire ICE state change events when the peer connection is being
closed by the application (which is probably spec-compliant).
But Chrome now also (always?) fires the 'error' event on the data
channel when it's being closed implicitly by the peer connection (wtf).