### PR TITLE
Replace 128-bit fingerprint with 256-bit public key

### DIFF
--- a/public/i18n/bg.json
+++ b/public/i18n/bg.json
@@ -132,7 +132,6 @@
         "MEMBER_OF_GROUPS": "Член на тези групи",
         "MEMBER_OF_DISTRIBUTION_LISTS": "Член на тези Списъци",
         "GROUP_MEMBERS": "Членове на групата",
-        "KEY_FINGERPRINT": "Ключов Пръстов Отпечатък",
         "GROUP_NAME": "Име на групата",
         "GROUP_CREATOR": "Създател на група",
         "GROUP_ROLE_NORMAL": "Член",

--- a/public/i18n/cs.json
+++ b/public/i18n/cs.json
@@ -133,7 +133,6 @@
         "MEMBER_OF_GROUPS": "Člen následujících skupin",
         "MEMBER_OF_DISTRIBUTION_LISTS": "Člen uvedených seznamů",
         "GROUP_MEMBERS": "Členové skupiny",
-        "KEY_FINGERPRINT": "Otisk klíče",
         "GROUP_NAME": "Jméno skupiny",
         "GROUP_CREATOR": "Správce skupiny",
         "GROUP_ROLE_NORMAL": "Člen",

--- a/public/i18n/de.json
+++ b/public/i18n/de.json
@@ -135,7 +135,6 @@
         "MEMBER_OF_GROUPS": "Mitglied in diesen Gruppen",
         "MEMBER_OF_DISTRIBUTION_LISTS": "Mitglied in diesen Verteilerlisten",
         "GROUP_MEMBERS": "Gruppenmitglieder",
-        "KEY_FINGERPRINT": "Schl\u00fcssel-Fingerabdruck",
         "GROUP_NAME": "Gruppenname",
         "GROUP_CREATOR": "Ersteller",
         "GROUP_ROLE_NORMAL": "Mitglied",

--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -135,7 +135,7 @@
         "MEMBER_OF_GROUPS": "Member of these groups",
         "MEMBER_OF_DISTRIBUTION_LISTS": "Member of these Lists",
         "GROUP_MEMBERS": "Group members",
-        "KEY_FINGERPRINT": "Key Fingerprint",
+        "PUBLIC_KEY": "Public Key",
         "GROUP_NAME": "Group name",
         "GROUP_CREATOR": "Group creator",
         "GROUP_ROLE_NORMAL": "Member",

--- a/public/i18n/eo.json
+++ b/public/i18n/eo.json
@@ -132,7 +132,6 @@
         "MEMBER_OF_GROUPS": "Member of these groups",
         "MEMBER_OF_DISTRIBUTION_LISTS": "Member of these Lists",
         "GROUP_MEMBERS": "Group members",
-        "KEY_FINGERPRINT": "Key Fingerprint",
         "GROUP_NAME": "Group name",
         "GROUP_CREATOR": "Group creator",
         "GROUP_ROLE_NORMAL": "Member",

--- a/public/i18n/es.json
+++ b/public/i18n/es.json
@@ -132,7 +132,6 @@
         "MEMBER_OF_GROUPS": "Miembro de estos grupos",
         "MEMBER_OF_DISTRIBUTION_LISTS": "Miembro de estas listas",
         "GROUP_MEMBERS": "Miembros del grupo",
-        "KEY_FINGERPRINT": "Huella dactilar",
         "GROUP_NAME": "Nombre del grupo",
         "GROUP_CREATOR": "Creador de grupo",
         "GROUP_ROLE_NORMAL": "Miembro",

--- a/public/i18n/fr.json
+++ b/public/i18n/fr.json
@@ -133,7 +133,6 @@
         "MEMBER_OF_GROUPS": "Les membres de ces groupes",
         "MEMBER_OF_DISTRIBUTION_LISTS": "Les membres de ces listes",
         "GROUP_MEMBERS": "Membres du groupe",
-        "KEY_FINGERPRINT": "Empreinte de clé",
         "GROUP_NAME": "Nom du groupe",
         "GROUP_CREATOR": "Créateur du groupe",
         "GROUP_ROLE_NORMAL": "Membres",

--- a/public/i18n/hu.json
+++ b/public/i18n/hu.json
@@ -132,7 +132,6 @@
         "MEMBER_OF_GROUPS": "Az alábbi csoportok tagja",
         "MEMBER_OF_DISTRIBUTION_LISTS": "A lista tagjai",
         "GROUP_MEMBERS": "Csoporttagok",
