### PR TITLE
Allow quoting all message types (quotes v2)

### DIFF
--- a/src/directives/message.ts
+++ b/src/directives/message.ts
@@ -92,7 +92,11 @@ export default [
                     this.showQuote = this.message.quote !== undefined;
                     this.showVoipInfo = this.message.type === 'voipStatus';
 
-                    this.access = messageService.getAccess(this.message, this.receiver);
+                    this.access = messageService.getAccess(
+                        this.message,
+                        this.receiver,
+                        webClientService.appCapabilities,
+                    );
 
                     this.ack = (ack: boolean) => {
                         webClientService.ackMessage(this.receiver, this.message, ack);

--- a/src/services/message.ts
+++ b/src/services/message.ts
@@ -63,7 +63,7 @@ export class MessageService {
                 || (message.type === 'location' && message.location?.description !== null && message.location!!.description.length > 0)
                 || (hasValue(message.caption) && message.caption.length > 0)
             const allowQuoteV2 = capabilities.quotesV2;
-            access.quote = allowQuoteV1 || allowQuoteV2;
+            access.quote = receiver.type !== 'distributionList' && (allowQuoteV1 || allowQuoteV2);
             access.copy = allowQuoteV1;
 
             if (receiver !== undefined && message.temporaryId === undefined) {

--- a/src/threema.d.ts
+++ b/src/threema.d.ts
@@ -763,6 +763,7 @@ declare namespace threema {
         maxFileSize: number;
         maxMessageBodySize: number;
         distributionLists: boolean;
+        quotesV2: boolean;
         imageFormat: ImageFormat;
         mdm?: MdmRestrictions;
     }

--- a/tests/service/message.js
+++ b/tests/service/message.js
@@ -17,7 +17,7 @@ describe('MessageService', function() {
 
     describe ('getAccess', () => {
         let test = (m, r) => {
-            return expect(messageService.getAccess(m, r));
+            return expect(messageService.getAccess(m, r, {quotesV2: false}));
         };
         it('invalid arguments', () => {
             test().toEqual(jasmine.objectContaining({

--- a/tests/service/message.js
+++ b/tests/service/message.js
@@ -30,22 +30,24 @@ describe('MessageService', function() {
             }));
         })
 
-        const testCases = [['contact', {id: 'ECHOECHO', type: 'contact'}, true],
+        const testCases = [
+            ['contact', {id: 'ECHOECHO', type: 'contact'}, true],
             ['gateway contact', {id: '*THREEMA', type: 'contact'}, true],
             ['group', {id: 1, type: 'group'}, false],
-            ['distributionList', {id: 1, type: 'distributionList'}, false]]
+            ['distributionList', {id: 1, type: 'distributionList'}, false],
+        ];
 
         testCases.forEach((testData) => {
-
-            let type = testData[0];
-            let receiver = testData[1];
-            let canAckDec = testData[2];
+            const type = testData[0];
+            const receiver = testData[1];
+            const canAckDec = testData[2];
+            const isDistributionList = receiver.type === 'distributionList';
 
             describe(type, () => {
                 it('text messages  ', () => {
                     test({isOutbox: false, type: 'text'}, receiver)
                         .toEqual(jasmine.objectContaining({
-                            quote: true,
+                            quote: !isDistributionList,
                             copy: true,
                             ack: true && canAckDec,
                             dec: true && canAckDec,
@@ -55,7 +57,7 @@ describe('MessageService', function() {
 
                     test({isOutbox: true, type: 'text'}, receiver)
                         .toEqual(jasmine.objectContaining({
-                            quote: true,
+                            quote: !isDistributionList,
                             copy: true,
                             ack: false,
                             dec: false,
@@ -65,7 +67,7 @@ describe('MessageService', function() {
 
                     test({isOutbox: false, type: 'text', state: 'user-ack'}, receiver)
                         .toEqual(jasmine.objectContaining({
-                            quote: true,
+                            quote: !isDistributionList,
                             copy: true,
                             ack: false,
                             dec: true && canAckDec,
@@ -76,7 +78,7 @@ describe('MessageService', function() {
 
                     test({isOutbox: false, type: 'text', state: 'user-dec'}, receiver)
                         .toEqual(jasmine.objectContaining({
-                            quote: true,
+                            quote: !isDistributionList,
                             copy: true,
                             ack: true && canAckDec,
                             dec: false,
@@ -88,7 +90,7 @@ describe('MessageService', function() {
                 it('location messages  ', () => {
                     test({isOutbox: false, type: 'text'}, receiver)
                         .toEqual(jasmine.objectContaining({
-                            quote: true,
+                            quote: !isDistributionList,
                             copy: true,
                             ack: true && canAckDec,
                             dec: true && canAckDec,
@@ -98,7 +100,7 @@ describe('MessageService', function() {
 
                     test({isOutbox: true, type: 'text'}, receiver)
                         .toEqual(jasmine.objectContaining({
-                            quote: true,
+                            quote: !isDistributionList,
                             copy: true,
                             ack: false,
                             dec: false,
@@ -108,7 +110,7 @@ describe('MessageService', function() {
 
                     test({isOutbox: false, type: 'text', state: 'user-ack'}, receiver)
                         .toEqual(jasmine.objectContaining({
-                            quote: true,
+                            quote: !isDistributionList,
                             copy: true,
                             ack: false,
                             dec: true && canAckDec,
@@ -119,7 +121,7 @@ describe('MessageService', function() {
 
                     test({isOutbox: false, type: 'text', state: 'user-dec'}, receiver)
                         .toEqual(jasmine.objectContaining({
-                            quote: true,
+                            quote: !isDistributionList,
                             copy: true,
                             ack: true && canAckDec,
                             dec: false,
@@ -144,7 +146,7 @@ describe('MessageService', function() {
                     it('inbox (caption) ' + type, () => {
                         test({isOutbox: false, type: type, caption: 'test'}, receiver)
                             .toEqual(jasmine.objectContaining({
-                                quote: true,
+                                quote: !isDistributionList,
                                 copy: true,
                                 ack: true && canAckDec,
                                 dec: true && canAckDec,
@@ -169,7 +171,7 @@ describe('MessageService', function() {
                     it('outbox (caption) ' + type, () => {
                         test({isOutbox: false, type: type, caption: 'test'}, receiver)
                             .toEqual(jasmine.objectContaining({
-                                quote: true,
+                                quote: !isDistributionList,
                                 copy: true,
                                 ack: true && canAckDec,
                                 dec: true && canAckDec,


### PR DESCRIPTION
If the app signals the `quoteV2` capability, then all message types can be quoted.

If no quote text is available, the quote preview falls back to the translated message type (e.g. "File").

![screenshot-20220426-110318](https://user-images.githubusercontent.com/78751145/165265911-172a400e-bc29-44e0-ad05-19e30ebe57b4.png)

![screenshot-20220426-110337](https://user-images.githubusercontent.com/78751145/165265920-e8e1a873-14bc-4a85-a059-9edd22f11310.png)

Fixes #1051.