### PR TITLE
Reset unread count only when necessary

### DIFF
--- a/src/services/state.ts
+++ b/src/services/state.ts
@@ -266,7 +266,7 @@ export class StateService {
     /**
      * Reset all states.
      */
-    public reset(connectionBuildupState: threema.ConnectionBuildupState = 'new', shouldResetUnreadCount : boolean = false): void {
+    public reset(connectionBuildupState: threema.ConnectionBuildupState = 'new', shouldResetUnreadCount : boolean = true): void {
         this.log.debug('Reset states');
 
         // Reset state

--- a/src/services/state.ts
+++ b/src/services/state.ts
@@ -266,7 +266,7 @@ export class StateService {
     /**
      * Reset all states.
      */
-    public reset(connectionBuildupState: threema.ConnectionBuildupState = 'new'): void {
+    public reset(connectionBuildupState: threema.ConnectionBuildupState = 'new', shouldResetUnreadCount : boolean = false): void {
         this.log.debug('Reset states');
 
         // Reset state
@@ -276,6 +276,10 @@ export class StateService {
         this.state = GlobalConnectionState.Error;
         this.connectionBuildupState = connectionBuildupState;
         this.progress = 0;
-        this.unreadCount = 0;
+
+        // iOS devices are regularly disconnected, but this is normal behavior.
+        if (shouldResetUnreadCount) {
+          this.unreadCount = 0;
+        }
     }
 }

--- a/src/services/state.ts
+++ b/src/services/state.ts
@@ -277,7 +277,6 @@ export class StateService {
         this.connectionBuildupState = connectionBuildupState;
         this.progress = 0;
 
-        // iOS devices are regularly disconnected, but this is normal behavior.
         if (shouldResetUnreadCount) {
           this.unreadCount = 0;
         }

--- a/src/services/webclient.ts
+++ b/src/services/webclient.ts
@@ -1347,10 +1347,8 @@ export class WebClientService {
         this.log.debug('Timer stopped');
 
         // Reset states
-        this.stateService.reset(args.connectionBuildupState);
-
-        // Reset the unread count
-        this.resetUnreadCount();
+        const shouldResetUnreadCount = this.chosenTask !== threema.ChosenTask.RelayedData || close
+        this.stateService.reset(args.connectionBuildupState, shouldResetUnreadCount);
 
         // Clear stored data (trusted key, push token, etc) if deleting the session
         if (remove) {
@@ -4271,13 +4269,6 @@ export class WebClientService {
             .get()
             .reduce((a: number, b: threema.Conversation) => a + b.unreadCount, 0);
         this.stateService.unreadCount = totalUnreadCount;
-    }
-
-    /**
-     * Reset the unread count in the window title
-     */
-    private resetUnreadCount(): void {
-        this.stateService.unreadCount = 0;
     }
 
     /**

--- a/src/services/webclient.ts
+++ b/src/services/webclient.ts
@@ -1347,6 +1347,9 @@ export class WebClientService {
         this.log.debug('Timer stopped');
 
         // Reset states
+        // iOS devices are regularly disconnected, but this is normal behavior.
+        // We therefore only reset the unread count if we are not using relayedData or are
+        // closing the connection.
         const shouldResetUnreadCount = this.chosenTask !== threema.ChosenTask.RelayedData || close
         this.stateService.reset(args.connectionBuildupState, shouldResetUnreadCount);
 


### PR DESCRIPTION
iOS devices are regularly disconnected, but this is normal behavior. We therefore only want to reset the unread count if the device the connection is closed for good.