### PR TITLE
Don't show a warning for Firefox on iOS

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -76,6 +76,7 @@ angular.module('3ema', [
 // Constants to be used by controllers
 .constant('BROWSER_MIN_VERSIONS', {
     FF: 60,
+    FF_IOS: 8,
     CHROME: 65,
     OPERA: 52,
     SAFARI: 11,

--- a/src/partials/welcome.ts
+++ b/src/partials/welcome.ts
@@ -137,6 +137,11 @@ class WelcomeController {
                 this.log.warn('Firefox is too old (' + version + ' < ' + minVersions.FF + ')');
                 this.showBrowserWarning();
             }
+        } else if (this.browser.name === threema.BrowserName.FirefoxIos) {
+            if (version < minVersions.FF_IOS) {
+                this.log.warn('Firefox on iOS is too old (WebKit ' + version + ' < ' + minVersions.FF_IOS + ')');
+                this.showBrowserWarning();
+            }
         } else if (this.browser.name === threema.BrowserName.Opera) {
             if (version < minVersions.OPERA) {
                 this.log.warn('Opera is too old (' + version + ' < ' + minVersions.OPERA + ')');

--- a/src/threema.d.ts
+++ b/src/threema.d.ts
@@ -697,6 +697,7 @@ declare namespace threema {
 
     interface BrowserMinVersions {
         FF: number;
+        FF_IOS: number;
         CHROME: number;
         OPERA: number;
         SAFARI: number;

--- a/tests/service/browser.js
+++ b/tests/service/browser.js
@@ -35,7 +35,7 @@ describe('BrowserService', function() {
         expect(browser.description()).toEqual('Firefox 59');
     });
 
-    it('firefoxIosMobile', () => {
+    it('firefoxIosMobile8', () => {
         const ua = 'Mozilla/5.0 (iPad; CPU OS 10_0_1 like Mac OS X) AppleWebKit/602.1.50 (KHTML, like Gecko) FxiOS/8.3b5826 Mobile/14A403 Safari/602.1.50';
         const service = testUserAgent(ua);
         const browser = service.getBrowser();
@@ -43,6 +43,16 @@ describe('BrowserService', function() {
         expect(browser.version).toEqual(8);
         expect(browser.mobile).toBe(true);
         expect(browser.description()).toEqual('Firefox (iOS) 8 [Mobile]');
+    });
+
+    it('firefoxIosMobile33', () => {
+        const ua = 'Mozilla/5.0 (iPhone; CPU OS 14_4_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) FxiOS/33.0  Mobile/15E148 Safari/605.1.15';
+        const service = testUserAgent(ua);
+        const browser = service.getBrowser();
+        expect(browser.name).toBe(BrowserName.FirefoxIos);
+        expect(browser.version).toEqual(33);
+        expect(browser.mobile).toBe(true);
+        expect(browser.description()).toEqual('Firefox (iOS) 33 [Mobile]');
     });
 
     it('chrome', () => {


### PR DESCRIPTION
Firefox on iOS is the same as Safari, so we don't show a warning (unless an Android device is connecting).

See https://github.com/webcompat/web-bugs/issues/69278 for context.