-        "KEY_FINGERPRINT": "Kulcs ujjlenyomata",
         "GROUP_NAME": "Csoport neve",
         "GROUP_CREATOR": "Csoport létrehozója",
         "GROUP_ROLE_NORMAL": "Tag",

--- a/public/i18n/ja.json
+++ b/public/i18n/ja.json
@@ -133,7 +133,6 @@
         "MEMBER_OF_GROUPS": "グループのメンバー",
         "MEMBER_OF_DISTRIBUTION_LISTS": "リストのメンバー",
         "GROUP_MEMBERS": "グループのメンバー",
-        "KEY_FINGERPRINT": "鍵のフィンガープリント",
         "GROUP_NAME": "グループの名前",
         "GROUP_CREATOR": "グループ作成者",
         "GROUP_ROLE_NORMAL": "メンバー",

--- a/public/i18n/ko.json
+++ b/public/i18n/ko.json
@@ -133,7 +133,6 @@
         "MEMBER_OF_GROUPS": "이 그룹의 멤버",
         "MEMBER_OF_DISTRIBUTION_LISTS": "이 목록의 멤버",
         "GROUP_MEMBERS": "그룹 멤버들",
-        "KEY_FINGERPRINT": "지문 인식",
         "GROUP_NAME": "그룹명",
         "GROUP_CREATOR": "그룹 만든 사람",
         "GROUP_ROLE_NORMAL": "멤버",

--- a/public/i18n/nl.json
+++ b/public/i18n/nl.json
@@ -135,7 +135,6 @@
         "MEMBER_OF_GROUPS": "Lid van deze groepen",
         "MEMBER_OF_DISTRIBUTION_LISTS": "Lid van deze lijsten",
         "GROUP_MEMBERS": "Groepsleden",
-        "KEY_FINGERPRINT": "Sleutel-vingerafdruk",
         "GROUP_NAME": "Groepsnaam",
         "GROUP_CREATOR": "Groepsmaker",
         "GROUP_ROLE_NORMAL": "Lid",

--- a/public/i18n/pl.json
+++ b/public/i18n/pl.json
@@ -133,7 +133,6 @@
         "MEMBER_OF_GROUPS": "Członek tych grup",
         "MEMBER_OF_DISTRIBUTION_LISTS": "Członek tych list",
         "GROUP_MEMBERS": "Członkowie grupy",
-        "KEY_FINGERPRINT": "Odcisk palca",
         "GROUP_NAME": "Nazwa grupy",
         "GROUP_CREATOR": "Twórca grupy",
         "GROUP_ROLE_NORMAL": "Członek",

--- a/public/i18n/pt.json
+++ b/public/i18n/pt.json
@@ -118,7 +118,6 @@
         "MEMBER_OF_GROUPS": "Membro destes grupos",
         "MEMBER_OF_DISTRIBUTION_LISTS": "Membro dessas Listas",
         "GROUP_MEMBERS": "Membros do grupo",
-        "KEY_FINGERPRINT": "Key Fingerprint",
         "GROUP_NAME": "Nome do grupo",
         "GROUP_CREATOR": "Criador do grupo",
         "GROUP_ROLE_NORMAL": "Membro",

--- a/public/i18n/ro.json
+++ b/public/i18n/ro.json
@@ -132,7 +132,6 @@
         "MEMBER_OF_GROUPS": "Membru a acestor grupuri",
         "MEMBER_OF_DISTRIBUTION_LISTS": "Membru a aceste liste",
         "GROUP_MEMBERS": "Membri grupului",
-        "KEY_FINGERPRINT": "Amprenta",
         "GROUP_NAME": "Numele grupului",
         "GROUP_CREATOR": "Creatorului grupului",
         "GROUP_ROLE_NORMAL": "Membru",

--- a/public/i18n/ru.json
+++ b/public/i18n/ru.json
@@ -133,7 +133,6 @@
         "MEMBER_OF_GROUPS": "Участник этих групп",
         "MEMBER_OF_DISTRIBUTION_LISTS": "Участник этих списков",
         "GROUP_MEMBERS": "Участники группы",
-        "KEY_FINGERPRINT": "Отпечаток ключа",
         "GROUP_NAME": "Название группы",
         "GROUP_CREATOR": "Создатель группы",
         "GROUP_ROLE_NORMAL": "Участник",

--- a/public/i18n/sk.json
+++ b/public/i18n/sk.json
@@ -132,7 +132,6 @@
         "MEMBER_OF_GROUPS": "Členovia týchto skupín",
         "MEMBER_OF_DISTRIBUTION_LISTS": "Člen týchto zoznamov",
         "GROUP_MEMBERS": "Členovia skupiny",
