### PR TITLE
Fix key combination for submitting messages

### DIFF
--- a/public/i18n/cs.json
+++ b/public/i18n/cs.json
@@ -312,7 +312,7 @@
         "composearea": {
             "COMPOSE_AREA": "Compose area",
             "SUBMIT_KEY_ENTER": "'Enter' to send a message. 'Shift+Enter' to add a new line.",
-            "SUBMIT_KEY_CTRL_ENTER": "'Ctrl/Cmd+Enter' to send a message. 'Enter' to add a new line."
+            "SUBMIT_KEY_CTRL_ENTER": "'Ctrl+Enter' to send a message. 'Enter' to add a new line."
         }
     },
     "deviceUnreachable": {

--- a/public/i18n/de.json
+++ b/public/i18n/de.json
@@ -311,7 +311,7 @@
         "composearea": {
             "COMPOSE_AREA": "Eingabefeld",
             "SUBMIT_KEY_ENTER": "'Enter' um eine Nachricht zu senden. 'Shift+Enter' um eine neue Zeile hinzuzufügen.",
-            "SUBMIT_KEY_CTRL_ENTER": "'Ctrl/Cmd+Enter' um eine Nachricht zu senden. 'Enter' um eine neue Zeile hinzuzufügen."
+            "SUBMIT_KEY_CTRL_ENTER": "'Ctrl+Enter' um eine Nachricht zu senden. 'Enter' um eine neue Zeile hinzuzufügen."
         }
     },
     "deviceUnreachable": {

--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -312,7 +312,7 @@
         "composearea": {
             "COMPOSE_AREA": "Compose area",
             "SUBMIT_KEY_ENTER": "'Enter' to send a message. 'Shift+Enter' to add a new line.",
-            "SUBMIT_KEY_CTRL_ENTER": "'Ctrl/Cmd+Enter' to send a message. 'Enter' to add a new line."
+            "SUBMIT_KEY_CTRL_ENTER": "'Ctrl+Enter' to send a message. 'Enter' to add a new line."
         }
     },
     "deviceUnreachable": {

--- a/public/i18n/eo.json
+++ b/public/i18n/eo.json
@@ -312,7 +312,7 @@
         "composearea": {
             "COMPOSE_AREA": "Compose area",
             "SUBMIT_KEY_ENTER": "'Enter' to send a message. 'Shift+Enter' to add a new line.",
-            "SUBMIT_KEY_CTRL_ENTER": "'Ctrl/Cmd+Enter' to send a message. 'Enter' to add a new line."
+            "SUBMIT_KEY_CTRL_ENTER": "'Ctrl+Enter' to send a message. 'Enter' to add a new line."
         }
     },
     "deviceUnreachable": {

--- a/public/i18n/es.json
+++ b/public/i18n/es.json
@@ -312,7 +312,7 @@
         "composearea": {
             "COMPOSE_AREA": "Compose area",
             "SUBMIT_KEY_ENTER": "'Enter' to send a message. 'Shift+Enter' to add a new line.",
-            "SUBMIT_KEY_CTRL_ENTER": "'Ctrl/Cmd+Enter' to send a message. 'Enter' to add a new line."
+            "SUBMIT_KEY_CTRL_ENTER": "'Ctrl+Enter' to send a message. 'Enter' to add a new line."
         }
     },
     "deviceUnreachable": {

--- a/public/i18n/fr.json
+++ b/public/i18n/fr.json
@@ -312,7 +312,7 @@
         "composearea": {
             "COMPOSE_AREA": "Compose area",
             "SUBMIT_KEY_ENTER": "'Enter' to send a message. 'Shift+Enter' to add a new line.",
-            "SUBMIT_KEY_CTRL_ENTER": "'Ctrl/Cmd+Enter' to send a message. 'Enter' to add a new line."
+            "SUBMIT_KEY_CTRL_ENTER": "'Ctrl+Enter' to send a message. 'Enter' to add a new line."
         }
     },
     "deviceUnreachable": {

--- a/public/i18n/hu.json
+++ b/public/i18n/hu.json
@@ -312,7 +312,7 @@
         "composearea": {
             "COMPOSE_AREA": "Compose area",
             "SUBMIT_KEY_ENTER": "'Enter' to send a message. 'Shift+Enter' to add a new line.",
-            "SUBMIT_KEY_CTRL_ENTER": "'Ctrl/Cmd+Enter' to send a message. 'Enter' to add a new line."
+            "SUBMIT_KEY_CTRL_ENTER": "'Ctrl+Enter' to send a message. 'Enter' to add a new line."
         }
     },
     "deviceUnreachable": {

--- a/public/i18n/nl.json
+++ b/public/i18n/nl.json
@@ -312,7 +312,7 @@
         "composearea": {
             "COMPOSE_AREA": "Compose area",
             "SUBMIT_KEY_ENTER": "'Enter' to send a message. 'Shift+Enter' to add a new line.",
-            "SUBMIT_KEY_CTRL_ENTER": "'Ctrl/Cmd+Enter' to send a message. 'Enter' to add a new line."
+            "SUBMIT_KEY_CTRL_ENTER": "'Ctrl+Enter' to send a message. 'Enter' to add a new line."
         }
     },
     "deviceUnreachable": {

--- a/public/i18n/pl.json
+++ b/public/i18n/pl.json
@@ -312,7 +312,7 @@
         "composearea": {
             "COMPOSE_AREA": "Compose area",
             "SUBMIT_KEY_ENTER": "'Enter' to send a message. 'Shift+Enter' to add a new line.",
-            "SUBMIT_KEY_CTRL_ENTER": "'Ctrl/Cmd+Enter' to send a message. 'Enter' to add a new line."
+            "SUBMIT_KEY_CTRL_ENTER": "'Ctrl+Enter' to send a message. 'Enter' to add a new line."
         }
     },
     "deviceUnreachable": {

--- a/public/i18n/ru.json
+++ b/public/i18n/ru.json
@@ -312,7 +312,7 @@
         "composearea": {
             "COMPOSE_AREA": "Compose area",
             "SUBMIT_KEY_ENTER": "'Enter' to send a message. 'Shift+Enter' to add a new line.",
-            "SUBMIT_KEY_CTRL_ENTER": "'Ctrl/Cmd+Enter' to send a message. 'Enter' to add a new line."
+            "SUBMIT_KEY_CTRL_ENTER": "'Ctrl+Enter' to send a message. 'Enter' to add a new line."
         }
     },
     "deviceUnreachable": {

--- a/public/i18n/sk.json
+++ b/public/i18n/sk.json
@@ -312,7 +312,7 @@
         "composearea": {
             "COMPOSE_AREA": "Compose area",
             "SUBMIT_KEY_ENTER": "'Enter' to send a message. 'Shift+Enter' to add a new line.",
-            "SUBMIT_KEY_CTRL_ENTER": "'Ctrl/Cmd+Enter' to send a message. 'Enter' to add a new line."
+            "SUBMIT_KEY_CTRL_ENTER": "'Ctrl+Enter' to send a message. 'Enter' to add a new line."
         }
     },
     "deviceUnreachable": {

--- a/public/i18n/tr.json
+++ b/public/i18n/tr.json
@@ -312,7 +312,7 @@
         "composearea": {
             "COMPOSE_AREA": "Compose area",
             "SUBMIT_KEY_ENTER": "'Enter' to send a message. 'Shift+Enter' to add a new line.",
-            "SUBMIT_KEY_CTRL_ENTER": "'Ctrl/Cmd+Enter' to send a message. 'Enter' to add a new line."
+            "SUBMIT_KEY_CTRL_ENTER": "'Ctrl+Enter' to send a message. 'Enter' to add a new line."
         }
     },
     "deviceUnreachable": {

--- a/public/i18n/uk.json
+++ b/public/i18n/uk.json
@@ -312,7 +312,7 @@
         "composearea": {
             "COMPOSE_AREA": "Compose area",
             "SUBMIT_KEY_ENTER": "'Enter' to send a message. 'Shift+Enter' to add a new line.",
-            "SUBMIT_KEY_CTRL_ENTER": "'Ctrl/Cmd+Enter' to send a message. 'Enter' to add a new line."
+            "SUBMIT_KEY_CTRL_ENTER": "'Ctrl+Enter' to send a message. 'Enter' to add a new line."
         }
     },
     "deviceUnreachable": {

--- a/public/i18n/zh.json
+++ b/public/i18n/zh.json
@@ -312,7 +312,7 @@
         "composearea": {
             "COMPOSE_AREA": "Compose area",
             "SUBMIT_KEY_ENTER": "'Enter' to send a message. 'Shift+Enter' to add a new line.",
-            "SUBMIT_KEY_CTRL_ENTER": "'Ctrl/Cmd+Enter' to send a message. 'Enter' to add a new line."
+            "SUBMIT_KEY_CTRL_ENTER": "'Ctrl+Enter' to send a message. 'Enter' to add a new line."
         }
     },
     "deviceUnreachable": {


### PR DESCRIPTION
On macOS, Ctrl+Enter should be used, not Cmd+Enter.