### PR TITLE
Only send typing update to contact receivers

### DIFF
--- a/src/partials/messenger.ts
+++ b/src/partials/messenger.ts
@@ -847,7 +847,9 @@ class ConversationController {
      */
     public startTyping = () => {
         // Notify app
-        this.webClientService.sendMeIsTyping(this.$stateParams, true);
+        if (isContactReceiver(this.receiver)) {
+            this.webClientService.sendMeIsTyping(this.receiver, true);
+        }
     }
 
     /**
@@ -855,7 +857,9 @@ class ConversationController {
      */
     public stopTyping = () => {
         // Notify app
-        this.webClientService.sendMeIsTyping(this.$stateParams, false);
+        if (isContactReceiver(this.receiver)) {
+            this.webClientService.sendMeIsTyping(this.receiver, false);
+        }
     }
 
     /**


### PR DESCRIPTION
Due to missing type annotations, we sent typing indicators for groups and distribution lists as well, not just for contacts.

This resulted in a logged exception in the Android code.