-        "KEY_FINGERPRINT": "Otlačok kľúča",
         "GROUP_NAME": "Názov skupiny",
         "GROUP_CREATOR": "Tvorca skupiny",
         "GROUP_ROLE_NORMAL": "Člen",

--- a/public/i18n/tr.json
+++ b/public/i18n/tr.json
@@ -133,7 +133,6 @@
         "MEMBER_OF_GROUPS": "Bu grubun üyeleri",
         "MEMBER_OF_DISTRIBUTION_LISTS": "Bu listenin üyeleri",
         "GROUP_MEMBERS": "Grup üyeleri",
-        "KEY_FINGERPRINT": "Parmak izi anahtarı",
         "GROUP_NAME": "Grup adı",
         "GROUP_CREATOR": "Grup kurucusu",
         "GROUP_ROLE_NORMAL": "Üye",

--- a/public/i18n/uk.json
+++ b/public/i18n/uk.json
@@ -132,7 +132,6 @@
         "MEMBER_OF_GROUPS": "Учасник цих груп",
         "MEMBER_OF_DISTRIBUTION_LISTS": "Учасник цих списків",
         "GROUP_MEMBERS": "Учасники групи",
-        "KEY_FINGERPRINT": "Відбиток пальця",
         "GROUP_NAME": "Назва групи",
         "GROUP_CREATOR": "Творець групи",
         "GROUP_ROLE_NORMAL": "Учасник",

--- a/public/i18n/zh.json
+++ b/public/i18n/zh.json
@@ -133,7 +133,6 @@
         "MEMBER_OF_GROUPS": "是这些群组的群员",
         "MEMBER_OF_DISTRIBUTION_LISTS": "是这些列表的成员",
         "GROUP_MEMBERS": "群组成员",
-        "KEY_FINGERPRINT": "指纹",
         "GROUP_NAME": "群组名称",
         "GROUP_CREATOR": "群组创建人",
         "GROUP_ROLE_NORMAL": "成员",

--- a/public/i18n/zh_TW.json
+++ b/public/i18n/zh_TW.json
@@ -133,7 +133,6 @@
         "MEMBER_OF_GROUPS": "是這些群組的成員",
         "MEMBER_OF_DISTRIBUTION_LISTS": "是這些通訊群組清單的成員",
         "GROUP_MEMBERS": "群組成員",
-        "KEY_FINGERPRINT": "密鑰指紋",
         "GROUP_NAME": "群組名稱",
         "GROUP_CREATOR": "群組建立者",
         "GROUP_ROLE_NORMAL": "成員",

--- a/src/helpers/public_key.ts
+++ b/src/helpers/public_key.ts
@@ -15,16 +15,29 @@
  * along with Threema Web. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import {sha256} from '../helpers/crypto';
+import {u8aToHex} from '../helpers';
 
