### PR TITLE
Show the complete public key

### DIFF
--- a/src/services/fingerprint.ts
+++ b/src/services/fingerprint.ts
@@ -22,7 +22,7 @@ export class FingerPrintService {
         if (publicKey !== undefined && publicKey.byteLength === 32) {
             const sha256PublicKey = await sha256(publicKey);
             if (sha256PublicKey !== undefined) {
-                return sha256PublicKey.toLowerCase().substr(0, 32);
+                return sha256PublicKey.toLowerCase();
             }
         }
         return 'undefined/failed';


### PR DESCRIPTION
Instead of showing only the first 32 chars of the public key, the complete public key should be displayed.