### PR TITLE
Fix version info dialog in minimal UI variant

### DIFF
--- a/src/controllers/footer.ts
+++ b/src/controllers/footer.ts
@@ -20,7 +20,10 @@ import {ThemeService} from '../services/theme';
 import {DialogController} from './dialog';
 import {TroubleshootingController} from './troubleshooting';
 
-class VersionDialogController extends DialogController {
+/**
+ * Controller for the version info dialog.
+ */
+export class VersionDialogController extends DialogController {
     public readonly version: string;
     public readonly fullVersion: string;
 

--- a/src/partials/messenger.ts
+++ b/src/partials/messenger.ts
@@ -26,6 +26,7 @@ import {Logger} from 'ts-log';
 
 import {ContactControllerModel} from '../controller_model/contact';
 import {DialogController} from '../controllers/dialog';
+import {VersionDialogController} from '../controllers/footer';
 import {TroubleshootingController} from '../controllers/troubleshooting';
 import {bufferToUrl, hasValue, supportsPassive, u8aToHex} from '../helpers';
 import {emojify} from '../helpers/emoji';
@@ -1015,21 +1016,6 @@ class ConversationController {
 }
 
 class AboutDialogController extends DialogController {
-    public readonly config: threema.Config;
-
-    public static readonly $inject = ['$scope', '$mdDialog', 'ThemeService', 'CONFIG'];
-    constructor(
-        $scope: ng.IScope,
-        $mdDialog: ng.material.IDialogService,
-        themeService: ThemeService,
-        config: threema.Config,
-    ) {
-        super($scope, $mdDialog, themeService);
-        this.config = config;
-    }
-}
-
-class VersionDialogController extends DialogController {
     public readonly config: threema.Config;
 
     public static readonly $inject = ['$scope', '$mdDialog', 'ThemeService', 'CONFIG'];


### PR DESCRIPTION
Fixes the version display when invoking the version info dialog from the menu, and not from the footer.

Fixes #1038.