### PR TITLE
Add `id` to session restore password form

### DIFF
--- a/src/partials/welcome.html
+++ b/src/partials/welcome.html
@@ -79,6 +79,7 @@
                     <form ng-submit="ctrl.unlockConfirm()">
                         <md-input-container md-no-float class="md-block">
                             <input ng-if="ctrl.inMemorySessionPassword === undefined"
+                                   id="session-restore-password"
                                    type="password"
                                    ng-model="ctrl.password"
                                    ng-disabled="ctrl.formLocked"


### PR DESCRIPTION
Some password managers (such as Bitwarden) allow autofilling of custom fields, such as the session restore password, using the `id` of the input field to distinguish it from other password fields. Unfortunately, the session restore password field, does not have an explicit `id` set, instead using an autogenerated one (either e.g. `input_0` or `input_1`), which can cause the custom autofilling to break.
This adds an explicit `id` to the session restore password field, to allowing password managers to distinguish it from the user password field.

Ref: https://bitwarden.com/help/auto-fill-custom-fields/#using-linked-custom-fields