### PR TITLE
Password input field: Remove autocomplete=off attribute

### DIFF
--- a/src/partials/welcome.html
+++ b/src/partials/welcome.html
@@ -14,7 +14,7 @@
             <div class="password-entry">
                 <label>
                     <p translate id="aria-label-password-create">welcome.CHOOSE_PASSWORD</p>
-                    <form autocomplete="off">
+                    <form>
                         <md-input-container md-no-float class="md-block">
                             <input type="password"
                                    ng-model="ctrl.password"


### PR DESCRIPTION
It doesn't make sense to specify both "autocomplete=off" and "autocomplete=new-password". (The extended autocomplete fields were added in #441, without removing this attribute.)

Alternatively we keep autocomplete=off, but using a password manager is better than picking a bad password. The user is responsible for using a secure password manager.