### PR TITLE
Add workaround for Firefox non-standard PDF download behavior

### DIFF
--- a/src/directives/mediabox.ts
+++ b/src/directives/mediabox.ts
@@ -17,7 +17,7 @@
 
 import {saveAs} from 'file-saver';
 
-import {bufferToUrl} from '../helpers';
+import {bufferToUrl, firefoxWorkaroundPdfDownload} from '../helpers';
 import {LogService} from '../services/log';
 import {MediaboxService} from '../services/mediabox';
 
@@ -56,7 +56,7 @@ export default [
                 this.save = () => {
                     saveAs(
                         new Blob([mediaboxService.data], {
-                            type: mediaboxService.mimetype,
+                            type: firefoxWorkaroundPdfDownload(mediaboxService.mimetype),
                         }),
                         mediaboxService.filename || 'image.jpg'
                     );

--- a/src/directives/message.ts
+++ b/src/directives/message.ts
@@ -19,8 +19,8 @@
 
 import {saveAs} from 'file-saver';
 
+import {firefoxWorkaroundPdfDownload} from '../helpers';
 import * as clipboard from '../helpers/clipboard';
-
 import {BrowserInfo} from '../helpers/browser_info';
 import {getSenderIdentity} from '../helpers/messages';
 import {BrowserService} from '../services/browser';
@@ -150,11 +150,10 @@ export default [
                                         case 'video':
                                         case 'file':
                                         case 'audio':
-                                            const options = {type: blobInfo.mimetype};
                                             saveAs(
                                                 new Blob(
                                                     [blobInfo.buffer],
-                                                    options
+                                                    {type: firefoxWorkaroundPdfDownload(blobInfo.mimetype)},
                                                 ),
                                                 blobInfo.filename
                                             );

--- a/src/directives/message_media.ts
+++ b/src/directives/message_media.ts
@@ -18,7 +18,7 @@
 import {Transition as UiTransition, TransitionService as UiTransitionService} from '@uirouter/angularjs';
 import {saveAs} from 'file-saver';
 
-import {bufferToUrl, hasValue} from '../helpers';
+import {bufferToUrl, firefoxWorkaroundPdfDownload, hasValue} from '../helpers';
 import {LogService} from '../services/log';
 import {MediaboxService} from '../services/mediabox';
 import {MessageService} from '../services/message';
@@ -268,6 +268,7 @@ export default [
                                                 // Hide thumbnail
                                                 this.showThumbnail = false;
                                             } else {
+                                                options.type = firefoxWorkaroundPdfDownload(options.type);
                                                 saveAs(
                                                     new Blob(
                                                         [blobInfo.buffer],

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -430,3 +430,18 @@ export function replaceWhitespace(text: string): string {
         .replace(/ /g, '&nbsp;')
         .replace(/\t/, '&nbsp;&nbsp;');
 }
+
+/**
+ * Work around nonstandard Firefox behavior when downloading a PDF by changing
+ * a PDF mimetype to application/octet-stream.
+ *
+ * See https://github.com/threema-ch/threema-web/issues/1118
+ */
+export function firefoxWorkaroundPdfDownload(mimetype: string): string {
+    const uagent = window.navigator.userAgent.toLowerCase();
+    const isFirefox = /mozilla/.test(uagent) && /firefox/.test(uagent); // Ugh
+    if (isFirefox && mimetype === 'application/pdf') {
+        return 'application/octet-stream';
+    }
+    return mimetype;
+}


### PR DESCRIPTION
See https://github.com/threema-ch/threema-web/issues/1118 for more details.

With this fix, the PDF still opens immediately instead of just downloading, but in a new tab.

@lgrahl do you see any major blocker here? (Yes, I know it's ugly.)