### PR TITLE
Fix logic for determining whether a point in time was yesterday

### DIFF
--- a/src/filters.ts
+++ b/src/filters.ts
@@ -382,7 +382,8 @@ angular.module('3ema.filters', [])
             return formatTime(date);
         }
 
-        const yesterday = new Date(now.getTime() - 1000 * 60 * 60 * 24);
+        const yesterday = new Date(now);
+        yesterday.setDate(now.getDate() - 1);
         if (!forceFull && isSameDay(date, yesterday)) {
             return $translate.instant('date.YESTERDAY') + ', ' + formatTime(date);
         }

--- a/tests/filters.js
+++ b/tests/filters.js
@@ -196,6 +196,18 @@ describe('Filters', function() {
             ]);
         });
 
+        it('shows "yesterday" for yesterday also around DST change', () => {
+            // This test relies on being run in timezone Europe/Zurich
+            // FIXME: Mock timezone, so that test is portable.
+            const beforeDST = new Date(2020, 2, 29, 0, 42);
+            const duringDST = new Date(2020, 2, 30, 0, 23);
+            jasmine.clock().install();
+            jasmine.clock().mockDate(duringDST);
+            this.testPatterns([
+                [beforeDST.getTime() / 1000, 'date.YESTERDAY, 00:42'],
+            ]);
+        });
+
         it('shows full datetime for other days', () => {
             jasmine.clock().install();
             jasmine.clock().mockDate(new Date(2018, 9, 9, 20, 42));

--- a/tests/filters.js
+++ b/tests/filters.js
@@ -196,22 +196,6 @@ describe('Filters', function() {
             ]);
         });
 
-        it('shows "yesterday" for yesterday also around DST change', () => {
-            // This test relies on being run in timezone Europe/Zurich
-            // FIXME: Mock timezone, so that test is portable.
-            const beforeDST1 = new Date(2020, 2, 29, 0, 42);
-            const beforeDST2 = new Date(2020, 2, 29, 12, 42);
-            const beforeDST3 = new Date(2020, 2, 29, 23, 59);
-            const duringDST = new Date(2020, 2, 30, 0, 23);
-            jasmine.clock().install();
-            jasmine.clock().mockDate(duringDST);
-            this.testPatterns([
-                [beforeDST1.getTime() / 1000, 'date.YESTERDAY, 00:42'],
-                [beforeDST2.getTime() / 1000, 'date.YESTERDAY, 12:42'],
-                [beforeDST3.getTime() / 1000, 'date.YESTERDAY, 23:59'],
-            ]);
-        });
-
         it('works across month and year boundaries', () => {
             const in20thCentury1 = new Date(1999, 11, 30, 23, 59);
             const in20thCentury2 = new Date(1999, 11, 31, 00, 00);

--- a/tests/filters.js
+++ b/tests/filters.js
@@ -199,12 +199,16 @@ describe('Filters', function() {
         it('shows "yesterday" for yesterday also around DST change', () => {
             // This test relies on being run in timezone Europe/Zurich
             // FIXME: Mock timezone, so that test is portable.
-            const beforeDST = new Date(2020, 2, 29, 0, 42);
+            const beforeDST1 = new Date(2020, 2, 29, 0, 42);
+            const beforeDST2 = new Date(2020, 2, 29, 12, 42);
+            const beforeDST3 = new Date(2020, 2, 29, 23, 59);
             const duringDST = new Date(2020, 2, 30, 0, 23);
             jasmine.clock().install();
             jasmine.clock().mockDate(duringDST);
             this.testPatterns([
-                [beforeDST.getTime() / 1000, 'date.YESTERDAY, 00:42'],
+                [beforeDST1.getTime() / 1000, 'date.YESTERDAY, 00:42'],
+                [beforeDST2.getTime() / 1000, 'date.YESTERDAY, 12:42'],
+                [beforeDST3.getTime() / 1000, 'date.YESTERDAY, 23:59'],
             ]);
         });
 

--- a/tests/filters.js
+++ b/tests/filters.js
@@ -208,6 +208,18 @@ describe('Filters', function() {
             ]);
         });
 
+        it('works across month and year boundaries', () => {
+            const in20thCentury1 = new Date(1999, 11, 30, 23, 59);
+            const in20thCentury2 = new Date(1999, 11, 31, 00, 00);
+            const in21thCentury = new Date(2000, 0, 1, 12, 34);
+            jasmine.clock().install();
+            jasmine.clock().mockDate(in21thCentury);
+            this.testPatterns([
+                [in20thCentury1.getTime() / 1000, '30. date.month_short.DEC 1999, 23:59'],
+                [in20thCentury2.getTime() / 1000, 'date.YESTERDAY, 00:00'],
+            ]);
+        });
+
         it('shows full datetime for other days', () => {
             jasmine.clock().install();
             jasmine.clock().mockDate(new Date(2018, 9, 9, 20, 42));


### PR DESCRIPTION
Fixes #1013

The previous logic https://github.com/threema-ch/threema-web/blob/39c046ffb5e9d06b1e7cad346df99d1f9766aee6/src/filters.ts#L385 didn't work correctly around leap seconds and DST changes.


For days longer than 24 h (i.e., leap seconds and "fall back" out of DST), this didn't matter, as the lines before it https://github.com/threema-ch/threema-web/blob/39c046ffb5e9d06b1e7cad346df99d1f9766aee6/src/filters.ts#L381-L383 would already have correctly identified any point in time of the same date as being on the same day, even if that point in time was more than 24 h before `now`.

For days shorter than 24 h (i.e., "spring forward" into DST), this however meant they could incorrectly be "skipped" when looking from a point in time on the next day but less than 24 h after the beginning of said shorter day (i.e. between 0:00 AM and 1:00 AM on the day _after_ the shorter day) back to points in time within that shorter day, as demonstrated by the added test: https://github.com/threema-ch/threema-web/blob/a3de76459d1f37b2c03a48d98e0faf1c4e729c5b/tests/filters.js#L199-L213 All 3 assertions fail without the change in `src/filters.ts`, when run in a timezone that switched for standard time to DST on 2020-03-29, such as `Europe/Zurich`. For the test to portably demonstrate the problem, the timezone would have to be mocked, for which jasmine doesn't seem to have native support. I've tried to use the approach from [How to mock your browser’s timezone with Jasmine and MomentJS](https://philippe.bourgau.net/how-to-mock-your-browsers-timezone-with-jasmine-and-momentjs/) in the branch [`mock-timezone`](https://github.com/das-g/threema-web/tree/mock-timezone) ([diff](https://github.com/das-g/threema-web/compare/fix-yesterday...mock-timezone)), but am unsure how to make `moment` available within `tests/filters.js`.

Despite looking funky, the new logic https://github.com/threema-ch/threema-web/blob/a3de76459d1f37b2c03a48d98e0faf1c4e729c5b/src/filters.ts#L385-L386 which takes an approach from [this Stack Overflow answer](https://stackoverflow.com/a/5511376/674064) works also across month and year boundaries, as demonstrated by another test: https://github.com/threema-ch/threema-web/blob/a3de76459d1f37b2c03a48d98e0faf1c4e729c5b/tests/filters.js#L215-L225 According to [a comment on said Stack Overflow answer](https://stackoverflow.com/questions/5511323/calculate-the-date-yesterday-in-javascript#comment34446144_5511376), it does so across multiple browsers.


### To do

Even without the fix, the test to demonstrate this issue passes in timezones that don't switch to DST on on 2020-03-29. Making the test timezone-aware probably requires either to use `moment-timezone` or more elaborate manual mocking. For either I'd need further guidance and/or someone else would have to implement them.