### PR TITLE
Fix creation of new conversations

### DIFF
--- a/src/partials/messenger.ts
+++ b/src/partials/messenger.ts
@@ -524,8 +524,10 @@ class ConversationController {
                     },
                 );
 
-                // Notify app about conversation opening
-                this.webClientService.sendActiveConversation(this.conversation);
+                // Notify app about conversation opening (if a conversation already exists)
+                if (this.conversation !== null) {
+                    this.webClientService.sendActiveConversation(this.conversation);
+                }
 
                 // Update "first unread" divider
                 this.webClientService.messages.updateFirstUnreadMessage(this.receiver);
@@ -567,7 +569,7 @@ class ConversationController {
                 }
             }
         } catch (error) {
-            this.log.error('Could not set receiver and type');
+            this.log.error('Could not set receiver and type:', error);
             $state.go('messenger.home');
         }
 


### PR DESCRIPTION
Only send the "active conversation" message for existing conversations.
Otherwise the conversation reference is null and causes a TypeError.

This fixes a regression introduced in #1050.