### PR TITLE
Own display name: Use localized "Me" if no nickname is set

### DIFF
--- a/src/services/webclient.ts
+++ b/src/services/webclient.ts
@@ -3296,9 +3296,16 @@ export class WebClientService {
         }
 
         // Update public nickname
-        if (data.publicNickname !== undefined) {
-            this.me.publicNickname = data.publicNickname;
-            this.me.displayName = this.me.publicNickname || this.me.id;
+        if (hasValue(data.publicNickname)) {
+            if (data.publicNickname === this.me.id) {
+                // Unset nickname
+                this.me.publicNickname = undefined;
+                this.me.displayName = this.$translate.instant('messenger.ME');
+            } else {
+                // Update nickname
+                this.me.publicNickname = data.publicNickname;
+                this.me.displayName = data.publicNickname;
+            }
         }
 
         // Update avatar
@@ -3310,8 +3317,7 @@ export class WebClientService {
             }
 
             // Request new low-res avatar
-            // noinspection JSIgnoredPromiseFromCall
-            this.requestAvatar(this.me, false);
+            void this.requestAvatar(this.me, false);
         }
     }
 
@@ -3430,11 +3436,12 @@ export class WebClientService {
 
         // Create 'me' receiver with profile + dummy data
         // TODO: Send both high-res and low-res avatars
+        const hasPublicNickname = hasValue(data.publicNickname) && data.publicNickname !== data.identity;
         this.receivers.setMe({
             type: 'me',
             id: data.identity,
             publicNickname: data.publicNickname,
-            displayName: data.publicNickname || data.identity,
+            displayName: hasPublicNickname ? data.publicNickname : this.$translate.instant('messenger.ME'),
             publicKey: data.publicKey,
             avatar: {
                 high: data.avatar,


### PR DESCRIPTION
Previously we'd fall back to the identity, which can confuse people in the context of quotes, if they don't know their own identity.

With nickname (before and after):

![screenshot-20221209-144453](https://user-images.githubusercontent.com/78751145/206716760-d7c5f43f-19b7-4dc5-9a57-bb87b69f9ce1.png)

Without nickname (before):

![screenshot-20221209-145028](https://user-images.githubusercontent.com/78751145/206717085-2de9a8c2-480e-424e-a1d3-4adf05dcea13.png)

Without nickname (after, German localization):

![screenshot-20221209-144523](https://user-images.githubusercontent.com/78751145/206717116-dd7845bb-a161-4285-ba3f-3dc2e0cc1fbf.png)