### PR TITLE
Ensure that update/activeConversation triggers a wakeup push

### DIFF
--- a/src/services/webclient.ts
+++ b/src/services/webclient.ts
@@ -1982,7 +1982,7 @@ export class WebClientService {
      */
     public sendActiveConversation(conversation: threema.Conversation): void {
         // noinspection JSIgnoredPromiseFromCall
-        this.sendUpdateWireMessage(WebClientService.SUB_TYPE_ACTIVE_CONVERSATION, false, {
+        this.sendUpdateWireMessage(WebClientService.SUB_TYPE_ACTIVE_CONVERSATION, true, {
             [WebClientService.ARGUMENT_RECEIVER_TYPE]: conversation.type,
             [WebClientService.ARGUMENT_RECEIVER_ID]: conversation.id,
         }, undefined);


### PR DESCRIPTION
Otherwise iOS devices are not woken up with the `activeConversation` message.