### PR TITLE
Enforce default value of isUnread flag

### DIFF
--- a/src/threema/container.ts
+++ b/src/threema/container.ts
@@ -291,6 +291,7 @@ export class Conversations implements threema.Container.Conversations {
                 delete conversation.position;
             }
             setDefault(conversation, 'isStarred', false);
+            setDefault(conversation, 'isUnread', false);
         }
         this.conversations = data;
     }
@@ -339,6 +340,7 @@ export class Conversations implements threema.Container.Conversations {
 
                 // Explicitly set defaults, to be able to override old values
                 setDefault(conversation, 'isStarred', false);
+                setDefault(conversation, 'isUnread', false);
 
                 // Copy properties from new conversation to old conversation
                 Object.assign(this.conversations[i], conversation);

--- a/tests/ts/containers.ts
+++ b/tests/ts/containers.ts
@@ -36,6 +36,7 @@ function makeContactConversation(id: string, position?: number): threema.Convers
         messageCount: 5,
         unreadCount: 0,
         isStarred: false,
+        isUnread: false,
     };
 }
 


### PR DESCRIPTION
Otherwise the flag isn't cleared properly when a conversation is updated.