### PR TITLE
Fix typing indicator on focus loss

### DIFF
--- a/src/directives/compose_area.ts
+++ b/src/directives/compose_area.ts
@@ -721,24 +721,25 @@ export default [
 
                 updateView();
 
-                const stopTypingOnBlur = () => stopTyping();
+                // Callbacks to unsubscribe listeners in $destroy
+                const unsubscribeListeners = [];
 
+                // Send "stop typing" message when switching tab or window
+                const stopTypingOnBlur = () => stopTyping();
                 window.addEventListener('blur', stopTypingOnBlur);
+                unsubscribeListeners.push(() => window.removeEventListener('blur', stopTypingOnBlur));
 
                 // Listen to broadcasts
-                const unsubscribeListeners = [];
                 unsubscribeListeners.push($rootScope.$on('onQuoted', (event: ng.IAngularEvent, args: any) => {
-                        composeArea.focus();
-                    }),
-                    () => window.removeEventListener('blur', stopTypingOnBlur)
-                );
+                    composeArea.focus();
+                }));
 
-                // When switching chat, send stopTyping message
+                // When closing the chat view...
                 scope.$on('$destroy', () => {
-                    unsubscribeListeners.forEach((u) => {
-                        // Unsubscribe
-                        u();
-                    });
+                    // ...unsubscribe listeners...
+                    unsubscribeListeners.forEach((u) => u());
+
+                    // ...and send "stop typing" message.
                     stopTyping();
                 });
             },

--- a/src/directives/compose_area.ts
+++ b/src/directives/compose_area.ts
@@ -735,6 +735,9 @@ export default [
                     });
                     stopTyping();
                 });
+
+                // When losing browser or tab focus, send stopTyping message
+                window.onblur = () => stopTyping();
             },
             // tslint:disable:max-line-length
             template: `

--- a/src/directives/compose_area.ts
+++ b/src/directives/compose_area.ts
@@ -721,11 +721,17 @@ export default [
 
                 updateView();
 
+                const stopTypingOnBlur = () => stopTyping();
+
+                window.addEventListener('blur', stopTypingOnBlur);
+
                 // Listen to broadcasts
                 const unsubscribeListeners = [];
                 unsubscribeListeners.push($rootScope.$on('onQuoted', (event: ng.IAngularEvent, args: any) => {
-                    composeArea.focus();
-                }));
+                        composeArea.focus();
+                    }),
+                    () => window.removeEventListener('blur', stopTypingOnBlur)
+                );
 
                 // When switching chat, send stopTyping message
                 scope.$on('$destroy', () => {
@@ -735,9 +741,6 @@ export default [
                     });
                     stopTyping();
                 });
-
-                // When losing browser or tab focus, send stopTyping message
-                window.onblur = () => stopTyping();
             },
             // tslint:disable:max-line-length
             template: `


### PR DESCRIPTION
Sends stopTyping message if window loses focus. Fixes #924.

Running the tests as instructed in the [contribution document](https://github.com/threema-ch/threema-web/blob/master/CONTRIBUTING.md) introduced no new failed tests.