### PR TITLE
Fix copy-paste XSS in debug log visualizing tool

### DIFF
--- a/troubleshoot/log.js
+++ b/troubleshoot/log.js
@@ -45,18 +45,18 @@ function formatRecordValue(value) {
     }
 
     // Handle boolean
-    if (value.constructor === Boolean) {
+    if (typeof value === 'boolean') {
         return `<span class="boolean">${escapeHTML(value)}</span>`;
     }
 
     // Handle number
-    if (value.constructor === Number) {
+    if (typeof value === 'number' || typeof value === 'bigint') {
         return `<span class="number">${escapeHTML(value)}</span>`;
     }
 
     // Handle string, converted types (e.g. ArrayBuffer, Blob, ...)
     // and errors (exceptions).
-    if (value.constructor === String) {
+    if (typeof value === 'string') {
         if (value.startsWith('[') && value.endsWith(']')) {
             return `<span class="converted">${escapeHTML(value)}</span>`;
         }
@@ -64,20 +64,6 @@ function formatRecordValue(value) {
             return `<span class="error">${escapeHTML(value)}</span>`;
         }
         return `<span class="string">${escapeHTML(value)}</span>`;
-    }
-
-    // Handle object
-    if (value.constructor === Object) {
-        const entries = Object.entries(value);
-        return `
-            <details>
-                <summary class="type">Object(${entries.length})</summary>
-                <ul>
-                    ${entries.map(([key, value]) => {
-                        return `<li><span class="type">${escapeHTML(key)}:</span> ${formatRecordValue(value)}</li>`;
-                    }).join('\n')}
-                </ul>
-            </details>`;
     }
 
     // Handle array
@@ -93,8 +79,23 @@ function formatRecordValue(value) {
             </details>`;
     }
 
+
+    // Handle object
+    if (typeof value === 'object') {
+        const entries = Object.entries(value);
+        return `
+            <details>
+                <summary class="type">Object(${entries.length})</summary>
+                <ul>
+                    ${entries.map(([key, value]) => {
+                        return `<li><span class="type">${escapeHTML(key)}:</span> ${formatRecordValue(value)}</li>`;
+                    }).join('\n')}
+                </ul>
+            </details>`;
+    }
+
     // Unknown
-    return `[${value.constructor}]`;
+    return `[${escapeHTML(value.constructor)}]`;
 }
 
 /**


### PR DESCRIPTION
For visualizing debug logs that users send us via the troubleshooting
dialog, we have a little web UI at `troubleshoot/log.html`. This tool
was vulnerable to copy-paste XSS. For this vulnerability to be
triggered, a specially crafted payload needed to be pasted into the
website by the victim without having strict CSP security headers set up
on the web server.

All official Threema Web instances have set up strict CSP rules and are
not exploitable. Only the local dev server or third-party deployments
without proper CSP rules are potentially exploitable.

Additionally, since this is a diagnostic tool aimed at the developers of
Threema Web, regular users of Threema Web are not affected by this
vulnerability.

This issue was discovered by GitHub Security Lab team member @erik-krogh
using the CodeQL query contributed by @bananabr. Thank you for the
report! The Security Lab reference is GHSL-2021-1004.