### PR TITLE
Use Ctrl+Enter to submit instead of Shift+Enter

### DIFF
--- a/public/i18n/cs.json
+++ b/public/i18n/cs.json
@@ -312,7 +312,7 @@
         "composearea": {
             "COMPOSE_AREA": "Compose area",
             "SUBMIT_KEY_ENTER": "'Enter' to send a message. 'Shift+Enter' to add a new line.",
-            "SUBMIT_KEY_SHIFT_ENTER": "'Shift+Enter' to send a message. 'Enter' to add a new line."
+            "SUBMIT_KEY_CTRL_ENTER": "'Ctrl/Cmd+Enter' to send a message. 'Enter' to add a new line."
         }
     },
     "deviceUnreachable": {

--- a/public/i18n/de.json
+++ b/public/i18n/de.json
@@ -311,7 +311,7 @@
         "composearea": {
             "COMPOSE_AREA": "Eingabefeld",
             "SUBMIT_KEY_ENTER": "'Enter' um eine Nachricht zu senden. 'Shift+Enter' um eine neue Zeile hinzuzufügen.",
-            "SUBMIT_KEY_SHIFT_ENTER": "'Shift+Enter' um eine Nachricht zu senden. 'Enter' um eine neue Zeile hinzuzufügen."
+            "SUBMIT_KEY_CTRL_ENTER": "'Ctrl/Cmd+Enter' um eine Nachricht zu senden. 'Enter' um eine neue Zeile hinzuzufügen."
         }
     },
     "deviceUnreachable": {

--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -312,7 +312,7 @@
         "composearea": {
             "COMPOSE_AREA": "Compose area",
             "SUBMIT_KEY_ENTER": "'Enter' to send a message. 'Shift+Enter' to add a new line.",
-            "SUBMIT_KEY_SHIFT_ENTER": "'Shift+Enter' to send a message. 'Enter' to add a new line."
+            "SUBMIT_KEY_CTRL_ENTER": "'Ctrl/Cmd+Enter' to send a message. 'Enter' to add a new line."
         }
     },
     "deviceUnreachable": {

--- a/public/i18n/es.json
+++ b/public/i18n/es.json
@@ -312,7 +312,7 @@
         "composearea": {
             "COMPOSE_AREA": "Compose area",
             "SUBMIT_KEY_ENTER": "'Enter' to send a message. 'Shift+Enter' to add a new line.",
-            "SUBMIT_KEY_SHIFT_ENTER": "'Shift+Enter' to send a message. 'Enter' to add a new line."
+            "SUBMIT_KEY_CTRL_ENTER": "'Ctrl/Cmd+Enter' to send a message. 'Enter' to add a new line."
         }
     },
     "deviceUnreachable": {

--- a/public/i18n/fr.json
+++ b/public/i18n/fr.json
@@ -312,7 +312,7 @@
         "composearea": {
             "COMPOSE_AREA": "Compose area",
             "SUBMIT_KEY_ENTER": "'Enter' to send a message. 'Shift+Enter' to add a new line.",
-            "SUBMIT_KEY_SHIFT_ENTER": "'Shift+Enter' to send a message. 'Enter' to add a new line."
+            "SUBMIT_KEY_CTRL_ENTER": "'Ctrl/Cmd+Enter' to send a message. 'Enter' to add a new line."
         }
     },
     "deviceUnreachable": {

--- a/public/i18n/nl.json
+++ b/public/i18n/nl.json
@@ -312,7 +312,7 @@
         "composearea": {
             "COMPOSE_AREA": "Compose area",
             "SUBMIT_KEY_ENTER": "'Enter' to send a message. 'Shift+Enter' to add a new line.",
-            "SUBMIT_KEY_SHIFT_ENTER": "'Shift+Enter' to send a message. 'Enter' to add a new line."
+            "SUBMIT_KEY_CTRL_ENTER": "'Ctrl/Cmd+Enter' to send a message. 'Enter' to add a new line."
         }
     },
     "deviceUnreachable": {

--- a/public/i18n/pl.json
+++ b/public/i18n/pl.json
@@ -312,7 +312,7 @@
         "composearea": {
             "COMPOSE_AREA": "Compose area",
             "SUBMIT_KEY_ENTER": "'Enter' to send a message. 'Shift+Enter' to add a new line.",
-            "SUBMIT_KEY_SHIFT_ENTER": "'Shift+Enter' to send a message. 'Enter' to add a new line."
+            "SUBMIT_KEY_CTRL_ENTER": "'Ctrl/Cmd+Enter' to send a message. 'Enter' to add a new line."
         }
     },
     "deviceUnreachable": {

--- a/public/i18n/sk.json
+++ b/public/i18n/sk.json
@@ -312,7 +312,7 @@
         "composearea": {
             "COMPOSE_AREA": "Compose area",
             "SUBMIT_KEY_ENTER": "'Enter' to send a message. 'Shift+Enter' to add a new line.",
-            "SUBMIT_KEY_SHIFT_ENTER": "'Shift+Enter' to send a message. 'Enter' to add a new line."
+            "SUBMIT_KEY_CTRL_ENTER": "'Ctrl/Cmd+Enter' to send a message. 'Enter' to add a new line."
         }
     },
     "deviceUnreachable": {

--- a/public/i18n/uk.json
+++ b/public/i18n/uk.json
@@ -312,7 +312,7 @@
         "composearea": {
             "COMPOSE_AREA": "Compose area",
             "SUBMIT_KEY_ENTER": "'Enter' to send a message. 'Shift+Enter' to add a new line.",
-            "SUBMIT_KEY_SHIFT_ENTER": "'Shift+Enter' to send a message. 'Enter' to add a new line."
+            "SUBMIT_KEY_CTRL_ENTER": "'Ctrl/Cmd+Enter' to send a message. 'Enter' to add a new line."
         }
     },
     "deviceUnreachable": {

--- a/public/i18n/zh.json
+++ b/public/i18n/zh.json
@@ -312,7 +312,7 @@
         "composearea": {
             "COMPOSE_AREA": "Compose area",
             "SUBMIT_KEY_ENTER": "'Enter' to send a message. 'Shift+Enter' to add a new line.",
-            "SUBMIT_KEY_SHIFT_ENTER": "'Shift+Enter' to send a message. 'Enter' to add a new line."
+            "SUBMIT_KEY_CTRL_ENTER": "'Ctrl/Cmd+Enter' to send a message. 'Enter' to add a new line."
         }
     },
     "deviceUnreachable": {

--- a/src/directives/compose_area.ts
+++ b/src/directives/compose_area.ts
@@ -285,8 +285,8 @@ export default [
                 function onKeyDown(ev: KeyboardEvent): void {
                     let submit = false;
                     switch (submitKey) {
-                        case threema.ComposeAreaSubmitKey.ShiftEnter:
-                            submit = ev.key === 'Enter' && ev.shiftKey;
+                        case threema.ComposeAreaSubmitKey.CtrlEnter:
+                            submit = ev.key === 'Enter' && ev.ctrlKey;
                             break;
                         case threema.ComposeAreaSubmitKey.Enter: // fallthrough
                         default:

--- a/src/partials/dialog.settings.html
+++ b/src/partials/dialog.settings.html
@@ -64,7 +64,7 @@
                                     <span translate>settings.composearea.SUBMIT_KEY_ENTER</span>
                                 </md-radio-button>
                                 <md-radio-button value="1" class="md-primary">
-                                    <span translate>settings.composearea.SUBMIT_KEY_SHIFT_ENTER</span>
+                                    <span translate>settings.composearea.SUBMIT_KEY_CTRL_ENTER</span>
                                 </md-radio-button>
                             </md-radio-group>
                         </md-list-item>

--- a/src/services/settings.ts
+++ b/src/services/settings.ts
@@ -43,7 +43,7 @@ class ComposeAreaSettings {
         }
         switch (submitKey) {
             case threema.ComposeAreaSubmitKey.Enter: // fallthrough
-            case threema.ComposeAreaSubmitKey.ShiftEnter:
+            case threema.ComposeAreaSubmitKey.CtrlEnter:
                 // Valid
                 return submitKey;
             default:

--- a/src/threema.d.ts
+++ b/src/threema.d.ts
@@ -817,7 +817,7 @@ declare namespace threema {
 
     const enum ComposeAreaSubmitKey {
         Enter = 0,
-        ShiftEnter = 1,
+        CtrlEnter = 1,
     }
 
     interface EmojiInfo {


### PR DESCRIPTION
This is a more common key combination.

@jaremforster could you test this on macOS, to verify that the Cmd key is properly recognized both in Safari and a third party browser (e.g. Chrome / Firefox)?