### PR TITLE
Fix hiding of "device unreachable" dialog

### DIFF
--- a/src/services/webclient.ts
+++ b/src/services/webclient.ts
@@ -1242,8 +1242,8 @@ export class WebClientService {
                 templateUrl: 'partials/dialog.device-unreachable.html',
                 parent: angular.element(document.body),
                 escapeToClose: false,
-            })
-                .finally(() => this.deviceUnreachableDialog = null);
+                onRemoving: () => { this.deviceUnreachableDialog = null; },
+            });
         }
     }
 


### PR DESCRIPTION
By using `onRemoving` instead of chaining futures, we get sync
processing instead of async processing. This resolves a race condition
that often occurred when the tab was was in the background (probably due
to throttling).