### PR TITLE
Show revoked contacts with strike-through text

### DIFF
--- a/src/partials/messenger.conversation.html
+++ b/src/partials/messenger.conversation.html
@@ -14,6 +14,7 @@
         </div>
         <div class="header-details" role="heading" aria-level="1" ng-click="ctrl.showReceiver()">
             <div class="conversation-header-details-name"
+                 ng-class="{'text-strike': ctrl.receiver.state === 'INVALID'}"
                  ng-bind-html="ctrl.receiver.displayName | escapeHtml | emojify"></div>
             <div class="conversation-header-details-detail" ng-if="ctrl.type === 'contact'">
             <eee-verification-level ng-if="ctrl.type === 'contact'"

--- a/src/partials/messenger.navigation.html
+++ b/src/partials/messenger.navigation.html
@@ -98,7 +98,10 @@
 
                 <section class="conversation-box">
                     <section class="receiver-box">
-                        <span class="title" ng-class="{'disabled': conversation.receiver.disabled === true}" ng-bind-html="conversation.receiver.displayName | escapeHtml | emojify" role="button">
+                        <span class="title"
+                            ng-class="{'text-strike': conversation.receiver.disabled || conversation.receiver.state === 'INVALID'}"
+                            ng-bind-html="conversation.receiver.displayName | escapeHtml | emojify"
+                            role="button">
                         </span>
                         <span class="notification-settings" ng-if="dndModeSimplified === 'on'">
                             <img height="16" width="16" src="img/ic_dnd_total_silence.svg" translate translate-attr-title="messenger.MUTED_NONE">
@@ -145,7 +148,7 @@
                             eee-resolution="'low'"></eee-avatar>
             </section>
 
-            <section class="left">
+            <section class="left" ng-class="{'text-strike': contact.state === 'INVALID'}">
                 <div class="name" ng-bind-html="contact.displayName | escapeHtml | emojify"></div>
                 <div class="identity">{{ contact.id }}</div>
             </section>

--- a/src/partials/messenger.receiver/contact.html
+++ b/src/partials/messenger.receiver/contact.html
@@ -11,7 +11,7 @@
 				<dd>
 					<span class="complex-values">
 						<span>{{ ctrl.receiver.id }}</span>
-                        <span ng-if="ctrl.receiver.state == 'INVALID'">({{ 'messenger.CONTACT_STATE_INVALID' | translate }}/{{ 'messenger.CONTACT_STATE_REVOKED' | translate }})</span>
+                        <span ng-if="ctrl.receiver.state == 'INVALID'">({{ 'messenger.CONTACT_STATE_REVOKED' | translate }})</span>
                         <span ng-if="ctrl.receiver.state == 'INACTIVE'">({{ 'messenger.CONTACT_STATE_INACTIVE' | translate }})</span>
 						<span class="indicator-icon" ng-if="ctrl.showBlocked()"
 							  translate-attr="{'aria-label': 'messenger.THREEMA_BLOCKED_RECEIVER'}">


### PR DESCRIPTION
So far, revoked contacts (state = INVALID) weren't consistently shown with strikethrough text. This PR fixes that.

![screenshot-20220505-101548](https://user-images.githubusercontent.com/78751145/166885780-333ba601-2a26-4f2a-b2e1-5ed36919d964.png)