### PR TITLE
Treat gifs like other images when sending

### DIFF
--- a/src/services/mime.ts
+++ b/src/services/mime.ts
@@ -22,7 +22,7 @@ export class MimeService {
 
     private $translate: ng.translate.ITranslateService;
 
-    private imageMimeTypes: string[] = ['image/png', 'image/jpg', 'image/jpeg'];
+    private imageMimeTypes: string[] = ['image/png', 'image/jpg', 'image/jpeg', 'image/gif'];
     private audioMimeTypesAndroid: string[] = ['audio/ogg'];
     private audioMimeTypesIos: string[] = ['audio/m4a', 'audio/x-m4a', 'audio/mp4'];
     private videoMimeTypes: string[] = ['video/mp4', 'video/mpg', 'video/mpeg'];


### PR DESCRIPTION
Currently gifs can only be sent as images and not as files in the Android app and vice versa in the iOS app. Adding gif mime type to imageMimeTypes allows sending gifs with rendering type 0 with the Android app. Sending gifs as images will be possible with the next update of the iOS app.