### PR TITLE
Catch and log unhandled exceptions

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -187,15 +187,18 @@ angular.module('3ema', [
 
 .factory('$exceptionHandler', ['LogService', function(logService: LogService) {
     const logger = logService.getLogger('UncaughtException');
-    return function myExceptionHandler(exception, cause) {
-        let info = String(exception.stack ? exception.stack : exception);
+    return function myExceptionHandler(exception: Error, cause) {
+        const data: any[] = [];
+        const message = exception.message.includes(exception.name)
+            ? exception.message
+            : `${exception.name}: ${exception.message}`;
+        data.push(`Unhandled exception (ng): ${message}\n`);
+        data.push(exception.stack ? exception.stack : exception);
         if (cause) {
-            info += `\nCaused by:\n${cause}`;
-            if (cause.stack) {
-                info += `\n${cause.stack}`;
-            }
+            data.push('\nCaused by:\n');
+            data.push(cause.stack ? cause.stack : cause);
         }
-        logger.error(info);
+        logger.error(...data);
     };
 }])
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -27,6 +27,7 @@ import './filters';
 import './partials/messenger';
 import './partials/welcome';
 import './services';
+import {LogService} from './services/log';
 import './threema/container';
 
 // Configure asynchronous events
@@ -182,6 +183,20 @@ angular.module('3ema', [
             },
         };
     }]);
+}])
+
+.factory('$exceptionHandler', ['LogService', function(logService: LogService) {
+    const logger = logService.getLogger('UncaughtException');
+    return function myExceptionHandler(exception, cause) {
+        let info = String(exception.stack ? exception.stack : exception);
+        if (cause) {
+            info += `\nCaused by:\n${cause}`;
+            if (cause.stack) {
+                info += `\n${cause.stack}`;
+            }
+        }
+        logger.error(info);
+    };
 }])
 
 ;

--- a/src/services/log.ts
+++ b/src/services/log.ts
@@ -96,9 +96,6 @@ export class LogService {
      * See $exceptionHandler factory in app.ts.
      */
     public setupUncaughtExceptionHandling() {
-        // tslint:disable-next-line:no-console (not using the logger here because it confuses unit tests)
-        console.debug('LogService: Registering uncaught exception handler');
-
         const logger = this.getLogger('UncaughtException');
 
         // Listen for uncaught exceptions

--- a/src/services/log.ts
+++ b/src/services/log.ts
@@ -96,27 +96,31 @@ export class LogService {
      * See $exceptionHandler factory in app.ts.
      */
     public setupUncaughtExceptionHandling() {
-        this.getLogger('Log-S').info('Registering uncaught exception handler');
+        // tslint:disable-next-line:no-console (not using the logger here because it confuses unit tests)
+        console.debug('LogService: Registering uncaught exception handler');
+
         const logger = this.getLogger('UncaughtException');
+
+        // Listen for uncaught exceptions
         window.addEventListener('error', (e: ErrorEvent) => {
-            let info = e.message;
-            if (e.error) {
-                info += e.error.stack ? `\n${e.error.stack}` : `\n${e.error}`;
-            }
-            logger.error(info);
+            const data: any[] = [];
+            data.push(`Unhandled exception (w): ${e.message}\n`);
+            data.push((e.error && e.error.stack) ? e.error.stack : e.error);
+            logger.error(...data);
             e.stopPropagation();
             e.preventDefault();
             return true;
         });
+
+        // Listen for unhandled rejections
         window.addEventListener('unhandledrejection', (e: PromiseRejectionEvent) => {
-            let info = 'Unhandled promise rejection: ';
-            if (e.reason) {
-                info += String(e.reason.stack ? e.reason.stack : e.reason);
-            }
-            logger.error(info);
+            logger.error(
+                'Unhandled promise rejection:',
+                (e.reason && e.reason.stack) ? e.reason.stack : e.reason,
+            )
             e.stopPropagation();
             e.preventDefault();
             return true;
-        })
+        });
     }
 }


### PR DESCRIPTION
This way exceptions also land in the troubleshooting log.

Here's an example of a log with the following cases covered:

- Uncaught exception
- Unhandled promise rejection (with `Error` as reject reason)
- Unhandled promise rejection (with string as reject reason)
- Uncaught exception in a callback (scheduled with `setTimeout`)

![2020-04-02-153357_1823x761_scrot](https://user-images.githubusercontent.com/105168/78255305-69dc2280-74f7-11ea-8f84-8b3b47774e1f.png)

Some of these cases can be handled by registering error handlers on the window object, others are caught by AngularJS and need to be processed using a `$exceptionHandler` factory.