### PR TITLE
Fix logic error in marking messages as read

### DIFF
--- a/src/partials/messenger.ts
+++ b/src/partials/messenger.ts
@@ -930,24 +930,22 @@ class ConversationController {
             return;
         }
 
+        // Ignore our own outgoing messages (those are alway read)
+        if (message.isOutbox) {
+            return;
+        }
+
+        // Ignore messages that are not unread
+        if (!message.unread) {
+            return;
+        }
+
         // Update lastReadMsg
         if (this.lastReadMsg === null || message.sortKey >= this.lastReadMsg.sortKey) {
             this.lastReadMsg = message;
         }
 
         if (!this.msgReadReportPending) {
-            // Don't send a read message for messages that are already read.
-            // (Note: Ignore own messages since those are always read.)
-            if (!message.isOutbox && !message.unread) {
-                return;
-            }
-
-            // Don't send a read message for conversations that have no unread messages.
-            const conversation = this.webClientService.conversations.find(this.receiver);
-            if (conversation !== null && conversation.unreadCount === 0) {
-                return;
-            }
-
             this.msgReadReportPending = true;
             const receiver = angular.copy(this.receiver);
             receiver.type = this.type;


### PR DESCRIPTION
In some  cases, a read receipt could be triggered for an outgoing
message. This wasn't an issue on Android, but on iOS this caused the
previous messages not to be marked as unread.

This commit refactors and simplifies the logic. Now read receipt should
only be sent for incoming unread non-status messages.