### PR TITLE
Do not show caption input field when sending multiple files

### DIFF
--- a/public/i18n/de.json
+++ b/public/i18n/de.json
@@ -153,6 +153,7 @@
         "MSG_HISTORY_MODIFIED": "Geändert",
         "NAVIGATE": "Navigieren",
         "CONFIRM_FILE_SEND": "Senden an «{senderName}»?",
+        "CONFIRM_FILE_SEND_MULTI": "{fileCount} Dateien an «{senderName}» senden?",
         "CONFIRM_FILE_CAPTION": "Optionale Beschriftung",
         "CONFIRM_SEND_AS_FILE": "Als Datei senden",
         "CONFIRM_DELETE_TITLE": "Nachricht Löschen",

--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -153,6 +153,7 @@
         "MSG_HISTORY_MODIFIED": "Modified",
         "NAVIGATE": "Navigate",
         "CONFIRM_FILE_SEND": "Send to «{senderName}»?",
+        "CONFIRM_FILE_SEND_MULTI": "Send {fileCount} files to «{senderName}»?",
         "CONFIRM_FILE_CAPTION": "Optional caption",
         "CONFIRM_SEND_AS_FILE": "Send as file message",
         "CONFIRM_DELETE_TITLE": "Delete Message",


### PR DESCRIPTION
It is not obvious what this does. Will it add the caption to the first file? To the last file? To all of them?

It's better to remove the input field.

Additionally, show the number of files being sent in the dialog title.

Single image:

![1-single-image](https://user-images.githubusercontent.com/78751145/126298268-582d7223-4ecd-49dd-9734-59202c9a5ccb.png)

Single file:

![2-single-file](https://user-images.githubusercontent.com/78751145/126298290-f360a687-f040-4e03-a92e-34952911a656.png)

Two files:

![3-two-files](https://user-images.githubusercontent.com/78751145/126298312-c7c1f427-e416-4ba3-b679-eecf0ee123cc.png)

Two images:

![4-two-images](https://user-images.githubusercontent.com/78751145/126298336-2f267e57-0341-4442-a29a-78a242094bfb.png)

Mixed files/images:

![5-mixed](https://user-images.githubusercontent.com/78751145/126298353-411020f8-a5bd-4d6e-a8e7-59fb6ca52b7c.png)