### PR TITLE
Fix beta link in work flavor and open in new tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,13 +84,13 @@
             <h2>Error: Browser not supported</h2>
             <p>You are using a browser without <strong>WebAssembly</strong> support. Please
             upgrade to the latest version of a
-            <a href="https://threema.ch/faq/web_requirements">supported browser</a>.</p>
+            <a href="https://threema.ch/faq/web_requirements" target="_blank">supported browser</a>.</p>
         </div>
         <div class="textdecoder" style="display: none;">
             <h2>Error: Browser not supported</h2>
             <p>You are using a browser without <strong>TextDecoder</strong> support. Please
             upgrade to the latest version of a
-            <a href="https://threema.ch/faq/web_requirements">supported browser</a>.</p>
+            <a href="https://threema.ch/faq/web_requirements" target="_blank">supported browser</a>.</p>
         </div>
     </div>
 

--- a/public/libs/angular-qrcode/index.html
+++ b/public/libs/angular-qrcode/index.html
@@ -153,7 +153,7 @@
   <div class="footer">
 
     <small>
-      <a href="http://monospaced.github.io/">Monospaced Labs</a>
+      <a href="http://monospaced.github.io/" target="_blank">Monospaced Labs</a>
     </small>
 
   </div>

--- a/src/partials/dialog.about.html
+++ b/src/partials/dialog.about.html
@@ -16,7 +16,7 @@
                     <span translate>about.ALL_RIGHTS_RESERVED</span>
                 </p>
 
-                <p><a href="https://threema.ch/">https://threema.ch/</a></p>
+                <p><a href="https://threema.ch/" target="_blank">https://threema.ch/</a></p>
 
                 <h2>Open Source</h2>
                 <p translate>about.OPEN_SOURCE</p>
@@ -38,7 +38,7 @@
                         The font software Lab Grotesque is the property of Letters from Sweden and
                         licensed to Threema GmbH. All rights reserved. May not be used by any third
                         party without acquiring a license from
-                        <a href="https://lettersfromsweden.se/">www.lettersfromsweden.se</a>.
+                        <a href="https://lettersfromsweden.se/" target="_blank">www.lettersfromsweden.se</a>.
                     </li>
                 </ul>
 

--- a/src/partials/welcome.html
+++ b/src/partials/welcome.html
@@ -13,7 +13,7 @@
             </p>
         </div>
 
-        <a class="button" href="https://threema.ch/download-md">
+        <a class="button" ng-href="{{ctrl.lastConnectedAppFlavor === 'work' ? 'https://threema.ch/work/download-mdw' : 'https://threema.ch/download-md'}}" target="_blank">
             <span class="badge" translate>common.BETA</span>
             <div class="content">
                 <img ng-if="ctrl.lastConnectedAppFlavor === 'consumer'" class="app-icon" src="img/app-icon-consumer-live.svg">


### PR DESCRIPTION
Correctly links to the work download page, and opens the beta link in a new tab.