### PR TITLE
Prevent drafts from being associated with the wrong conversation

### DIFF
--- a/src/threema.d.ts
+++ b/src/threema.d.ts
@@ -220,6 +220,8 @@ declare namespace threema {
 
     /**
      * The base class for a receiver. Only type and id.
+     *
+     * Note: The id alone is not guaranteed to be unique, always compare both type and ID!
      */
     interface BaseReceiver {
         id: string;

--- a/src/threema/container.ts
+++ b/src/threema/container.ts
@@ -833,7 +833,7 @@ class Typing implements threema.Container.Typing {
     private set = new StringHashSet();
 
     private getReceiverUid(receiver: threema.BaseReceiver): string {
-        return receiver.type + '-' + receiver.id;
+        return `${receiver.type}-${receiver.id}`;
     }
 
     public setTyping(receiver: threema.BaseReceiver): void {
@@ -860,12 +860,10 @@ class Drafts implements threema.Container.Drafts {
 
     private quotes = new Map<string, threema.Quote>();
 
-    // Use to implement draft texts!
     private texts = new Map<string, string>();
 
     private getReceiverUid(receiver: threema.Receiver): string {
-        // do not use receiver.type => can be null
-        return receiver.id;
+        return `${receiver.type}-${receiver.id}`;
     }
 
     public setQuote(receiver: threema.Receiver, quote: threema.Quote): void {


### PR DESCRIPTION
The receiver ID is not unique!

Fixes #1037.