### PR TITLE
Shorten quotes if too long

### DIFF
--- a/src/directives/compose_area.ts
+++ b/src/directives/compose_area.ts
@@ -215,14 +215,17 @@ export default [
                         };
 
                         // Check for max length
+                        //
+                        // Note: Messages that use the entire available message size become a
+                        // problem when being quoted, since the quote also becomes part of the
+                        // message. As a workaround, until a better quote system is implemented,
+                        // reduce the max length and the chunk size to counter this. (If the
+                        // message text + quote text are too long, then the quote will be shortened
+                        // in WebClientService.)
                         const byteLength = (new TextEncoder().encode(text)).length;
-                        if (byteLength > scope.maxTextLength) {
-                            // Messages that use the entire available message size become a problem
-                            // when being quoted, since the quote also becomes part of the message.
-                            // As a workaround, until a better quote system is implemented, reduce
-                            // the chunk size so that reaching the limit becomes more unlikely.
+                        const reducedMaxLength = scope.maxTextLength - 30;
+                        if (byteLength > reducedMaxLength) {
                             const chunkSize = scope.maxTextLength * 0.85;
-
                             const pieces: string[] = stringService.byteChunk(text, chunkSize, 50);
 
                             const confirm = $mdDialog.confirm()

--- a/src/partials/messenger.ts
+++ b/src/partials/messenger.ts
@@ -739,13 +739,14 @@ class ConversationController {
                 case 'text':
                     // do not show confirmation, send directly
                     contents.forEach((msg: threema.MessageData, index: number) => {
+                        // Move quote from receiver to message
                         const quote = this.webClientService.getQuote(this.receiver);
                         if (hasValue(quote)) {
                             msg.quote = quote;
                         }
-                        // Remove quote
                         this.webClientService.setQuote(this.receiver, null);
-                        // send message
+
+                        // Send message
                         // TODO: This should probably be moved into the
                         //       WebClientService as a specific method for the
                         //       type.

--- a/src/services/webclient.ts
+++ b/src/services/webclient.ts
@@ -2324,6 +2324,9 @@ export class WebClientService {
                     identity: message.isOutbox ? this.me.id : message.partnerId,
                     text: quoteText,
                 } as threema.Quote;
+                if (message.id != null && message.id.length > 0) {
+                    quote.messageId = message.id;
+                }
 
                 this.drafts.setQuote(receiver, quote);
                 this.$rootScope.$broadcast('onQuoted', {

--- a/src/threema.d.ts
+++ b/src/threema.d.ts
@@ -498,6 +498,7 @@ declare namespace threema {
     interface Quote {
         identity: string;
         text: string;
+        messageId?: string;
     }
 
     interface PushSessionConfig {


### PR DESCRIPTION
Long messages that exceed the max message size are split into multiple messages. This works nicely, but breaks if a quote is involved, since the quote size and its markup overhead is not considered. If a long message is quoted with a long reply, data loss can occur.

To counter this, shorten the quote if it's too long.

The implementation is a bit hacky, and quote v2 messages would be much nicer, but that requires support from both Android and iOS apps as well. So for now, this should help.