### PR TITLE
Fix file size limit check

### DIFF
--- a/src/services/webclient.ts
+++ b/src/services/webclient.ts
@@ -1841,12 +1841,11 @@ export class WebClientService {
                     if (task.version === 'v0' && fileData.size > WebClientService.MAX_FILE_SIZE_WEBRTC_TASK_V0) {
                         throw this.$translate.instant('error.FILE_TOO_LARGE_WEB');
                     }
-                } else {
-                    if (fileData.size > this.clientInfo.capabilities.maxFileSize) {
-                        throw this.$translate.instant('error.FILE_TOO_LARGE', {
-                            maxmb: Math.floor(this.clientInfo.capabilities.maxFileSize / 1024 / 1024),
-                        });
-                    }
+                }
+                if (fileData.size > this.clientInfo.capabilities.maxFileSize) {
+                    throw this.$translate.instant('error.FILE_TOO_LARGE', {
+                        maxmb: Math.floor(this.clientInfo.capabilities.maxFileSize / 1024 / 1024),
+                    });
                 }
 
                 // Determine reflected type


### PR DESCRIPTION
The logic was broken: When using the WebRTC task, a limit was only enforced for v0, not for v1.

Fixes #1176.