### PR TITLE
Allow easily clearing search box

### DIFF
--- a/src/partials/messenger.navigation.html
+++ b/src/partials/messenger.navigation.html
@@ -64,7 +64,7 @@
         </md-button>
     </div>
     <div class="search" searchbox searchbox-focus="ctrl.searchVisible">
-        <input type="text" ng-model="ctrl.searchText" translate translate-attr-placeholder="messenger.SEARCH" aria-label="Search" translate-attr-aria-label="messenger.SEARCH">
+        <input type="search" ng-model="ctrl.searchText" translate translate-attr-placeholder="messenger.SEARCH" aria-label="Search" translate-attr-aria-label="messenger.SEARCH" ng-keyup="ctrl.clearSearch($event)">
     </div>
 </div>
 
@@ -81,6 +81,7 @@
             ng-if="ctrl.isVisible(conversation)">
 
             <div class="conversation"
+                  ng-click="ctrl.toggleSearchOff()"
                   ng-class="{'unread': conversation.unreadCount > 0,
                             'starred': conversation.isStarred,
                             'active': ctrl.isActive(conversation)}">
@@ -126,7 +127,8 @@
 <div id="navigation-contacts" class="tab-content" ng-if="ctrl.activeTab == 'contacts'" in-view-container>
     <p class="empty" ng-if="ctrl.contacts().length === 0" translate>messenger.NO_CONTACTS_FOUND</p>
     <ul ng-class="{'hide-inactive': ctrl.hideInactiveContacts()}">
-        <li ng-repeat="contact in ctrl.contacts() | filter:ctrl.searchContact"
+        <li ng-click="ctrl.toggleSearchOff()"
+            ng-repeat="contact in ctrl.contacts() | filter:ctrl.searchContact"
             ui-sref="messenger.home.conversation({ type: 'contact', id: contact.id, initParams: null })"
             class="contact"
             ng-class="{'inactive': contact.state == 'INACTIVE'}">

--- a/src/partials/messenger.navigation.html
+++ b/src/partials/messenger.navigation.html
@@ -64,7 +64,7 @@
         </md-button>
     </div>
     <div class="search" searchbox searchbox-focus="ctrl.searchVisible">
-        <input type="search" ng-model="ctrl.searchText" translate translate-attr-placeholder="messenger.SEARCH" aria-label="Search" translate-attr-aria-label="messenger.SEARCH" ng-keyup="ctrl.clearSearch($event)">
+        <input type="search" ng-model="ctrl.searchText" translate translate-attr-placeholder="messenger.SEARCH" aria-label="Search" translate-attr-aria-label="messenger.SEARCH" ng-keydown="ctrl.clearSearch($event)">
     </div>
 </div>
 

--- a/src/partials/messenger.ts
+++ b/src/partials/messenger.ts
@@ -1268,6 +1268,21 @@ class NavigationController {
     }
 
     /**
+     * Toggle search bar off.
+     */
+    public toggleSearchOff(): void {
+        if (this.searchVisible) this.searchVisible = false;
+    }
+
+    /**
+     * Clear search when pressing ESC.
+     */
+    public clearSearch(ev): void {
+        if (ev.keyCode === 27) this.searchText = '';
+    }
+
+
+    /**
      * Return the user profile.
      */
     public getMe(): threema.MeReceiver {

--- a/src/partials/messenger.ts
+++ b/src/partials/messenger.ts
@@ -1281,7 +1281,11 @@ class NavigationController {
      */
     public clearSearch(ev): void {
         if (ev.key === 'Escape') {
-            this.searchText = '';
+            if (this.searchText === '') {
+                this.searchVisible = false;
+            } else {
+                this.searchText = '';
+            }
         }
     }
 

--- a/src/partials/messenger.ts
+++ b/src/partials/messenger.ts
@@ -1280,7 +1280,9 @@ class NavigationController {
      * Clear search when pressing ESC.
      */
     public clearSearch(ev): void {
-        if (ev.keyCode === 27) this.searchText = '';
+        if (ev.key === 'Escape') {
+            this.searchText = '';
+        }
     }
 
 

--- a/src/partials/messenger.ts
+++ b/src/partials/messenger.ts
@@ -1271,7 +1271,9 @@ class NavigationController {
      * Toggle search bar off.
      */
     public toggleSearchOff(): void {
-        if (this.searchVisible) this.searchVisible = false;
+        if (this.searchVisible) {
+            this.searchVisible = false;
+        }
     }
 
     /**

--- a/src/sass/sections/_navigation.scss
+++ b/src/sass/sections/_navigation.scss
@@ -68,7 +68,7 @@
         max-height: 0;
 
         input {
-            &[type='text'] {
+            &[type='search'] {
                 margin: 0;
                 border: 1px solid #dddddd;
                 border-radius: $material-radius;
@@ -89,6 +89,12 @@
 
             // Animation when appearing
             max-height: 50px;
+
+            // sass-lint:disable no-vendor-prefixes
+            ::-webkit-search-cancel-button {
+                -webkit-appearance: searchfield-cancel-button;
+            }
+            // sass-lint:enable no-vendor-prefixes
         }
     }
 }


### PR DESCRIPTION
Fix related to "add X to clear search bar", issue #92 

- Clear search bar with ESC or X (X only works in Chrome)
- Hide search bar when conversation or contact is clicked