### PR TITLE
Disallow quoting of call status messages

### DIFF
--- a/src/services/message.ts
+++ b/src/services/message.ts
@@ -64,7 +64,7 @@ export class MessageService {
                 || (message.type === 'location' && message.location?.description !== null && message.location!!.description.length > 0)
                 || (hasValue(message.caption) && message.caption.length > 0)
             const allowQuoteV2 = capabilities.quotesV2;
-            access.quote = receiver.type !== 'distributionList' && (allowQuoteV1 || allowQuoteV2);
+            access.quote = receiver.type !== 'distributionList' && message.type !== 'voipStatus' && (allowQuoteV1 || allowQuoteV2);
             access.copy = allowQuoteV1;
 
             if (receiver !== undefined && message.temporaryId === undefined) {


### PR DESCRIPTION
Call status messages could be quoted. This should not be allowed.