-export class FingerPrintService {
-    public async generate(publicKey: ArrayBuffer): Promise<string> {
-        if (publicKey !== undefined && publicKey.byteLength === 32) {
-            const sha256PublicKey = await sha256(publicKey);
-            if (sha256PublicKey !== undefined) {
-                return sha256PublicKey.toLowerCase().substr(0, 32);
-            }
+/**
+ * Visualize a 32 bit public key in an 8x8 hex grid.
+ *
+ * Return a string containing newlines.
+ */
+export function publicKeyGrid(publicKey: Uint8Array): string {
+    const hex = u8aToHex(publicKey);
+    let grid = '';
+    for (let i = 0; i < hex.length; i++) {
+        // Prepend a newline if end of row is reached
+        if (i % 8 === 0 && i > 0 && i < 63) {
+            grid += '\n';
         }
-        return 'undefined/failed';
+
+        // Prepend a space if this isn't the first char of a row
+        if (i % 8 > 0) {
+            grid += ' ';
+        }
+
+        // Add hex character
+        grid += hex[i];
     }
+    return grid;
 }

--- a/src/partials/messenger.receiver/contact.html
+++ b/src/partials/messenger.receiver/contact.html
@@ -26,9 +26,6 @@
 					</span>
 				</dd>
 
-				<dt><span translate>messenger.KEY_FINGERPRINT</span></dt>
-				<dd>{{ ctrl.fingerPrint.value || "Loading..." }}</dd>
-
 				<dt><span translate>messenger.NICKNAME</span></dt>
 				<dd ng-if="ctrl.receiver.publicNickname" ng-bind-html="ctrl.receiver.publicNickname | emojify"></dd>
 				<dd ng-if="!ctrl.receiver.publicNickname">-</dd>
@@ -38,6 +35,10 @@
 
 				<dt><span translate>messenger.LAST_NAME</span></dt>
 				<dd>{{ ctrl.receiver.lastName || "-" }}</dd>
+
+				<dt><span translate>messenger.PUBLIC_KEY</span></dt>
+                <dd><pre><code>{{ ctrl.publicKeyGrid }}</code></pre></dd>
+
 			</dl>
 		</md-card-content>
 	</md-card>

--- a/src/partials/messenger.receiver/me.html
+++ b/src/partials/messenger.receiver/me.html
@@ -13,11 +13,12 @@
 							contact="ctrl.receiver">
 					</eee-verification-level></dd>
 
-				<dt><span translate>messenger.KEY_FINGERPRINT</span></dt>
-				<dd>{{ ctrl.fingerPrint.value || "Loading..." }}</dd>
-
 				<dt><span translate>messenger.MY_PUBLIC_NICKNAME</span></dt>
 				<dd>{{ ctrl.controllerModel.nickname || "-" }}</dd>
+
+				<dt><span translate>messenger.PUBLIC_KEY</span></dt>
+                <dd><pre><code>{{ ctrl.publicKeyGrid }}</code></pre></dd>
+
 			</dl>
 		</md-card-content>
 	</md-card>

--- a/src/sass/base/_typography.scss
+++ b/src/sass/base/_typography.scss
@@ -39,3 +39,7 @@ strong {
 .text-strike {
     text-decoration: line-through;
 }
+
+code {
+    font-family: monospace;
+}

--- a/src/services.ts
+++ b/src/services.ts
@@ -20,7 +20,6 @@ import {BrowserService} from './services/browser';
 import {ContactService} from './services/contact';
 import {ControllerService} from './services/controller';
 import {ControllerModelService} from './services/controller_model';
-import {FingerPrintService} from './services/fingerprint';
 import {TrustedKeyStoreService} from './services/keystore';
 import {LogService} from './services/log';
 import {MediaboxService} from './services/mediabox';
@@ -48,7 +47,6 @@ angular.module('3ema.services', [])
 .service('BatteryStatusService', BatteryStatusService)
 .service('ContactService', ContactService)
 .service('ControllerModelService', ControllerModelService)
-.service('FingerPrintService', FingerPrintService)
 .service('MessageService', MessageService)
 .service('NotificationService', NotificationService)
 .service('PushService', PushService)

--- a/tests/ts/public_key_helpers.ts
+++ b/tests/ts/public_key_helpers.ts
@@ -17,15 +17,25 @@
  * along with Threema Web. If not, see <http://www.gnu.org/licenses/>.
  */
 
-// tslint:disable:no-reference
-/// <reference path="../../src/threema.d.ts" />
+import {publicKeyGrid} from '../../src/helpers/public_key';
 
-import './confidential_helpers';
-import './containers';
-import './crypto_helpers';
-import './emoji_helpers';
-import './helpers';
-import './logger_helpers';
-import './password_strength_helpers';
-import './public_key_helpers';
-import './receiver_helpers';
+describe('PublicKey Helpers', () => {
+    it('publicKeyGrid', function() {
+        const arr = Uint8Array.of(
+            0, 1, 2, 3, 4, 5, 6, 7,
+            8, 9, 10, 11, 12, 13, 14, 15,
+            16, 17, 18, 19, 20, 21, 22, 23,
+            248, 249, 250, 251, 252, 253, 254, 255,
+        );
+        expect(publicKeyGrid(arr)).toEqual(
+            '0 0 0 1 0 2 0 3\n' +
+            '0 4 0 5 0 6 0 7\n' +
+            '0 8 0 9 0 a 0 b\n' +
+            '0 c 0 d 0 e 0 f\n' +
+            '1 0 1 1 1 2 1 3\n' +
+            '1 4 1 5 1 6 1 7\n' +
+            'f 8 f 9 f a f b\n' +
+            'f c f d f e f f'
+        );
+    });
+});


### PR DESCRIPTION
Display the public key in a 8x8 grid, so that it's easier to read and compare.

![image](https://user-images.githubusercontent.com/78751145/141644483-da140199-78bf-4c23-9c5e-8b062b27c886.png)

The font isn't too nice (it's the system's default monospace font), but we don't currently ship a monospace webfont and I don't think it's worth it to add one just for the public key.