### PR TITLE
Revert clearing of search when clicking on conversation / contact

### DIFF
--- a/src/partials/messenger.navigation.html
+++ b/src/partials/messenger.navigation.html
@@ -87,7 +87,6 @@
             ng-if="ctrl.isVisible(conversation)">
 
             <div class="conversation"
-                  ng-click="ctrl.toggleSearchOff()"
                   ng-class="{'unread': conversation.unreadCount > 0,
                             'starred': conversation.isStarred,
                             'active': ctrl.isActive(conversation)}">
@@ -133,8 +132,7 @@
 <div id="navigation-contacts" class="tab-content" ng-if="ctrl.activeTab == 'contacts'" in-view-container>
     <p class="empty" ng-if="ctrl.contacts().length === 0" translate>messenger.NO_CONTACTS_FOUND</p>
     <ul ng-class="{'hide-inactive': ctrl.hideInactiveContacts()}">
-        <li ng-click="ctrl.toggleSearchOff()"
-            ng-repeat="contact in ctrl.contacts() | filter:ctrl.searchContact"
+        <li ng-repeat="contact in ctrl.contacts() | filter:ctrl.searchContact"
             ui-sref="messenger.home.conversation({ type: 'contact', id: contact.id, initParams: null })"
             class="contact"
             ng-class="{'inactive': contact.state == 'INACTIVE'}">


### PR DESCRIPTION
It seems that when searching through a lot of conversations (I have over
230 conversations), after clicking on a conversation, the search clears
almost instantly, but it sometimes takes multiple seconds until the
conversation has opened.

This has a lot to do with the inefficient architecture of AngularJS,
where every UI update can trigger a lot of processing code, which in
turn may cause yet another UI update.

For now, we need to disable the clearing/hiding of the search when
clicking on a search result.

Refs #1026.